### PR TITLE
Add PostgreSQL Cursor skill and fix dev Npgsql connection string

### DIFF
--- a/.cursor/skills/jobnecto-postgresql/SKILL.md
+++ b/.cursor/skills/jobnecto-postgresql/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: jobnecto-postgresql
+description: Connects to the JobNecto PostgreSQL database using dev connection strings, CLI tools (psql, dotnet ef), repository patterns, and ad-hoc SQL for reads and test data. Use when querying the DB, inserting seed or test rows, running migrations, or when the user mentions Postgres, Npgsql, test data, or local database setup for this project.
+---
+
+# JobNecto PostgreSQL
+
+## Connection strings (Development)
+
+- **Read credentials from**: `backend/src/JobNecto.API/appsettings.Development.json` → `ConnectionStrings:Postgres` (used when `ASPNETCORE_ENVIRONMENT=Development`).
+- **Fallback template**: `backend/src/JobNecto.API/appsettings.json` → same key.
+- **Registration in app**: `GetConnectionString("Postgres")` → `AppDbContext` with Npgsql (`backend/src/JobNecto.Infrastructure/DI.cs`).
+
+Npgsql uses semicolon-separated `Key=Value` pairs (e.g. `Port=5432`).
+
+Parse the string for CLI use:
+
+| Part        | Typical dev (from file) |
+|------------|-------------------------|
+| Host       | `localhost`             |
+| Port       | `5432`                  |
+| Database   | `JobNecto`              |
+| Username   | `admin`                 |
+| Password   | `admin`                 |
+
+## CLI: get data from the database
+
+**Preferred for quick inspection**: `psql` (PostgreSQL client). Install via PostgreSQL tools or package manager if missing.
+
+1. Load host/port/db/user/password from `appsettings.Development.json` (do not hardcode secrets from production).
+2. Connect (PowerShell example):
+
+```powershell
+$env:PGPASSWORD = '<Password>'
+psql -h localhost -p 5432 -U admin -d JobNecto
+```
+
+3. Inside `psql`, discover schema:
+
+```text
+\dt
+\d "Users"
+```
+
+4. Run read-only SQL as needed, e.g. `SELECT "Id", "Email", "Login" FROM "Users" LIMIT 10;`
+
+**Notes**
+
+- Table and column names are **PascalCase** in this model unless a configuration renames them; quote identifiers in SQL when case-sensitive (`"Users"`, `"Id"`).
+- For relationship order: insert **Users** before rows that reference `UserId` (Resumes, Educations, Vacancies, CoverLetters). **CoverLetters** need both `UserId` and `VacancyId`.
+
+## CLI: add test / seed data
+
+1. Ensure schema exists: `dotnet ef database update` (see migrations section).
+2. Prefer **one-off `psql` sessions** or a **`.sql` file** under something like `backend/scripts/` (create the folder if the team agrees) that you execute with:
+
+```powershell
+$env:PGPASSWORD = '<Password>'
+psql -h localhost -p 5432 -U admin -d JobNecto -f backend/scripts/your-seed.sql
+```
+
+3. Respect **check constraints** and **required columns** from entity configs (`backend/src/JobNecto.Infrastructure/Persistance/Config/*Configuration.cs`). Examples:
+   - **Users**: valid email pattern, optional `Phone` must match `+` E.164 if set, `Age` between 1 and 99 if set.
+   - **Vacancies**: `JobSource` is stored as **jsonb** (shape matches `JobSource` in domain code).
+4. Use `gen_random_uuid()` for new `uuid` keys if the DB supports it, or generate GUIDs in the script.
+
+For column-level details and table list, see [reference.md](reference.md).
+
+## Stack (application code)
+
+| Piece | Location |
+|-------|----------|
+| DbContext | `backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs` |
+| EF Core + Npgsql | `JobNecto.Infrastructure.csproj` |
+| Migrations assembly | `JobNecto.Infrastructure` |
+
+## Entities (DbSets)
+
+`Users`, `Resumes`, `Educations`, `CoverLetters`, `Vacancies`. Join table: `ResumeEducations` (many-to-many). Configurations: `Persistance/Config/*Configuration.cs`.
+
+## CRUD in C# (when changing app code)
+
+Prefer **repository + unit of work** (`IRepository<T>`, `IEditableRepository<T>`, `IUnitOfWork`, `BaseRepository<T>`). After mutations, call `SaveChangesAsync` on the unit of work when implemented.
+
+## EF Core CLI (migrations and schema)
+
+From repo root:
+
+```bash
+dotnet ef migrations add <Name> --project backend/src/JobNecto.Infrastructure --startup-project backend/src/JobNecto.API
+dotnet ef database update --project backend/src/JobNecto.Infrastructure --startup-project backend/src/JobNecto.API
+```
+
+Optional: generate SQL from the model for review:
+
+```bash
+dotnet ef dbcontext script --project backend/src/JobNecto.Infrastructure --startup-project backend/src/JobNecto.API -o backend/scripts/schema.sql
+```
+
+Ensure `ConnectionStrings:Postgres` is valid for the environment you target.
+
+## Additional resources
+
+- [reference.md](reference.md) — tables, constraints summary, pagination types, minimal SQL examples

