### PR TITLE
Add function-comments command, skill, and agent profile (consolidated)

### DIFF
--- a/.cursor/agents/function-comments.md
+++ b/.cursor/agents/function-comments.md
@@ -1,0 +1,29 @@
+---
+name: Function comments
+description: Adds or completes C# XML documentation on functions that need it; respects skip rules for trivial and boilerplate code.
+model: fast
+subagent_type: generalPurpose
+---
+
+# Function comments subagent profile
+
+You are the agent responsible for **function-comments** work in this repository.
+
+## Mission
+
+Add **`///` XML documentation** (`<summary>`, `<param>`, `<returns>` as applicable) to C# members that **require** explanation per `.cursor/skills/function-comments/SKILL.md`.
+
+## Rules
+
+- Follow the skill exactly for **scope** (paths and symbol names vs full scan under `backend/src` per the command).
+- **Skip** thin CRUD repositories, trivial one-liners, EF `Configure` mappings, and ordinary test methods unless instructed otherwise.
+- Work **file by file**, **member by member**, without skipping in-scope files.
+- After substantive edits, ensure **`dotnet build backend/JobNecto.slnx`** succeeds, then **`dotnet test backend/JobNecto.slnx`**.
+
+## Output
+
+Return:
+
+- Scope summary.
+- Files changed and approximate number of members documented.
+- Notable skips (by policy).

--- a/.cursor/commands/function-comments.md
+++ b/.cursor/commands/function-comments.md
@@ -12,8 +12,9 @@ Requirements:
 
 Execution steps:
 
-1. **If arguments are provided** (file paths, folder paths, or function names):
+1. **If arguments are provided** (file paths, folder paths, or function/type names):
    - Scope the work to only the specified targets.
+   - For a bare symbol name with no path, search `backend/src` for definitions; if multiple matches exist, narrow scope (ask the user or process each match).
    - Read each file, identify qualifying functions, add XML doc comments.
 
 2. **If no arguments are provided** (full project scan):

--- a/.cursor/commands/function-comments.md
+++ b/.cursor/commands/function-comments.md
@@ -1,0 +1,31 @@
+---
+description: Add XML doc comments to functions that need them
+argument-hint: [file-or-folder paths...]
+---
+
+Add C# XML documentation comments (`/// <summary>`, `/// <param>`, `/// <returns>`) to functions and methods that benefit from documentation. Skip trivial, self-explanatory, or boilerplate code.
+
+Requirements:
+- Use the skill: `.cursor/skills/function-comments/SKILL.md`
+- Follow the comment/skip criteria defined in the skill.
+- Preserve existing XML doc comments unless they are clearly wrong.
+
+Execution steps:
+
+1. **If arguments are provided** (file paths, folder paths, or function names):
+   - Scope the work to only the specified targets.
+   - Read each file, identify qualifying functions, add XML doc comments.
+
+2. **If no arguments are provided** (full project scan):
+   - Recursively scan `backend/src/` one project at a time.
+   - Process in order: Application → Domain → Infrastructure → Infrastructure.LLM → Infrastructure.JobSources → API.
+   - Within each project, process one file at a time.
+   - Add XML doc comments only to functions matching the "MUST comment" criteria from the skill.
+
+3. After all changes, verify:
+   - `dotnet build backend/JobNecto.slnx`
+   - `dotnet test backend/JobNecto.slnx`
+
+Output:
+- List of files modified and functions commented.
+- Build and test results confirming no regressions.

