### PR TITLE
Add function-comments command for XML doc generation

### DIFF
--- a/.cursor/commands/function-comments.md
+++ b/.cursor/commands/function-comments.md
@@ -1,6 +1,6 @@
 ---
 description: Add XML doc comments to functions that need them
-argument-hint: "[file-or-folder paths...]"
+argument-hint: [file-or-folder paths...]
 ---
 
 Add C# XML documentation comments (`/// <summary>`, `/// <param>`, `/// <returns>`) to functions and methods that benefit from documentation. Skip trivial, self-explanatory, or boilerplate code.

--- a/.cursor/commands/function-comments.md
+++ b/.cursor/commands/function-comments.md
@@ -1,0 +1,31 @@
+---
+description: Add XML doc comments to functions that need them
+argument-hint: "[file-or-folder paths...]"
+---
+
+Add C# XML documentation comments (`/// <summary>`, `/// <param>`, `/// <returns>`) to functions and methods that benefit from documentation. Skip trivial, self-explanatory, or boilerplate code.
+
+Requirements:
+- Use the skill: `.cursor/skills/function-comments/SKILL.md`
+- Follow the comment/skip criteria defined in the skill.
+- Preserve existing XML doc comments unless they are clearly wrong.
+
+Execution steps:
+
+1. **If arguments are provided** (file paths, folder paths, or function names):
+   - Scope the work to only the specified targets.
+   - Read each file, identify qualifying functions, add XML doc comments.
+
+2. **If no arguments are provided** (full project scan):
+   - Recursively scan `backend/src/` one project at a time.
+   - Process in order: Application → Domain → Infrastructure → Infrastructure.LLM → Infrastructure.JobSources → API.
+   - Within each project, process one file at a time.
+   - Add XML doc comments only to functions matching the "MUST comment" criteria from the skill.
+
+3. After all changes, verify:
+   - `dotnet build backend/JobNecto.slnx`
+   - `dotnet test backend/JobNecto.slnx`
+
+Output:
+- List of files modified and functions commented.
+- Build and test results confirming no regressions.

