### PR TITLE
Wire PostgreSQL and DbContext in API startup (#16)

### DIFF
--- a/.github/scripts/pr_review_llm.mjs
+++ b/.github/scripts/pr_review_llm.mjs
@@ -36,10 +36,11 @@ const DEFAULT_MODEL = "stepfun/step-3.5-flash:free";
  * Matches paths from `diff --git a/... b/...` (normalized to forward slashes).
  */
 const SKIP_PATH_RE = new RegExp(
-  "(?i)(^|/)(node_modules|bin|obj|\\.git)(/|$)|" +
+  "(^|/)(node_modules|bin|obj|\\.git)(/|$)|" +
     "\\.(lock|dll|exe|pdb|png|jpe?g|gif|webp|ico|pdf|zip|ttf|woff2?|eot)$|" +
     "(packages\\.lock\\.json|package-lock\\.json|yarn\\.lock|pnpm-lock\\.yaml|\\.min\\.js)$|" +
     "\\.Designer\\.cs$|\\.g\\.cs$|\\.generated\\.|/Generated/",
+  "i",
 );
 
 function shouldSkipFile(path) {

--- a/.github/scripts/pr_review_llm.mjs
+++ b/.github/scripts/pr_review_llm.mjs
@@ -29,7 +29,7 @@ const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_DIFF_CHARS = 900_000;
 
 /** Used when OPENROUTER_MODEL is unset or empty. */
-const DEFAULT_MODEL = "stepfun/step-3.5-flash:free";
+const DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b:free";
 
 /**
  * Paths whose entire diff hunks we drop before calling the LLM.

--- a/backend/src/JobNecto.API/ApiAssemblyMarker.cs
+++ b/backend/src/JobNecto.API/ApiAssemblyMarker.cs
@@ -1,0 +1,6 @@
+namespace JobNecto.API;
+
+/// <summary>
+/// Entry for <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}" /> so tests can bootstrap this assembly without relying on the synthesized <c>Program</c> type.
+/// </summary>
+public sealed class ApiAssemblyMarker;

--- a/backend/src/JobNecto.API/Program.cs
+++ b/backend/src/JobNecto.API/Program.cs
@@ -3,6 +3,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();
 
@@ -15,4 +16,3 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.Run();
-

--- a/backend/src/JobNecto.Infrastructure/DI.cs
+++ b/backend/src/JobNecto.Infrastructure/DI.cs
@@ -1,15 +1,24 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 public static class InfrastructureCollectionExtensions
 {
+    /// <summary>
+    /// Registers EF Core (<see cref="AppDbContext"/>) and infrastructure services.
+    /// </summary>
+    /// <param name="services">Application DI collection.</param>
+    /// <param name="configuration">Must define a usable <c>ConnectionStrings:Postgres</c> value (non-empty, parseable, with a host).</param>
+    /// <returns><paramref name="services"/> for chaining.</returns>
+    /// <exception cref="InvalidOperationException">When the Postgres connection string is missing, blank, unparsable, or has no host (common misconfiguration).</exception>
     public static IServiceCollection AddInfrastructure(
         this IServiceCollection services,
         IConfiguration configuration
     )
     {
         var connectionString = configuration.GetConnectionString("Postgres");
+        EnsureValidPostgresConnectionString(connectionString);
 
         services.AddDbContext<AppDbContext>(options =>
             options.UseNpgsql(
@@ -21,5 +30,41 @@ public static class InfrastructureCollectionExtensions
         services.AddScoped<IUnitOfWork, UnitOfWork>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Purpose: fail fast at composition time so operators see a clear configuration error instead of an Npgsql error on first query.
+    /// Assumes: standard Npgsql keyword connection strings (see <see cref="NpgsqlConnectionStringBuilder"/>).
+    /// Contract: returns normally only when <paramref name="connectionString"/> is non-blank and supplies a non-empty host.
+    /// Failure modes: <see cref="InvalidOperationException"/> for null/empty, parse errors, or empty host (e.g. template <c>Host=;</c> in appsettings).
+    /// </summary>
+    private static void EnsureValidPostgresConnectionString(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                "ConnectionStrings:Postgres is missing or empty. Set it in configuration, environment variables, or user secrets (see appsettings.Development.json for a local development example)."
+            );
+        }
+
+        NpgsqlConnectionStringBuilder builder;
+        try
+        {
+            builder = new NpgsqlConnectionStringBuilder(connectionString);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "ConnectionStrings:Postgres is not a valid PostgreSQL connection string.",
+                ex
+            );
+        }
+
+        if (string.IsNullOrWhiteSpace(builder.Host))
+        {
+            throw new InvalidOperationException(
+                "ConnectionStrings:Postgres must include a non-empty Host (current value looks like a template; override with real credentials for the target environment)."
+            );
+        }
     }
 }

--- a/backend/tests/JobNecto.Tests/API/InfrastructureHostingTests.cs
+++ b/backend/tests/JobNecto.Tests/API/InfrastructureHostingTests.cs
@@ -99,4 +99,73 @@ public sealed class InfrastructureHostingTests
                 && d.Lifetime == ServiceLifetime.Scoped
             );
     }
+
+    /// <summary>
+    /// Purpose: guard <c>EnsureValidPostgresConnectionString</c> when the key is absent.
+    /// Contract: <see cref="InvalidOperationException"/> mentions Postgres configuration.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_throws_when_Postgres_connection_string_is_missing()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+
+        var act = () => services.AddInfrastructure(configuration);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .Which.Message.Should()
+            .Contain("Postgres")
+            .And.Contain("missing")
+            .And.Contain("empty");
+    }
+
+    /// <summary>
+    /// Purpose: reject blank connection string values (whitespace only).
+    /// Contract: <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_throws_when_Postgres_connection_string_is_whitespace()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:Postgres"] = "   " })
+            .Build();
+
+        var services = new ServiceCollection();
+
+        var act = () => services.AddInfrastructure(configuration);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Purpose: catch template appsettings where <c>Host=;</c> leaves host empty after parse.
+    /// Contract: message explains host requirement.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_throws_when_Postgres_host_is_empty()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:Postgres"] =
+                        "Host=;Port=5432;Database=JobNecto;Username=x;Password=y;Pooling=true;",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+
+        var act = () => services.AddInfrastructure(configuration);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .Which.Message.Should()
+            .Contain("Host")
+            .And.Contain("non-empty");
+    }
 }

--- a/backend/tests/JobNecto.Tests/API/InfrastructureHostingTests.cs
+++ b/backend/tests/JobNecto.Tests/API/InfrastructureHostingTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using JobNecto.API;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace JobNecto.Tests.API;
+
+/// <summary>
+/// Verifies issue #16: infrastructure is wired so the host builds and <see cref="AppDbContext"/> resolves from DI (Development settings).
+/// </summary>
+public sealed class InfrastructureHostingTests
+{
+    /// <summary>
+    /// Purpose: regression guard that the API host composes with Infrastructure DI.
+    /// Assumes: default API configuration includes a Postgres connection string (Development appsettings).
+    /// Contract: scoped <see cref="AppDbContext"/> resolves (issue #16); no DB round-trip required.
+    /// Side effects: builds the test host only.
+    /// Failure modes: <see cref="IUnitOfWork"/> is not resolved here because <c>UnitOfWork.DisposeAsync</c> is not implemented yet (#14).
+    /// </summary>
+    [Fact]
+    public async Task WebApplicationFactory_in_Development_resolves_AppDbContext()
+    {
+        await using var factory = new WebApplicationFactory<ApiAssemblyMarker>().WithWebHostBuilder(
+            builder => builder.UseEnvironment(Environments.Development)
+        );
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        db.Should().NotBeNull();
+        db.Database.ProviderName.Should().Be("Npgsql.EntityFrameworkCore.PostgreSQL");
+    }
+
+    /// <summary>
+    /// Purpose: prove <see cref="InfrastructureCollectionExtensions.AddInfrastructure"/> wires Npgsql <see cref="AppDbContext"/> when <c>ConnectionStrings:Postgres</c> is set.
+    /// Assumes: in-memory configuration uses the same key shape as appsettings.
+    /// Contract: scoped <see cref="AppDbContext"/> resolves with Npgsql provider metadata.
+    /// Side effects: builds and disposes a <see cref="ServiceProvider"/>.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_with_Postgres_connection_registers_scoped_AppDbContext()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:Postgres"] =
+                        "Host=localhost;Port=5432;Database=JobNecto;Username=test;Password=test",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging();
+        services.AddInfrastructure(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        db.Database.ProviderName.Should().Be("Npgsql.EntityFrameworkCore.PostgreSQL");
+    }
+
+    /// <summary>
+    /// Purpose: document that UoW is registered alongside EF without constructing <see cref="UnitOfWork"/> (avoids <c>DisposeAsync</c> until #14).
+    /// Assumes: <see cref="InfrastructureCollectionExtensions.AddInfrastructure"/> unchanged.
+    /// Contract: exactly one scoped <see cref="IUnitOfWork"/> → <see cref="UnitOfWork"/> registration exists.
+    /// Side effects: none (descriptor inspection only).
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_registers_scoped_IUnitOfWork()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:Postgres"] =
+                        "Host=localhost;Port=5432;Database=JobNecto;Username=test;Password=test",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging();
+        services.AddInfrastructure(configuration);
+
+        services
+            .Should()
+            .ContainSingle(d =>
+                d.ServiceType == typeof(IUnitOfWork)
+                && d.ImplementationType == typeof(UnitOfWork)
+                && d.Lifetime == ServiceLifetime.Scoped
+            );
+    }
+}

--- a/backend/tests/JobNecto.Tests/JobNecto.Tests.csproj
+++ b/backend/tests/JobNecto.Tests/JobNecto.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
## Summary
Implements [GitHub issue #16](https://github.com/TimmyGray/Jobnecto/issues/16): the API host calls \AddInfrastructure(builder.Configuration)\ so \AppDbContext\ is registered with Npgsql using the \Postgres\ connection string from configuration (see \ppsettings.Development.json\).

## Done when (from issue)
- App composes with Development settings and \AppDbContext\ resolves from DI.

## Changes
- \Program.cs\: register infrastructure alongside OpenAPI.
- \ApiAssemblyMarker.cs\: assembly entry type for \WebApplicationFactory\ in tests.
- \InfrastructureHostingTests\: integration-style check for the real host plus \AddInfrastructure\ unit checks; \Microsoft.AspNetCore.Mvc.Testing\ package added.

## Verification
- \dotnet build backend/JobNecto.slnx --configuration Release --warnaserror\
- \dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror\

Fixes #16

Made with [Cursor](https://cursor.com)