--- a/.cursor/skills/function-comments/SKILL.md
+++ b/.cursor/skills/function-comments/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: function-comments
+description: Add XML documentation comments to functions that benefit from them. Use when asked to document functions, add comments, or improve code documentation across the project.
+---
+
+# Function Comments
+
+Add C# XML documentation comments (`/// <summary>`, `/// <param>`, `/// <returns>`) to functions and methods that benefit from documentation. Skip trivial or self-explanatory code.
+
+## When to use
+
+- User runs the `function-comments` command (with or without arguments).
+- User asks to "add comments", "document functions", or "improve documentation".
+
+## What to comment
+
+### MUST comment (non-trivial logic that benefits developers and AI agents)
+
+- **Interface method signatures** in the Application layer — these define contracts consumed by multiple implementations and callers.
+- **Extension methods for DI registration** (`AddInfrastructure`, `AddApplication`, etc.) — describe what services are registered and any required configuration.
+- **Methods with complex business logic** — filtering, scoring, matching, transformation pipelines, multi-step workflows.
+- **Methods with non-obvious side effects** — methods that throw on missing entities, mutate external state, or have retry/fallback behavior.
+- **Public API endpoints** — controllers, minimal API route handlers, middleware.
+- **Generic/abstract base class methods** with non-trivial behavior — pagination strategies, cursor-based queries, soft-delete implementations.
+- **Domain value objects and records** with business meaning — class-level `<summary>` when the type represents a domain concept that is not obvious from the name alone.
+
+### SHOULD NOT comment (self-explanatory or boilerplate)
+
+- Simple CRUD repository methods whose behavior is obvious from name and signature (e.g. `GetByIdAsync(Guid id)`, `CreateAsync(T entity)`, `DeleteAsync(Guid id)`).
+- EF Core `IEntityTypeConfiguration.Configure` methods — the fluent API calls are self-documenting.
+- Trivial property accessors, constructors that only assign fields, and empty/`NotImplementedException` stubs.
+- Enum definitions, simple record/class declarations with only auto-properties or public fields.
+- Private methods that are only called from one place and whose intent is clear from context.
+
+### Grey area (use judgement)
+
+- Private helper methods with moderate complexity — comment if the logic is not immediately clear.
+- Overridden virtual methods — comment only if the override changes the contract or adds behavior beyond the base.
+- Test methods — prefer descriptive test names over XML doc comments.
+
+## Comment format
+
+Use standard C# XML documentation:
+
+```csharp
+/// <summary>
+/// Brief description of what the method does and why.
+/// </summary>
+/// <param name="paramName">What this parameter represents and any constraints.</param>
+/// <returns>What is returned, including edge cases (null, empty, exceptions).</returns>
+```
+
+Rules:
+
+1. `<summary>` is always required.
+2. `<param>` tags for every parameter unless the method has zero parameters.
+3. `<returns>` for methods that return a value; omit for `void`. For `Task` / `Task<T>` / `ValueTask` / `ValueTask<T>`, describe what completing the task means and what the result represents when there is one.
+4. `<exception cref="...">` only when the method explicitly throws and callers need to know.
+5. Keep descriptions concise — one to three sentences. Do not restate the method signature.
+6. Focus on **intent**, **constraints**, and **edge-case behavior** rather than implementation details.
+7. Write in third-person present tense ("Retrieves…", "Applies…", "Registers…").
+
+## Execution workflow
+
+### With arguments (targeted)
+
+When the user provides file paths or function names:
+
+1. Read each specified file.
+2. Identify functions/methods matching the criteria above.
+3. Add XML doc comments to qualifying functions.
+4. Skip functions in the "SHOULD NOT comment" category.
+5. Build to verify no compilation issues: `dotnet build backend/JobNecto.slnx`.
+
+### Without arguments (full project scan)
+
+When no arguments are provided, scan the entire `backend/src/` tree:
+
+1. Process one project at a time in this order:
+   - `JobNecto.Application` (interfaces and contracts first — highest value)
+   - `JobNecto.Domain` (value objects, records, entity summaries)
+   - `JobNecto.Infrastructure` (DI registration, non-trivial repository methods)
+   - `JobNecto.Infrastructure.LLM` (if `.cs` files exist)
+   - `JobNecto.Infrastructure.JobSources` (if `.cs` files exist)
+   - `JobNecto.API` (endpoints, middleware, program configuration)
+2. Within each project, process one file at a time.
+3. For each file:
+   - Read the file.
+   - Identify every public/protected method and class.
+   - Apply the "MUST comment" / "SHOULD NOT comment" criteria.
+   - Add XML doc comments only where they add value.
+   - Preserve existing `/// <summary>` comments — do not overwrite them unless they are obviously wrong or incomplete.
+4. After all files in a project are processed, run: `dotnet build backend/JobNecto.slnx`.
+5. Fix any issues before moving to the next project.
+6. After all projects: run full build and test to confirm no regressions.
+
+```bash
+dotnet build backend/JobNecto.slnx
+dotnet test backend/JobNecto.slnx
+```
+
+## Examples
+
+### Good: Interface method with contract documentation
+
+```csharp
+/// <summary>
+/// Retrieves a paginated list of vacancies filtered by the specified criteria.
+/// Supports cursor-based pagination using <paramref name="pagedQuery"/>.
+/// </summary>
+/// <param name="pagedQuery">Pagination cursor with page size and last-seen identifiers.</param>
+/// <param name="filter">Optional filter criteria; when null, no filtering is applied.</param>
+/// <param name="ct">Cancellation token.</param>
+/// <returns>A paged result containing matching vacancies and pagination metadata.</returns>
+Task<PagedResult<Vacancy>> GetFilteredAsync(PagedQuery pagedQuery, VacancyFilter? filter = null, CancellationToken ct = default);
+```
+
+### Good: DI registration extension method
+
+```csharp
+/// <summary>
+/// Registers infrastructure services including the EF Core database context
+/// (PostgreSQL via Npgsql) and the Unit of Work pattern.
+/// Reads the "Postgres" connection string from <paramref name="configuration"/>.
+/// </summary>
+/// <param name="services">The service collection to add registrations to.</param>
+/// <param name="configuration">Application configuration containing connection strings.</param>
+/// <returns>The service collection for chaining.</returns>
+public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+```
+
+### Good: Class-level summary for a domain concept
+
+```csharp
+/// <summary>
+/// Captures a user's professional profile snapshot used as the primary input
+/// for vacancy matching algorithms and LLM-driven cover letter generation.
+/// </summary>
+public sealed class Resume : BaseEntity
+```
+
+### Skip: Simple CRUD — no comment needed
+
+```csharp
+// No XML doc needed — GetByIdAsync is universally understood.
+public virtual async Task<T?> GetByIdAsync(Guid id, CancellationToken ct)
+{
+    return await _dbSet.FindAsync([id], ct);
+}
+```
+
+### Skip: EF configuration — no comment needed
+
+```csharp
+// No XML doc needed — fluent API calls are self-documenting.
+public void Configure(EntityTypeBuilder<Vacancy> builder) { ... }
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,13 @@ JobNecto is a .NET 10 backend API for job vacancy aggregation and matching. Clea
 - The `Program.cs` does not yet call `AddInfrastructure()`, so the DB connection is not used at startup. When it is wired up, PostgreSQL must be running with the above credentials.
 - To start PostgreSQL: `sudo pg_ctlcluster 16 main start`
 
+### Cursor agent command: function comments
+
+- **Command:** `.cursor/commands/function-comments.md`
+- **Skill:** `.cursor/skills/function-comments/SKILL.md`
+- **Purpose:** Add C# XML docs (`///` with `<summary>`, `<param>`, `<returns>`) to functions that benefit from documentation; skip trivial code per the skill.
+- **Arguments:** Optional file paths, folders, or function names to limit scope; with no arguments, scan `backend/src/` in project order (see the command).
+
 ### Gotchas
 
 - The root `.sln` (`Jobnecto.sln`) uses Windows-style backslash paths and does not include the test project. Always use `backend/JobNecto.slnx` for builds and tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,9 @@ JobNecto is a .NET 10 backend API for job vacancy aggregation and matching. Clea
 
 - **Command:** `.cursor/commands/function-comments.md`
 - **Skill:** `.cursor/skills/function-comments/SKILL.md`