--- a/.cursor/skills/function-comments/SKILL.md
+++ b/.cursor/skills/function-comments/SKILL.md
@@ -133,8 +133,8 @@ public static IServiceCollection AddInfrastructure(this IServiceCollection servi
 
 ```csharp
 /// <summary>
-/// Template resume used for filtering and matching vacancies,
-/// and for helping the LLM generate personalized cover letters.
+/// Captures a user's professional profile snapshot used as the primary input
+/// for vacancy matching algorithms and LLM-driven cover letter generation.
 /// </summary>
 public sealed class Resume : BaseEntity
 ```

--- a/.cursor/skills/function-comments/SKILL.md
+++ b/.cursor/skills/function-comments/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: function-comments
+description: Add XML documentation comments to functions that benefit from them. Use when asked to document functions, add comments, or improve code documentation across the project.
+---
+
+# Function Comments
+
+Add C# XML documentation comments (`/// <summary>`, `/// <param>`, `/// <returns>`) to functions and methods that benefit from documentation. Skip trivial or self-explanatory code.
+
+## When to use
+
+- User runs the `function-comments` command (with or without arguments).
+- User asks to "add comments", "document functions", or "improve documentation".
+
+## What to comment
+
+### MUST comment (non-trivial logic that benefits developers and AI agents)
+
+- **Interface method signatures** in the Application layer — these define contracts consumed by multiple implementations and callers.
+- **Extension methods for DI registration** (`AddInfrastructure`, `AddApplication`, etc.) — describe what services are registered and any required configuration.
+- **Methods with complex business logic** — filtering, scoring, matching, transformation pipelines, multi-step workflows.
+- **Methods with non-obvious side effects** — methods that throw on missing entities, mutate external state, or have retry/fallback behavior.
+- **Public API endpoints** — controllers, minimal API route handlers, middleware.
+- **Generic/abstract base class methods** with non-trivial behavior — pagination strategies, cursor-based queries, soft-delete implementations.
+- **Domain value objects and records** with business meaning — class-level `<summary>` when the type represents a domain concept that is not obvious from the name alone.
+
+### SHOULD NOT comment (self-explanatory or boilerplate)
+
+- Simple CRUD repository methods whose behavior is obvious from name and signature (e.g. `GetByIdAsync(Guid id)`, `CreateAsync(T entity)`, `DeleteAsync(Guid id)`).
+- EF Core `IEntityTypeConfiguration.Configure` methods — the fluent API calls are self-documenting.
+- Trivial property accessors, constructors that only assign fields, and empty/`NotImplementedException` stubs.
+- Enum definitions, simple record/class declarations with only auto-properties or public fields.
+- Private methods that are only called from one place and whose intent is clear from context.
+
+### Grey area (use judgement)
+
+- Private helper methods with moderate complexity — comment if the logic is not immediately clear.
+- Overridden virtual methods — comment only if the override changes the contract or adds behavior beyond the base.
+- Test methods — prefer descriptive test names over XML doc comments.
+
+## Comment format
+
+Use standard C# XML documentation:
+
+```csharp
+/// <summary>
+/// Brief description of what the method does and why.
+/// </summary>
+/// <param name="paramName">What this parameter represents and any constraints.</param>
+/// <returns>What is returned, including edge cases (null, empty, exceptions).</returns>
+```
+
+Rules:
+
+1. `<summary>` is always required.
+2. `<param>` tags for every parameter unless the method has zero parameters.
+3. `<returns>` for methods that return a value (skip for `void` / `Task` without result).
+4. `<exception cref="...">` only when the method explicitly throws and callers need to know.
+5. Keep descriptions concise — one to three sentences. Do not restate the method signature.
+6. Focus on **intent**, **constraints**, and **edge-case behavior** rather than implementation details.
+7. Write in third-person present tense ("Retrieves…", "Applies…", "Registers…").
+
+## Execution workflow
+
+### With arguments (targeted)
+
+When the user provides file paths or function names:
+
+1. Read each specified file.
+2. Identify functions/methods matching the criteria above.
+3. Add XML doc comments to qualifying functions.
+4. Skip functions in the "SHOULD NOT comment" category.
+5. Build to verify no compilation issues: `dotnet build backend/JobNecto.slnx`.
+
+### Without arguments (full project scan)
+
+When no arguments are provided, scan the entire `backend/src/` tree:
+
+1. Process one project at a time in this order:
+   - `JobNecto.Application` (interfaces and contracts first — highest value)
+   - `JobNecto.Domain` (value objects, records, entity summaries)
+   - `JobNecto.Infrastructure` (DI registration, non-trivial repository methods)
+   - `JobNecto.Infrastructure.LLM` (if `.cs` files exist)
+   - `JobNecto.Infrastructure.JobSources` (if `.cs` files exist)
+   - `JobNecto.API` (endpoints, middleware, program configuration)
+2. Within each project, process one file at a time.
+3. For each file:
+   - Read the file.
+   - Identify every public/protected method and class.
+   - Apply the "MUST comment" / "SHOULD NOT comment" criteria.
+   - Add XML doc comments only where they add value.
+   - Preserve existing `/// <summary>` comments — do not overwrite them unless they are obviously wrong or incomplete.
+4. After all files in a project are processed, run: `dotnet build backend/JobNecto.slnx`.
+5. Fix any issues before moving to the next project.
+6. After all projects: run full build and test to confirm no regressions.
+
+```bash
+dotnet build backend/JobNecto.slnx
+dotnet test backend/JobNecto.slnx
+```
+
+## Examples
+
+### Good: Interface method with contract documentation
+
+```csharp
+/// <summary>
+/// Retrieves a paginated list of vacancies filtered by the specified criteria.
+/// Supports cursor-based pagination using <paramref name="pagedQuery"/>.
+/// </summary>
+/// <param name="pagedQuery">Pagination cursor with page size and last-seen identifiers.</param>
+/// <param name="filter">Optional filter criteria; when null, no filtering is applied.</param>
+/// <param name="ct">Cancellation token.</param>
+/// <returns>A paged result containing matching vacancies and pagination metadata.</returns>
+Task<PagedResult<Vacancy>> GetFilteredAsync(PagedQuery pagedQuery, VacancyFilter? filter = null, CancellationToken ct = default);
+```
+
+### Good: DI registration extension method
+
+```csharp
+/// <summary>
+/// Registers infrastructure services including the EF Core database context
+/// (PostgreSQL via Npgsql) and the Unit of Work pattern.
+/// Reads the "Postgres" connection string from <paramref name="configuration"/>.
+/// </summary>
+/// <param name="services">The service collection to add registrations to.</param>
+/// <param name="configuration">Application configuration containing connection strings.</param>
+/// <returns>The service collection for chaining.</returns>
+public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+```
+
+### Good: Class-level summary for a domain concept
+
+```csharp
+/// <summary>
+/// Template resume used for filtering and matching vacancies,
+/// and for helping the LLM generate personalized cover letters.
+/// </summary>
+public sealed class Resume : BaseEntity
+```
+
+### Skip: Simple CRUD — no comment needed
+
+```csharp
+// No XML doc needed — GetByIdAsync is universally understood.
+public virtual async Task<T?> GetByIdAsync(Guid id, CancellationToken ct)
+{
+    return await _dbSet.FindAsync([id], ct);
+}
+```
+
+### Skip: EF configuration — no comment needed
+
+```csharp
+// No XML doc needed — fluent API calls are self-documenting.
+public void Configure(EntityTypeBuilder<Vacancy> builder) { ... }
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new Cursor agent command (`function-comments`) and its supporting skill that instructs agents to add C# XML documentation comments to functions that benefit from them, while skipping trivial/boilerplate code.

## What's included

### Command: `.cursor/commands/function-comments.md`
- Supports **targeted mode** (with file paths, folder paths, or function names as arguments) — scopes work to specified targets only.
- Supports **full-project scan mode** (no arguments) — recursively processes `backend/src/` one project at a time, in dependency order.
- Verifies build and test health after changes.

### Skill: `.cursor/skills/function-comments/SKILL.md`
Defines the complete SOP:

**MUST comment:**
- Interface method signatures in the Application layer
- DI registration extension methods (`AddInfrastructure`, `AddApplication`, etc.)
- Methods with complex business logic (filtering, scoring, matching)
- Methods with non-obvious side effects
- Public API endpoints and middleware
- Generic/abstract base class methods with non-trivial behavior
- Domain value objects/records with business meaning

**SHOULD NOT comment:**
- Simple CRUD repository methods (`GetByIdAsync`, `CreateAsync`, `DeleteAsync`)
- EF Core `IEntityTypeConfiguration.Configure` methods
- Trivial constructors, property accessors, empty stubs
- Enum definitions, simple records/classes
- Private methods with clear intent from context

**Format:** Standard `/// <summary>`, `/// <param>`, `/// <returns>`, `/// <exception>` with focus on intent, constraints, and edge-case behavior.

## Testing
- `dotnet build backend/JobNecto.slnx` — passed
- `dotnet test backend/JobNecto.slnx` — passed (1/1)
- `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` — passed

## Review
- Code review completed with no blocking findings (3 low-severity items, all addressed).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-783d4f25-9f28-425b-b3ed-e6220a1b93ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-783d4f25-9f28-425b-b3ed-e6220a1b93ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

