### PR TITLE
Add write-comments Cursor command

### DIFF
--- a/.cursor/commands/write-comments.md
+++ b/.cursor/commands/write-comments.md
@@ -13,7 +13,8 @@ Goal:
 Scope resolution:
 1. Parse arguments as optional targets.
 2. If arguments are provided, inspect only the requested files, folders, or function filters.
-3. If no arguments are provided, recursively inspect the repository file by file and function by function.
+3. If no arguments are provided, recursively inspect C# source files under `backend/src` file by file and function by function.
+4. Unless explicitly targeted by arguments, skip tests, generated files, migrations, build artifacts, and non-C# files.
 
 Accepted target styles:
 - File path: `backend/src/JobNecto.Domain/Entities/Resume.cs`

--- a/.cursor/commands/write-comments.md
+++ b/.cursor/commands/write-comments.md
@@ -1,0 +1,56 @@
+---
+description: Add XML doc comments for important functions only
+argument-hint: [paths and/or function filters]
+---
+
+Write missing function comments in the requested scope.
+
+Goal:
+- Improve developer and agent understanding of non-trivial logic.
+- Add comments only where they add value.
+- Do not blanket-comment trivial methods or persistence boilerplate.
+
+Scope resolution:
+1. Parse arguments as optional targets.
+2. If arguments are provided, inspect only the requested files, folders, or function filters.
+3. If no arguments are provided, recursively inspect the repository file by file and function by function.
+
+Accepted target styles:
+- File path: `backend/src/JobNecto.Domain/Entities/Resume.cs`
+- Directory path: `backend/src/JobNecto.Application`
+- File + function filter: `backend/src/JobNecto.Domain/Entities/Resume.cs::BuildPrompt`
+- Symbol/function name filter when unambiguous: `BuildPrompt`
+
+Commenting rules:
+- Prefer C# XML documentation comments for functions:
+  - `/// <summary>`
+  - `/// <param name="...">`
+  - `/// <returns>`
+- Add comments for functions that contain meaningful business logic, orchestration, validation, calculations, multi-step transformations, non-obvious side effects, or important domain decisions.
+- Comment public and protected methods first; include private methods only when their intent is not obvious from the code.
+- Keep comments concise, factual, and implementation-aware.
+- Describe:
+  - what the function does
+  - each important argument
+  - the return value or observable effect
+
+Skip these unless the code is unusually complex:
+- trivial getters/setters or obvious one-liners
+- simple CRUD/repository/database wrapper methods
+- EF Core configurations and mappings
+- boilerplate constructors or dependency injection wiring
+- obvious DTO/entity mapping helpers
+- generated code, migrations, and test boilerplate
+
+Execution workflow:
+1. Identify candidate functions in the requested scope.
+2. Skip trivial or low-value candidates.
+3. Add XML docs only to the remaining functions.
+4. Preserve behavior; do not refactor code unless required to make comments accurate.
+5. Summarize which files and functions were documented and which categories were intentionally skipped.
+
+Quality bar:
+- Do not invent behavior not present in code.
+- Do not restate the method name with no extra meaning.
+- If the return type is `Task`, document the awaited result/effect, not just that it is asynchronous.
+- If a function mutates state or calls external systems, mention that clearly.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Command files:
 
 The `code-reviewer` command instructs the agent to run the mechanical report script and execute a dedicated `Code reviewer` subagent workflow.
 
-The `write-comments` command instructs the agent to add XML documentation only for non-trivial functions in the requested scope. With no arguments, it recursively inspects the repository and documents only functions where comments materially improve understanding; trivial CRUD, repository, mapping, and boilerplate methods should be skipped.
+The `write-comments` command instructs the agent to add XML documentation only for non-trivial functions in the requested scope. With no arguments, it recursively inspects C# source files under `backend/src` and documents only functions where comments materially improve understanding; trivial CRUD, repository, mapping, and boilerplate methods should be skipped.
 
 ### Dedicated subagent profile
 

--- a/README.md
+++ b/README.md
@@ -165,16 +165,22 @@ This skill requires running a separate subagent with description `Code reviewer`
 If your IDE supports `.cursor/commands`, run:
 
 - `/code-reviewer`
+- `/write-comments`
 
 Optional:
 
 - `/code-reviewer origin/master`
+- `/write-comments backend/src/JobNecto.Application`
+- `/write-comments backend/src/JobNecto.Domain/Entities/Resume.cs::BuildPrompt`
 
 Command files:
 
 - `.cursor/commands/code-reviewer.md`
+- `.cursor/commands/write-comments.md`
 
-This command instruct the agent to run the mechanical report script and execute a dedicated `Code reviewer` subagent workflow.
+The `code-reviewer` command instructs the agent to run the mechanical report script and execute a dedicated `Code reviewer` subagent workflow.
+
+The `write-comments` command instructs the agent to add XML documentation only for non-trivial functions in the requested scope. With no arguments, it recursively inspects the repository and documents only functions where comments materially improve understanding; trivial CRUD, repository, mapping, and boilerplate methods should be skipped.
 
 ### Dedicated subagent profile
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `/write-comments` Cursor command for adding XML documentation comments to non-trivial functions
- support targeted file, directory, and function-filter arguments, plus a sensible no-argument default over `backend/src` C# files
- document the new command in `README.md` with usage examples and skip criteria

## Testing
- `dotnet build backend/JobNecto.slnx`
- `dotnet test backend/JobNecto.slnx`
- `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`
- `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror`
- dedicated Code Reviewer subagent run with no blocking findings

## Notes
- the command intentionally skips trivial one-liners, CRUD/repository wrappers, EF mappings, DI boilerplate, generated files, migrations, tests, and non-C# files unless explicitly targeted
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-609baef5-91b5-4009-ad8d-499d42831931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-609baef5-91b5-4009-ad8d-499d42831931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