+- **Agent profile (optional):** `.cursor/agents/function-comments.md`
 - **Purpose:** Add C# XML docs (`///` with `<summary>`, `<param>`, `<returns>`) to functions that benefit from documentation; skip trivial code per the skill.
-- **Arguments:** Optional file paths, folders, or function names to limit scope; with no arguments, scan `backend/src/` in project order (see the command).
+- **Arguments:** Optional file paths, folders, or function names to limit scope; with no arguments, scan `backend/src/` in project order (see the command). If only a bare function or type name is given, search the solution for matches or ask for a file path when ambiguous.
 
 ### Gotchas
 

--- a/README.md
+++ b/README.md
@@ -182,13 +182,12 @@ The `code-reviewer` command instructs the agent to run the mechanical report scr
 
 The `function-comments` command instructs the agent to add C# XML documentation for non-trivial functions in the requested scope. With no arguments, it scans `backend/src` in dependency order and skips boilerplate per `.cursor/skills/function-comments/SKILL.md`.
 
-### Dedicated subagent profile
+### Dedicated agent profiles
 
-Repository subagent profile:
+Repository agent profiles:
 
-- `.cursor/subagents/code-reviewer.md`
-
-This profile standardizes the dedicated reviewer behavior and required risk-scored output format.
+- `.cursor/agents/code-reviewer.md` — dedicated reviewer behavior and required risk-scored output format
+- `.cursor/agents/function-comments.md` — optional subagent for large `function-comments` runs (follows the skill)
 
 ## Future features
 

