### PR TITLE
Add AGENTS.md with development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+JobNecto is a .NET 10 backend API for job vacancy aggregation and matching. Clean Architecture with layers: API, Application, Domain, Infrastructure, Infrastructure.LLM, Infrastructure.JobSources. See `.github/workflows/ci.yml` for CI commands.
+
+### Build, test, lint
+
+- **Solution file:** `backend/JobNecto.slnx` (used by CI and for all dotnet commands)
+- **Build:** `dotnet build backend/JobNecto.slnx`
+- **Test:** `dotnet test backend/JobNecto.slnx`
+- **CI-equivalent lint/build:** `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`
+
+### Running the API
+
+- Start: `cd backend/src/JobNecto.API && ASPNETCORE_ENVIRONMENT=Development DOTNET_URLS="http://localhost:5000" dotnet run`
+- The API serves OpenAPI spec at `GET /openapi/v1.json`.
+- No user-facing routes exist yet; 404 on root is expected.
+
+### PostgreSQL
+
+- Required for the full application (EF Core + Npgsql).
+- Dev config (`appsettings.Development.json`) expects: `Host=localhost;Port=5432;Database=JobNecto;Username=admin;Password=admin`
+- **Known issue:** `appsettings.Development.json` has `Port:5432` (colon) instead of `Port=5432` (equals). This is an existing repo bug.
+- The `Program.cs` does not yet call `AddInfrastructure()`, so the DB connection is not used at startup. When it is wired up, PostgreSQL must be running with the above credentials.
+- To start PostgreSQL: `sudo pg_ctlcluster 16 main start`
+
+### Gotchas
+
+- The root `.sln` (`Jobnecto.sln`) uses Windows-style backslash paths and does not include the test project. Always use `backend/JobNecto.slnx` for builds and tests.
+- Docker files (`docker/Dockerfile`, `docker/docker-compose.yml`) are empty placeholders.
+- Redis and Quartz are referenced in `Infrastructure.csproj` but have no implementation yet.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for developing in this repository.

## Changes

- **`AGENTS.md`**: Documents build/test/run commands, PostgreSQL requirements, known issues (connection string typo, empty Docker files), and gotchas (use `backend/JobNecto.slnx` over root `.sln`).

## Environment Setup Verified

| Check | Status |
|---|---|
| .NET 10.0 SDK install | Passed |
| `dotnet restore backend/JobNecto.slnx` | Passed |
| `dotnet build backend/JobNecto.slnx` | Passed (0 warnings, 0 errors) |
| `dotnet build --configuration Release --warnaserror` | Passed |
| `dotnet test backend/JobNecto.slnx` | Passed (1/1 tests) |
| PostgreSQL 16 running | Passed |
| API running on `http://localhost:5000` | Passed |
| `GET /openapi/v1.json` returns 200 | Passed |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd124653-58bc-48b1-8078-1caadd72658e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd124653-58bc-48b1-8078-1caadd72658e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