--- a/.cursor/skills/jobnecto-postgresql/reference.md
+++ b/.cursor/skills/jobnecto-postgresql/reference.md
@@ -1,0 +1,72 @@
+# Tables and relationships
+
+| Table | Notes |
+|-------|--------|
+| `Users` | Root entity; check constraints on `Email`, `Phone`, `Age` |
+| `Resumes` | FK `UserId` → `Users` |
+| `Educations` | FK `UserId` → `Users`; M:N with `Resumes` via `ResumeEducations` |
+| `Vacancies` | FK `UserId` → `Users`; `JobSource` is **jsonb** |
+| `CoverLetters` | FKs `UserId`, `VacancyId` |
+| `ResumeEducations` | Join for Resume ↔ Education |
+
+Discover in `psql`: `\d "Users"`, `\d "Vacancies"`, etc.
+
+# Pagination (C# repositories)
+
+`PagedQuery`: `PageSize` (default 20), optional `LastSeenId`, `LastSeenUpdatedAt` for cursor paging.
+
+`PagedResult<T>`: `Items`, `TotalCount`, next-cursor fields, `HasNext`, `TotalPages`.
+
+`BaseRepository` orders by `UpdatedAt` desc, then `Id` desc.
+
+# Minimal SQL examples (dev / test)
+
+Adjust UUIDs and run only against a safe dev database.
+
+**Insert a user** (valid email; omit `Phone` or use `+15551234567` style):
+
+```sql
+INSERT INTO "Users" ("Id", "Login", "Password", "Email", "CreatedAt", "UpdatedAt")
+VALUES (
+  gen_random_uuid(),
+  'testuser',
+  'changeme',
+  'test@example.com',
+  NOW(),
+  NOW()
+);
+```
+
+**Insert a vacancy** (requires `UserId` and `JobSource` jsonb):
+
+```sql
+INSERT INTO "Vacancies" (
+  "Id", "UserId", "Title", "JobSource", "IsChosen", "IsHidden", "CreatedAt", "UpdatedAt"
+)
+VALUES (
+  gen_random_uuid(),
+  '<existing-user-guid>'::uuid,
+  'Sample job',
+  '{"Name": "Manual", "Url": null}'::jsonb,
+  false,
+  false,
+  NOW(),
+  NOW()
+);
+```
+
+**Insert a cover letter** (needs existing `UserId` and `VacancyId`):
+
+```sql
+INSERT INTO "CoverLetters" ("Id", "UserId", "VacancyId", "Content", "CreatedAt", "UpdatedAt")
+VALUES (
+  gen_random_uuid(),
+  '<user-guid>'::uuid,
+  '<vacancy-guid>'::uuid,
+  'Test cover letter body',
+  NOW(),
+  NOW()
+);
+```
+
+If `gen_random_uuid()` is unavailable, enable `pgcrypto` (`CREATE EXTENSION IF NOT EXISTS pgcrypto;`) or supply explicit UUIDs from the shell.

--- a/backend/src/JobNecto.API/appsettings.Development.json
+++ b/backend/src/JobNecto.API/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "Postgres":"Host=localhost;Port:5432;Database=JobNecto;Username=admin;Password=admin"
+    "Postgres": "Host=localhost;Port=5432;Database=JobNecto;Username=admin;Password=admin"
   }
 }


### PR DESCRIPTION
## Summary
- Adds \.cursor/skills/jobnecto-postgresql/\ with instructions for dev connection strings, \psql\ and \dotnet ef\ CLI workflows, and SQL reference for querying and test data.
- Corrects \ppsettings.Development.json\: Npgsql expects \Port=5432\ (was invalid \Port:5432\).

## Related issue
Closes #6

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds developer-facing documentation and fixes a typo in the development Npgsql connection string; no runtime logic changes beyond enabling local DB connectivity.
> 
> **Overview**
> Adds a new `.cursor/skills/jobnecto-postgresql` Cursor skill with project-specific guidance for connecting to the dev PostgreSQL database, using `psql`/`dotnet ef`, and running minimal SQL for test/seed data.
> 
> Fixes `backend/src/JobNecto.API/appsettings.Development.json` by correcting the Npgsql connection string syntax from `Port:5432` to `Port=5432`, ensuring local EF Core/Npgsql connections work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0085896d97cc84f5c262381361b4b024e86c0772. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->