--- a/README.md
+++ b/README.md
@@ -165,16 +165,22 @@ This skill requires running a separate subagent with description `Code reviewer`
 If your IDE supports `.cursor/commands`, run:
 
 - `/code-reviewer`
+- `/function-comments`
 
 Optional:
 
 - `/code-reviewer origin/master`
+- `/function-comments backend/src/JobNecto.Application`
+- `/function-comments backend/src/JobNecto.Domain/Entities/Resume.cs`
 
 Command files:
 
 - `.cursor/commands/code-reviewer.md`
+- `.cursor/commands/function-comments.md`
 
-This command instruct the agent to run the mechanical report script and execute a dedicated `Code reviewer` subagent workflow.
+The `code-reviewer` command instructs the agent to run the mechanical report script and execute a dedicated `Code reviewer` subagent workflow.
+
+The `function-comments` command instructs the agent to add C# XML documentation for non-trivial functions in the requested scope. With no arguments, it scans `backend/src` in dependency order and skips boilerplate per `.cursor/skills/function-comments/SKILL.md`.
 
 ### Dedicated subagent profile
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates four overlapping PRs that all aimed at the same feature: **Cursor tooling to add C# XML documentation** to non-trivial members, with optional scoping or a full pass over `backend/src`.

**Chosen approach:** One unified PR that keeps the best of each branch instead of merging any single duplicate as-is.

## How the four PRs compared

| PR | Strengths | Gaps / why not merge alone |
|----|-----------|---------------------------|
| **#40** (`function-comments` + skill) | Deepest `function-comments` command + `function-comments` skill (MUST/SHOULD NOT, project order, build+test). | No `AGENTS.md` / README discoverability; no optional agent profile. |
| **#41** (`document-functions`) | `AGENTS.md` cross-link, `document-functions` skill, optional `document-functions` agent. | Second command name (`document-functions`) duplicates the same workflow; less JobNecto-specific depth than #40’s skill. |
| **#42** (`write-comments`) | README examples and self-contained command rules. | No skill file; different command name only. |
| **#43** (`function-comments` + README) | README mention. | Thin command, mixed TS/JS/Python doc styles; weaker than #40 for this repo. |

**Resolution:** Use **#40’s** command + skill as the core, add **#41-style** `AGENTS.md` + optional **`.cursor/agents/function-comments.md`**, and **README** examples aligned with **#42** (paths + scope). Single command name: **`/function-comments`** (no parallel `document-functions` / `write-comments`).

## What’s included

- `.cursor/commands/function-comments.md` — scoped or full `backend/src` scan; build + test verification; clarifies bare symbol arguments.
- `.cursor/skills/function-comments/SKILL.md` — criteria, XML format, execution order, examples.
- `.cursor/agents/function-comments.md` — optional subagent profile for large runs.
- `AGENTS.md` — discoverability section.
- `README.md` — IDE commands + examples; fixes incorrect `.cursor/subagents/code-reviewer.md` path to `.cursor/agents/code-reviewer.md` and lists function-comments agent profile.

## Testing

- `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`
- `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror`

## Follow-up

After merge, **close PRs #40–#43** as superseded by this PR to avoid duplicate commands and naming drift.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8426a4ac-192b-48b3-aa98-d1d85088867e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8426a4ac-192b-48b3-aa98-d1d85088867e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

