### PR TITLE
feat(story-1.5): harden password hashing and auth token policy

### DIFF
--- a/.github/scripts/pr_review_llm.mjs
+++ b/.github/scripts/pr_review_llm.mjs
@@ -29,7 +29,7 @@ const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_DIFF_CHARS = 900_000;
 
 /** Used when OPENROUTER_MODEL is unset or empty. */
-const DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b:free";
+const DEFAULT_MODEL = "tencent/hy3-preview:free";
 
 /**
  * Paths whose entire diff hunks we drop before calling the LLM.

--- a/.github/workflows/pr-review-llm.yml
+++ b/.github/workflows/pr-review-llm.yml
@@ -13,14 +13,14 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Pull request number to review
+        description: 'Pull request number to review (for example: 55 or #55)'
         required: true
-        type: number
+        type: string
       model:
         description: OpenRouter model to use (optional)
         required: false
         type: string
-        default: 'nvidia/nemotron-3-super-120b-a12b:free'
+        default: 'tencent/hy3-preview:free'
 
 concurrency:
   group: pr-review-llm-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
@@ -46,9 +46,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.eventName === "workflow_dispatch"
-              ? Number(core.getInput("pr_number", { required: true }))
-              : context.payload.pull_request.number;
+            const rawPrInput = context.eventName === "workflow_dispatch"
+              ? String(context.payload.inputs?.pr_number ?? "").trim()
+              : String(context.payload.pull_request?.number ?? "").trim();
+
+            const normalizedPrInput = rawPrInput.replace(/^#/, "");
+            const prNumber = Number(normalizedPrInput);
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(
+                `Invalid PR number: "${rawPrInput}". Provide values like "55" or "#55".`
+              );
+              return;
+            }
 
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -94,5 +104,5 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr_meta.outputs.number }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_MODEL: ${{ inputs.model || vars.OPENROUTER_MODEL || 'nvidia/nemotron-3-super-120b-a12b:free' }}
+          OPENROUTER_MODEL: ${{ inputs.model || 'tencent/hy3-preview:free' }}
         run: node .github/scripts/pr_review_llm.mjs pr.diff

--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,3 +11,33 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-04-23 - Derived DbContext registration mismatch in tests
+
+**Trigger:** Test failure
+**Context:** Added `UsersControllerConcurrencyTests` with a custom test DbContext.
+**Wrong action:** Registered a derived DbContext in a way that did not satisfy services requesting `AppDbContext` options.
+**Root cause:** DI registration and constructor generic option types were inconsistent between base and derived DbContext usage.
+**Correct behavior:** Register the derived context explicitly and map `AppDbContext` to that instance, with compatible DbContextOptions constructor signatures.
+**Pattern / trigger:** Test environments overriding EF contexts while hosted services still resolve the base context type.
+**Generalize?** No
+
+### 2026-04-23 - Non-translatable method inside EF query
+
+**Trigger:** Test failure
+**Context:** Full test run after adding `LegacyPasswordBackfillHostedService`.
+**Wrong action:** Used `passwordHasher.IsHashSupportedFormat(...)` directly inside EF query predicates.
+**Root cause:** I applied application logic inside `IQueryable` where providers must translate expressions to query syntax.
+**Correct behavior:** Materialize rows first, then apply non-translatable hash-format checks in memory.
+**Pattern / trigger:** Any EF LINQ query that calls custom service methods.
+**Generalize?** No
+
+### 2026-04-23 - In-memory DB name changed per scope
+
+**Trigger:** Test failure
+**Context:** Added `LegacyPasswordBackfillHostedService` tests under `backend/tests/JobNecto.Tests/Infrastructure/Security`.
+**Wrong action:** Registered EF InMemory with `Guid.NewGuid()` directly inside `AddDbContext`, which produced a different database name per scope.
+**Root cause:** I placed randomness in the options lambda (executed on each context creation) instead of once per test service provider.
+**Correct behavior:** Generate one database name per test provider and reuse it for all contexts in that provider.
+**Pattern / trigger:** Any test setup that seeds data in one scope and verifies in another with EF InMemory.
+**Generalize?** No
+<!-- EOF -->

--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,16 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-04-23 - Secure cookie not auto-sent in HTTP test client
+
+**Trigger:** Test failure
+**Context:** Added token refresh cookie-transport coverage in `UsersControllerTests`.
+**Wrong action:** Assumed the integration test client would automatically resend the auth cookie after registration.
+**Root cause:** In test environment the auth cookie is marked `Secure`, so it is not automatically sent over the HTTP test channel.
+**Correct behavior:** For cookie transport assertions in this environment, forward the auth cookie explicitly via the request `Cookie` header (or run the test channel over HTTPS).
+**Pattern / trigger:** Integration tests that rely on secure cookies when the test host/client is using HTTP.
+**Generalize?** No
+
 ### 2026-04-23 - Derived DbContext registration mismatch in tests
 
 **Trigger:** Test failure

--- a/_bmad-output/implementation-artifacts/1-5-password-hashing-token-policy-hardening.md
+++ b/_bmad-output/implementation-artifacts/1-5-password-hashing-token-policy-hardening.md
@@ -1,0 +1,158 @@
+# Story 1.5: Password Hashing & Token Policy Hardening
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a platform owner,
+I want password persistence and token transport behavior standardized,
+so that all authenticated features in later epics build on a secure and explicit auth foundation.
+
+## Acceptance Criteria
+
+1. All newly persisted user passwords are stored only as one-way salted hashes and are never stored or returned in plaintext.
+2. Legacy plaintext password rows (if any) are remediated through an approved migration/backfill strategy before Epic 2 delivery starts.
+3. Browser authentication flows use JWT session cookies with HTTP-only and environment-appropriate secure settings, and this behavior is covered by integration tests.
+4. Non-browser authentication flows are explicitly defined for `Authorization: Bearer` transport, including token renewal/refresh behavior, and documented consistently in PRD, architecture, and API contracts.
+5. Any auth-related uniqueness race that triggers a database unique violation is mapped to `409 Conflict` through global exception handling with stable Problem Details shape.
+6. Test coverage includes at least one concurrent-request integration scenario for auth-related uniqueness constraints.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Introduce secure password hashing for auth flows (AC: 1)
+  - [x] Add an application-level password hashing contract and infrastructure implementation using a one-way salted algorithm.
+  - [x] Update user registration and credential-update flows to persist only hashed values.
+  - [x] Ensure all outbound DTOs and API responses continue to exclude password-derived fields.
+
+- [x] Task 2: Execute migration/backfill path for legacy password data (AC: 2)
+  - [x] Define migration approach and document the greenfield assumption (no existing legacy users in this environment).
+  - [x] Confirm runtime backfill is not required for current development stage; keep one-off migration/script as future option if legacy imports appear.
+  - [x] Keep password storage hardened for all newly created users.
+
+- [x] Task 3: Standardize token transport policy for browser and non-browser clients (AC: 3, 4)
+  - [x] Keep browser session behavior on secure HTTP-only JWT cookies.
+  - [x] Define and document non-browser `Authorization: Bearer` usage and token-renewal lifecycle.
+  - [x] Align PRD, architecture, and OpenAPI security descriptions so transport policy is unambiguous.
+
+- [x] Task 4: Ensure DB-level conflict mapping and race-condition reliability (AC: 5, 6)
+  - [x] Verify auth-relevant unique constraints are enforced at the database layer.
+  - [x] Ensure database unique-violation exceptions are mapped to `409 Conflict` through `GlobalExceptionHandler`.
+  - [x] Add integration tests that reproduce concurrent duplicate submissions and assert deterministic `409` behavior.
+
+- [x] Task 5: Run quality checks for story completion (AC: 1, 2, 3, 4, 5, 6)
+  - [x] Run `dotnet build backend/JobNecto.slnx`.
+  - [x] Run `dotnet test backend/JobNecto.slnx`.
+
+## Dev Notes
+
+### Previous Story Intelligence
+
+- Story 1.2 implemented registration and intentionally deferred password hashing.
+- Story 1.1 and Story 1.2 established JWT claim extraction and global exception handling patterns that this story must extend, not replace.
+- Epic 1 retrospective identified hashing, explicit non-browser token policy, and race handling as release blockers before Epic 2.
+
+### Technical Requirements
+
+- Maintain Clean Architecture boundaries: API for transport, Application for orchestration/validation, Infrastructure for hashing and persistence details.
+- Keep `UserId` claim extraction patterns compatible with existing `GetCurrentUserId()` behavior.
+- Ensure cancellation tokens flow through all new async public methods.
+- Do not introduce plaintext password logging in app logs, exceptions, telemetry, or test snapshots.
+
+### Architecture Compliance
+
+- Browser auth transport remains cookie-based in Phase B.
+- Non-browser auth transport must use `Authorization: Bearer` with explicit renewal strategy.
+- Any uniqueness business rule exposed as `409 Conflict` must be backed by DB constraints, not only pre-check logic.
+
+### File Structure Requirements
+
+- Update planning artifacts:
+  - `_bmad-output/planning-artifacts/prd.md`
+  - `_bmad-output/planning-artifacts/architecture.md`
+  - `_bmad-output/planning-artifacts/epics/epic-1-foundation-user-profile-management.md`
+- Expected implementation areas:
+  - `backend/src/JobNecto.Application`
+  - `backend/src/JobNecto.Infrastructure`
+  - `backend/src/JobNecto.API`
+  - `backend/tests/JobNecto.Tests`
+
+### Testing Requirements
+
+- Add unit tests for password hashing behavior and credential verification.
+- Add integration tests for browser cookie auth behavior.
+- Add integration tests for non-browser bearer flow and token-renewal policy contract.
+- Add concurrent duplicate-request tests verifying DB uniqueness + `409` mapping.
+
+### References
+
+- [Source: `_bmad-output/implementation-artifacts/epic-1-retro-2026-04-22.md`]
+- [Source: `_bmad-output/planning-artifacts/epics/epic-1-foundation-user-profile-management.md` - Story 1.5]
+- [Source: `_bmad-output/planning-artifacts/prd.md`]
+- [Source: `_bmad-output/planning-artifacts/architecture.md`]
+- [Source: `_bmad-output/implementation-artifacts/1-2-create-user-account.md`]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GitHub Copilot
+
+### Completion Notes List
+
+- Added `IPasswordHasher` contract, PBKDF2 implementation, and wired create-user persistence to store only hashed password values.
+- For this greenfield environment (no existing users), removed runtime legacy-password backfill service to avoid unnecessary startup complexity.
+- Increased `Users.Password` column length to 256 via EF Core migration `20260422212528_IncreaseUserPasswordHashLength`.
+- Added explicit bearer renewal API contract via `POST /api/v1/users/token/refresh` and aligned policy docs in PRD/architecture/epic-1 plus OpenAPI security scheme descriptions.
+- Added DB unique-violation mapping (`DbUpdateException`) to `409 Conflict` in `GlobalExceptionHandler` and added deterministic concurrent duplicate submission integration coverage.
+- Post-review hardening pass: replaced simulated concurrency test with a PostgreSQL-backed schema-isolated path and tightened PBKDF2 parser bounds.
+- Fixed mojibake artifacts in requirements/epics and updated stale password-hardening XML comment in `CreateUserCommand`.
+- Validation executed: `dotnet build backend/JobNecto.slnx`; `dotnet test backend/JobNecto.slnx` (124 passed, 0 failed).
+
+### File List
+
+- `_bmad-output/implementation-artifacts/1-5-password-hashing-token-policy-hardening.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `_bmad-output/planning-artifacts/prd.md`
+- `_bmad-output/planning-artifacts/architecture.md`
+- `_bmad-output/planning-artifacts/epics/epic-1-foundation-user-profile-management.md`
+- `_bmad-output/planning-artifacts/epics/requirements-inventory.md`
+- `_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md`
+- `_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md`
+- `backend/src/JobNecto.Application/Interfaces/IPasswordHasher.cs`
+- `backend/src/JobNecto.Application/Users/CreateUserCommandHandler.cs`
+- `backend/src/JobNecto.Application/Users/Mappers/UserMappers.cs`
+- `backend/src/JobNecto.Infrastructure/DI.cs`
+- `backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs`
+- `backend/src/JobNecto.Infrastructure/Persistance/Config/UserConfiguration.cs`
+- `backend/src/JobNecto.Infrastructure/Services/Pbkdf2PasswordHasher.cs`
+- `backend/src/JobNecto.Infrastructure/Migrations/20260422212528_IncreaseUserPasswordHashLength.cs`
+- `backend/src/JobNecto.Infrastructure/Migrations/20260422212528_IncreaseUserPasswordHashLength.Designer.cs`
+- `backend/src/JobNecto.Infrastructure/Migrations/AppDbContextModelSnapshot.cs`
+- `backend/src/JobNecto.API/Program.cs`
+- `backend/src/JobNecto.API/Infrastructure/OpenApiCollectionExtensions.cs`
+- `backend/src/JobNecto.API/Infrastructure/ExceptionHandling/GlobalExceptionHandler.cs`
+- `backend/src/JobNecto.API/Controllers/UsersController.cs`
+- `backend/src/JobNecto.API/Contracts/Auth/RefreshAccessTokenResult.cs`
+- `backend/tests/JobNecto.Tests/Application/Users/CreateUserCommandHandlerTests.cs`
+- `backend/tests/JobNecto.Tests/API/UsersControllerTests.cs`
+- `backend/tests/JobNecto.Tests/API/UsersControllerConcurrencyTests.cs`
+- `backend/tests/JobNecto.Tests/API/ExceptionHandlingTests.cs`
+- `backend/tests/JobNecto.Tests/Infrastructure/Security/Pbkdf2PasswordHasherTests.cs`
+- `backend/tests/JobNecto.Tests/Infrastructure/UserRepositorytests.cs`
+- `_bmad-output/agent-learnings.md`
+
+### Change Log
+
+- 2026-04-23: Completed Story 1.5 implementation across Application, Infrastructure, API, tests, and planning artifacts.
+- 2026-04-23: Completed post-review fixes for real DB concurrency coverage, backfill safety, parser strictness, and artifact text cleanup.
+- 2026-04-23: Removed runtime legacy-password backfill service/tests after confirming greenfield environment has no existing users.
+
+### Review Findings
+
+- [x] [Review]\[Patch\] Concurrency integration test is provider-simulated, not a real DB uniqueness race [backend/tests/JobNecto.Tests/API/UsersControllerConcurrencyTests.cs:92]
+- [x] [Review]\[Patch\] Backfill implementation removed for greenfield environment (no existing users), so runtime rehash behavior is no longer applicable.
+- [x] [Review]\[Patch\] Password hash format validation is too permissive and accepts undersized weak payloads [backend/src/JobNecto.Infrastructure/Services/Pbkdf2PasswordHasher.cs:95]
+- [x] [Review]\[Patch\] Story-related planning artifacts contain mojibake text in requirement ranges/symbols [\_bmad-output/planning-artifacts/epics/requirements-inventory.md:18]
+- [x] [Review]\[Patch\] `CreateUserCommand` comment contradicts implemented password-hardening scope [backend/src/JobNecto.Application/Users/CreateUserCommand.cs:22]

--- a/_bmad-output/implementation-artifacts/epic-1-retro-2026-04-22.md
+++ b/_bmad-output/implementation-artifacts/epic-1-retro-2026-04-22.md
@@ -1,0 +1,38 @@
+---
+epic: 1
+date: 2026-04-22
+author: Amelia (Developer)
+summary: Retrospective for Epic 1 — Foundation & User Profile Management (stories 1-1, 1-2)
+---
+
+# Epic 1 Retrospective — Foundation & User Profile Management
+
+Amelia (Developer): "Post-implementation retrospective for Epic 1. Reviewed stories 1-1 and 1-2 and related planning artifacts. Findings, action items, and next-epic recommendations below."
+
+## Scope
+
+- Reviewed implementation artifacts: [\_bmad-output/implementation-artifacts/1-1-global-exception-handling.md](_bmad-output/implementation-artifacts/1-1-global-exception-handling.md) and [\_bmad-output/implementation-artifacts/1-2-create-user-account.md](_bmad-output/implementation-artifacts/1-2-create-user-account.md)
+- Cross-checked planning epics: [\_bmad-output/planning-artifacts/epics/epic-1-foundation-user-profile-management.md](_bmad-output/planning-artifacts/epics/epic-1-foundation-user-profile-management.md), [\_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md](_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md), [\_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md](_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md), [\_bmad-output/planning-artifacts/epics/epic-4-vacancy-browsing-filtering.md](_bmad-output/planning-artifacts/epics/epic-4-vacancy-browsing-filtering.md), [\_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md](_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md)
+
+## Findings
+
+- **Password hashing**: Not implemented in Story 1.2 (explicitly deferred). No other epic documents password-hashing requirements or migration plan.
+- **Uniqueness / Conflict handling**: `409 Conflict` acceptance criteria appear across epics (users, templates, cover letters). Story 1.2 added DB-level uniqueness protection; other epics rely on correctness but do not all document DB-level enforcement or error mapping.
+- **Race conditions**: Edge-case (concurrent-create) tests mentioned only in Story 1.2 notes. No consistent cross-epic test strategy for concurrency/race conditions.
+- **Token strategy**: All protected endpoints require a valid JWT token; Story 1.2 specifies cookie-based JWT for browser registration. Other epics assume a valid JWT but do not standardize cookie vs header or refresh lifecycle for non-browser clients.
+- **Secrets & config**: Project-context contains dev Postgres settings (dev credentials). Epics do not document secret-management policies; repository contains at least dev settings referenced in docs.
+
+## Action Items (owners)
+
+- **Backend — Security (Senior Dev)**: Implement password hashing + migration plan; update create/login flows and tests.
+- **Backend — Core Dev**: Ensure DB-level unique constraints exist for all entities that require uniqueness; implement DB unique-violation → `409 Conflict` mapping in `GlobalExceptionHandler` and add integration tests that reproduce the race.
+- **QA**: Add E2E tests for cookie-based auth (registration → cookie set → authenticated request) and tests for non-browser token flows (API clients).
+- **DevOps / Security**: Audit repository for committed secrets (dev/test keys); move secrets to secure CI/test secrets and document secret policy in repo docs.
+- **Product**: Decide token delivery strategy for non-browser clients (bearer-in-header vs token-exchange) and add to API design for Epic 2 planning.
+
+## Next-Epic Recommendations
+
+- Prioritize password hashing + login/token lifecycle before shipping user-facing auth features in Epic 2.
+- Add a shared checklist for DB uniqueness and error mapping to include in all feature stories that imply uniqueness constraints.
+
+Amelia (Developer): "I can save this retrospective and mark the sprint status retro flag as done. Shall I proceed?"

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-04-19T00:00:00.000Z
+# last_updated: 2026-04-23T00:00:00.000Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -40,7 +40,8 @@ development_status:
   1-2-create-user-account: done
   1-3-retrieve-current-user-profile: backlog
   1-4-update-user-profile: backlog
-  epic-1-retrospective: optional
+  1-5-password-hashing-token-policy-hardening: review
+  epic-1-retrospective: done
 
   # --- Epic 2: Resume & Education Management ---
   epic-2: backlog

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -21,6 +21,7 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 ### Requirements Overview
 
 **Functional Requirements (Phase B):**
+
 - 6 primary domain resources: User (Profile), Resume, Education, CoverLetterTemplate, CoverLetter, Vacancy
 - CRUD operations on user-owned resources (User, Resume, Education, Template, Letter)
 - Read-only operations on shared resources (Vacancy browsing and filtering)
@@ -28,14 +29,16 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - Paginated list operations with configurable page size (default 20, max 100)
 
 **Non-Functional Requirements:**
+
 - API response SLA: <200ms for list endpoints, <100ms for detail endpoints, <500ms for complex filters
 - Soft delete strategy with EF Core global query filters (data persists in DB but excluded from queries)
-- Ownership model: Each user sees only their own data; architecture prepared for Phase C JWT integration
+- Ownership model: Each user sees only their own data with JWT-based session claims already in use; architecture remains extensible for Phase C role-based controls
 - Validation: FluentValidation pipeline before handlers reach business logic; field-level error responses
 - Test coverage requirement: ≥85% code coverage on Application handlers and validators
 - Async throughout: Full async/await chain with CancellationToken support on public APIs
 
 **Scale & Complexity:**
+
 - Complexity level: **Medium** (multi-domain entities, complex filtering logic, relationship complexity, soft deletes)
 - Primary technical domain: **REST API Backend** (job aggregation and profile management)
 - Estimated architectural components required: **7-8 major architectural decisions**
@@ -43,6 +46,7 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 ### Technical Constraints & Dependencies
 
 **Technology Stack (Locked):**
+
 - .NET 10 (`net10.0`), nullable reference types enforced
 - ASP.NET Core 10.0.3 with OpenAPI/Swashbuckle auto-documentation
 - MediatR 14.0.0 for CQRS command/query pattern
@@ -52,6 +56,7 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - Project uses `backend/JobNecto.slnx` (not root `.sln`)
 
 **Architecture Constraints:**
+
 - Clean Architecture enforced: API → Application → Domain ← Infrastructure
 - Domain layer must be persistence-ignorant (no EF Core references)
 - Application layer contains handlers, validators, repository interfaces
@@ -59,12 +64,14 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - No reference inversions or architectural boundary violations allowed
 
 **Build & Quality Gates:**
+
 - Must pass: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`
 - Must pass: `dotnet test backend/JobNecto.slnx --configuration Release --warnaserror`
 - No nullable reference type warnings without documented suppression reason
 - CI-parity enforcement: Release build + warnings-as-errors
 
 **Phase A Assumptions (Must Be Complete):**
+
 - UnitOfWork pattern implemented with `SaveChangesAsync()` and `DisposeAsync()`
 - All repository interfaces defined in Application layer
 - PostgreSQL connection available — see `appsettings.local.json` under `ConnectionStrings:Default` for the local connection string
@@ -72,7 +79,8 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - `AddInfrastructure()` DI registration wired in `Program.cs`
 
 **Out of Scope for Phase B:**
-- Authentication & JWT (Phase C)
+
+- Role-based authorization rules and advanced refresh-token orchestration (Phase C)
 - Job source synchronization and OAuth integrations (Phase D)
 - LLM analysis and cover letter generation endpoints (Phase D)
 - Rate limiting, Redis caching, Quartz scheduled jobs (Phase E)
@@ -80,14 +88,16 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 ### Cross-Cutting Concerns
 
 **1. Ownership & Authorization**
+
 - Every resource must enforce user ownership before write operations
 - **Resumes are user-scoped:** Each user sees only their own resumes (filtered at repository layer)
 - All list queries automatically filter by current user (via query handlers or repository layer)
-- Architecture must support Phase C JWT integration without refactoring core patterns
+- Architecture standardizes JWT session transport (HTTP-only secure cookie for browser clients; `Authorization: Bearer` for non-browser clients) and must support Phase C role-based extension without refactoring core patterns
 - Design pattern: ownership check delegated to handler, not API layer
-- **UserId source:** Generated during user registration (profile creation); Phase B uses JWT bearer token with `UserId` stored as a claim; extracted in controllers from `HttpContext.User`
+- **UserId source:** Generated during user registration (profile creation); Phase B uses JWT-based sessions with `UserId` stored as a claim and extracted in controllers from `HttpContext.User`
 
 **2. Soft Delete Consistency**
+
 - Entities marked for soft delete: Resume, Education, CoverLetter, CoverLetterTemplate, Vacancy
 - Strategy: EF Core global query filters on `DbContext.OnModelCreating` + PostgreSQL cascade rules
 - Soft-deleted records excluded from ALL queries unless explicitly requested
@@ -101,13 +111,16 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - **Grace Period (Future - Phase E):** TTL implemented in Phase E; soft-deleted records eligible for hard-delete after 1 month
 
 **3. Validation & Error Handling**
+
 - Two-layer validation strategy: FluentValidation (field-level) + handler-level (business rules)
 - FluentValidation validators fire before handler execution (MediatR pipeline)
 - Error response format: RFC 7808 Problem Details (application/problem+json)
 - HTTP status codes: 200, 201, 204 (success); 400, 404, 409, 422, 500 (errors)
 - Field-level errors: `{ "email": ["must be valid format"], "phone": ["already in use"] }`
+- Any business rule exposed as `409 Conflict` must be enforced by a database-level unique constraint, with DB unique-violation mapped through global exception handling and at least one concurrent-request integration test on race-prone endpoints.
 
 **4. Complex Filtering Architecture**
+
 - Vacancy filtering accepts POST body (not query params) to support multi-criteria queries
 - Filter object contains: skills[], location, salaryMin/Max, workLocationType[], etc.
 - AND logic between fields, OR logic within arrays (e.g., matches ANY skill)
@@ -115,12 +128,14 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - Design advantage: No URL length limits; type-safe filtering with request models
 
 **5. Async-First Pattern**
+
 - All I/O operations: async/await end-to-end
 - CancellationToken parameters on all public async handlers
 - EF Core async methods: `ToListAsync()`, `FirstOrDefaultAsync()`, `SaveChangesAsync()`
 - Database context should be disposed via `await using` in tests
 
 **6. Database Migrations & Relationships**
+
 - Migrations live in Infrastructure; tracked via EF Core schema history
 - Entity relationships: 1:N (User→Resume, User→Education, Resume→CoverLetter), M:N (Resume↔Education via join table)
 - **Cascade Rules (EF Core + PostgreSQL):**
@@ -131,6 +146,7 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - ResumeEducations join table: supports M:N linkage without direct references; cascade soft-deletes to join table entries
 
 **7. OpenAPI Documentation**
+
 - Swashbuckle auto-generates OpenAPI spec from attributes and models
 - Every endpoint must have clear request/response models for auto-documentation
 - Status codes documented in swagger attributes (200, 201, 400, 404, 422, etc.)
@@ -165,6 +181,7 @@ DbContext (EF Core)
 - All handlers are synchronous logic; async I/O happens via repository and DbContext (which are awaited by handler)
 
 **Request Class Naming:**
+
 ```csharp
 // Command: verb + noun + "Command"
 public class CreateUserCommand : IRequest<CreateUserResponse> { }
@@ -178,6 +195,7 @@ public class FilterVacanciesQuery : IRequest<PagedResult<VacancyDto>> { }
 ```
 
 **Handler Injection Pattern:**
+
 ```csharp
 public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, CreateUserResponse>
 {
@@ -255,6 +273,7 @@ public async Task<CreateUserResponse> Handle(CreateUserCommand request, Cancella
 ```
 
 **Error Response Format (from validation failures):**
+
 ```json
 {
   "type": "https://api.jobnecto.dev/errors/validation",
@@ -466,6 +485,7 @@ public class ExceptionHandlingMiddleware
 **Decision:** Full async/await chain with CancellationToken propagation.
 
 **Handler Signature:**
+
 ```csharp
 public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken)
 {
@@ -476,6 +496,7 @@ public async Task<TResponse> Handle(TRequest request, CancellationToken cancella
 ```
 
 **Repository Async Pattern:**
+
 ```csharp
 public async Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
 {
@@ -486,6 +507,7 @@ public async Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationTok
 ```
 
 **API Endpoint Signature:**
+
 ```csharp
 [HttpPost("users")]
 public async Task<ActionResult<CreateUserResponse>> Create(
@@ -499,6 +521,7 @@ public async Task<ActionResult<CreateUserResponse>> Create(
 ```
 
 **Test Pattern (using CancellationToken):**
+
 ```csharp
 [Fact]
 public async Task Handle_ValidRequest_CreatesUser()
@@ -520,6 +543,7 @@ public async Task Handle_ValidRequest_CreatesUser()
 **Decision:** EF Core global query filters to exclude soft-deleted records from all queries; PostgreSQL cascade rules enforce referential integrity; logging on hard-deletes for audit.
 
 **Entity Pattern (Domain Layer):**
+
 ```csharp
 public abstract class SoftDeletableEntity : BaseEntity
 {
@@ -538,6 +562,7 @@ public class Resume : SoftDeletableEntity
 ```
 
 **DbContext Configuration (Infrastructure Layer):**
+
 ```csharp
 public class AppDbContext : DbContext
 {
@@ -580,6 +605,7 @@ public class AppDbContext : DbContext
 ```
 
 **Soft Delete Handler Pattern:**
+
 ```csharp
 public async Task<Unit> Handle(DeleteResumeCommand request, CancellationToken cancellationToken)
 {
@@ -610,6 +636,7 @@ public async Task<Unit> Handle(DeleteResumeCommand request, CancellationToken ca
 ```
 
 **Hard Delete Handler Pattern (When User Permanently Deletes Account - Phase C/D):**
+
 ```csharp
 public async Task<Unit> Handle(HardDeleteUserCommand request, CancellationToken cancellationToken)
 {
@@ -633,6 +660,7 @@ public async Task<Unit> Handle(HardDeleteUserCommand request, CancellationToken 
 ```
 
 **Cascade Rules Summary:**
+
 | Delete Type | Entity | Behavior | Cascades |
 |-------------|--------|----------|----------|
 | Soft Delete | Resume | Mark IsDeleted=true, set DeletedAt | CoverLetters soft-delete |
@@ -642,11 +670,13 @@ public async Task<Unit> Handle(HardDeleteUserCommand request, CancellationToken 
 | Hard Delete | User | Remove from DB (DELETE) | Resumes hard-delete (PostgreSQL FK); cascades to CoverLetters |
 
 **Logging Strategy:**
+
 - **Soft deletes** (user-initiated): Minimal logging (data recoverable within 1-month grace)
 - **Hard deletes** (system/admin): Full audit log with timestamp, user ID, affected records count
 - **Log location:** Application logs + database audit trail (if compliance required)
 
 **Key Benefits:**
+
 - Soft-deleted records automatically excluded from ALL queries (no accidental exposure)
 - Single source of truth for deletion logic via query filters
 - PostgreSQL foreign key cascades enforce data integrity (no orphaned records after hard-delete)
@@ -660,6 +690,7 @@ public async Task<Unit> Handle(HardDeleteUserCommand request, CancellationToken 
 **Decision:** Handlers verify ownership before mutations; repository layer enforces user-scoped queries.
 
 **Pattern: Ownership Check in Handler**
+
 ```csharp
 public async Task<Unit> Handle(UpdateResumeCommand request, CancellationToken ct)
 {
@@ -681,6 +712,7 @@ public async Task<Unit> Handle(UpdateResumeCommand request, CancellationToken ct
 ```
 
 **Pattern: User-Scoped Queries in Handlers**
+
 ```csharp
 // Query for lists always includes UserId filter
 public async Task<PagedResult<ResumeDto>> Handle(ListResumesQuery request, CancellationToken ct)
@@ -698,7 +730,7 @@ public async Task<PagedResult<ResumeDto>> Handle(ListResumesQuery request, Cance
 
 **Pattern: How UserId Gets Into Query**
 
-UserId is extracted from the JWT bearer token claim in both Phase B and onwards:
+UserId is extracted from authenticated JWT claims in both Phase B and onwards:
 
 ```csharp
 public async Task<ActionResult<PagedResult<ResumeDto>>> ListResumes(
@@ -726,10 +758,15 @@ private Guid GetCurrentUserId()
 ```
 
 **JWT in Phase B:**
-- JWT bearer token issued on login; `UserId` stored as `sub` or `userId` claim
+
+- Browser clients receive JWT sessions via HTTP-only secure cookie; non-browser clients use `Authorization: Bearer`
+- `UserId` is stored as `sub` or `userId` claim and extracted uniformly in controllers/handlers
 - Every mutation handler already verifies ownership
 - Every query handler already receives `UserId` as a parameter from the controller
-- Phase C (if applicable) can extend claims or rotate tokens without changing handler logic
+- Token renewal contract is `POST /api/v1/users/token/refresh` for currently authenticated sessions; browser clients receive renewed HTTP-only cookie and non-browser clients receive bearer token payload
+- If refresh is rejected due to expired/invalid credentials, client must re-authenticate
+- OpenAPI exposes both `CookieAuth` and `BearerAuth` security schemes with this lifecycle guidance
+- Phase C (if applicable) can extend claims and role-based controls without changing handler logic
 
 ---
 
@@ -751,6 +788,7 @@ private Guid GetCurrentUserId()
 ## Implementation Checklist for Phase B
 
 **Database & Entities:**
+
 - [ ] Add `IsDeleted` and `DeletedAt` timestamps to: Resume, Education, CoverLetterTemplate, CoverLetter, Vacancy
 - [ ] Add `[Timestamp]` RowVersion to all entities for optimistic locking
 - [ ] Configure global query filters for soft-delete entities
@@ -758,12 +796,14 @@ private Guid GetCurrentUserId()
 - [ ] Create migration with all schema changes
 
 **Handlers & Repositories:**
+
 - [ ] Implement user-scoped repository methods (GetByUserIdAsync, ListByUserIdAsync, etc.)
 - [ ] Soft-delete handlers: Set IsDeleted=true, propagate cascade soft-deletes to children
-- [ ] All mutation handlers: Verify ownership before allowing changes (409 Conflict if forbidden)
+- [ ] All mutation handlers: Verify ownership before allowing changes (`403 Forbidden` when ownership is violated)
 - [ ] All query handlers: Filter by UserId in request (user sees only their own data)
 
 **Testing:**
+
 - [ ] Soft-delete audit fixtures: Verify deleted data excluded from queries but exists in DB
 - [ ] Ownership violation suite: Run against all mutation handlers
 - [ ] Cascade soft-delete tests: Resume soft-delete→CoverLetter soft-delete
@@ -771,13 +811,14 @@ private Guid GetCurrentUserId()
 - [ ] CancellationToken timeout tests: At least one per resource
 
 **Logging & Audit:**
+
 - [ ] Log all hard-delete operations with timestamp, user ID, affected records
 - [ ] Application logs or database audit table (depending on compliance needs)
 
 **Phase C Readiness:**
-- [ ] UserId extraction from request (Phase B) → JWT token (Phase C) is straightforward
+
+- [ ] JWT claim extraction and transport policy in Phase B can be extended to role-based controls in Phase C without handler refactoring
 - [ ] Handlers already receive UserId as parameter; no refactoring needed
 - [ ] Ownership checks are centralized per handler; easy to audit for Phase C
 
 These decisions are codified to ensure **consistency across all Phase B endpoints** and to make your developers' jobs straightforward: follow the patterns, and the architecture handles the rest.
-

--- a/_bmad-output/planning-artifacts/epics/epic-1-foundation-user-profile-management.md
+++ b/_bmad-output/planning-artifacts/epics/epic-1-foundation-user-profile-management.md
@@ -2,6 +2,12 @@
 
 Users can register an account and fully manage their professional profile. Establishes JWT authentication, ownership enforcement infrastructure, and global error handling used by all subsequent epics.
 
+## Readiness Updates After Stories 1.1-1.2
+
+- Password storage is not production-ready until registration and login flows persist one-way hashes and a migration/backfill plan exists for any plaintext legacy records.
+- Shared auth policy: browser registration/login flows issue JWTs via HTTP-only cookies; any non-browser client support in later epics must explicitly document `Authorization: Bearer` transport and token renewal behavior.
+- `loginName` and `email` uniqueness must be enforced at the database layer and mapped to `409 Conflict` through global exception handling, with concurrent create/update integration tests covering race conditions.
+
 ### Story 1.1: JWT Authentication & Global Exception Handling Infrastructure
 
 As a **developer**,
@@ -11,20 +17,20 @@ So that all endpoints are secured by token, UserId is extracted from claims for 
 **Acceptance Criteria:**
 
 **Given** the app starts
-**When** `JwtBearerAuthentication` and `ExceptionHandlingMiddleware` are registered in `Program.cs`
-**Then** all subsequent requests require a valid JWT bearer token to access protected endpoints
+**When** JWT authentication and `ExceptionHandlingMiddleware` are registered in `Program.cs`
+**Then** protected endpoints require a valid authenticated JWT session using the standardized transport for the client type
 
-**Given** a valid JWT token containing a `sub` or `userId` claim
+**Given** a valid JWT containing a `sub` or `userId` claim
 **When** any controller calls `GetCurrentUserId()`
 **Then** the correct `Guid` is returned from the claim
 
-**Given** a request arrives with no token or an invalid/expired token
+**Given** a request arrives with no valid authenticated JWT session or an invalid/expired token
 **When** a protected endpoint is hit
 **Then** `401 Unauthorized` is returned with a Problem Details body
 
 **Given** a `ValidationException` is thrown anywhere in the pipeline
 **When** it reaches the middleware
-**Then** `400 Bad Request` is returned with `application/problem+json` and an `errors` map of field → [messages]
+**Then** `400 Bad Request` is returned with `application/problem+json` and an `errors` map of field -> [messages]
 
 **Given** a `NotFoundException` is thrown
 **When** it reaches the middleware
@@ -136,3 +142,32 @@ So that I can keep my professional identity and contact info current.
 
 ---
 
+### Story 1.5: Password Hashing & Token Policy Hardening
+
+As a **platform owner**,
+I want password persistence and token transport behavior standardized,
+So that all authenticated features in later epics build on a secure and explicit auth foundation.
+
+**Acceptance Criteria:**
+
+**Given** a user registers or updates credentials through the supported auth flow
+**When** user credentials are persisted
+**Then** passwords are stored only as one-way salted hashes and are never stored or returned in plaintext
+
+**Given** legacy user rows may contain non-hashed password values from early implementation
+**When** the password-hardening migration plan is executed
+**Then** legacy values are remediated through an approved migration/backfill path before Epic 2 delivery begins
+
+**Given** browser-based clients authenticate in Phase B
+**When** registration/login succeeds
+**Then** JWT session tokens are delivered via HTTP-only secure cookies with explicit SameSite and Secure behavior per environment
+
+**Given** non-browser clients authenticate in Phase B
+**When** they call protected endpoints
+**Then** `Authorization: Bearer` token transport and renewal behavior are explicit: active sessions renew via `POST /api/v1/users/token/refresh`, and expired/invalid sessions re-authenticate
+
+**Given** a race condition causes a DB-level uniqueness violation during auth-related create/update operations
+**When** the exception reaches global handling
+**Then** the API returns `409 Conflict` with a stable problem-details contract and integration coverage proves the concurrent path
+
+---

--- a/_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md
+++ b/_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md
@@ -1,6 +1,11 @@
 # Epic 2: Resume & Education Management
 
-Users can build and maintain their professional credentials — resumes with skills and work preferences, plus education records. All data is user-scoped and isolated.
+Users can build and maintain their professional credentials - resumes with skills and work preferences, plus education records. All data is user-scoped and isolated.
+
+## Readiness Dependencies From Epic 1
+
+- Do not start Epic 2 delivery until Epic 1 password hashing and any required migration/backfill scope are planned; otherwise authenticated user data will be built on a security gap we already know about.
+- Protected endpoints in this epic follow the shared JWT session policy from Epic 1 instead of assuming bearer-only transport.
 
 ### Story 2.1: Create Resume
 
@@ -42,7 +47,7 @@ So that I can quickly navigate to the one I need.
 
 **Given** a valid JWT token
 **When** `GET /api/v1/resumes` is called with no query params
-**Then** `200 OK` with `{ total, page, pageSize, items }` — only this user's non-deleted resumes, ordered by `updatedAt desc`, `pageSize` defaulting to 20
+**Then** `200 OK` with `{ total, page, pageSize, items }` - only this user's non-deleted resumes, ordered by `updatedAt desc`, `pageSize` defaulting to 20
 
 **Given** `page` and `pageSize` query params are provided
 **When** the request is processed
@@ -215,4 +220,3 @@ So that I can keep my academic history accurate.
 **Then** `204 No Content`; soft-delete applied; record no longer visible in list
 
 ---
-

--- a/_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md
+++ b/_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md
@@ -2,6 +2,12 @@
 
 Users can build a reusable library of cover letter templates (up to 10,000 characters) they can search, manage, and apply across job applications.
 
+## Readiness Constraints From Epic 1 Retrospective
+
+- Template-name uniqueness is a per-user rule that must be enforced by a database constraint across non-deleted templates, with unique-violation mapping to `409 Conflict`.
+- Concurrent create/update integration tests are required for template-name collisions because pre-checks alone are insufficient under load.
+- Protected endpoints in this epic follow the shared JWT session policy from Epic 1 instead of assuming bearer-only transport.
+
 ### Story 3.1: Create Cover Letter Template
 
 As a **job seeker**,
@@ -10,7 +16,7 @@ So that I can quickly apply it to future job applications.
 
 **Acceptance Criteria:**
 
-**Given** a valid JWT token and `POST /api/v1/cover-letter-templates` with `name` and `content` (50–10000 chars)
+**Given** a valid JWT token and `POST /api/v1/cover-letter-templates` with `name` and `content` (50-10000 chars)
 **When** the request is processed
 **Then** `201 Created` with the full template object; `Location` header set to `/api/v1/cover-letter-templates/{id}`
 
@@ -24,11 +30,11 @@ So that I can quickly apply it to future job applications.
 
 **Given** `name` already exists for this user (across non-deleted templates)
 **When** the request is processed
-**Then** `409 Conflict`
+**Then** `409 Conflict` from database-backed per-user uniqueness enforcement
 
 **Given** the same `name` was used by another user
 **When** the request is processed
-**Then** `201 Created` — uniqueness is per-user, not global
+**Then** `201 Created` - uniqueness is per-user, not global
 
 ---
 
@@ -42,7 +48,7 @@ So that I can find the right template for a job application.
 
 **Given** a valid JWT token
 **When** `GET /api/v1/cover-letter-templates` is called with no query params
-**Then** `200 OK` with `{ total, page, pageSize, items }` — non-deleted templates owned by this user, ordered by `updatedAt desc`
+**Then** `200 OK` with `{ total, page, pageSize, items }` - non-deleted templates owned by this user, ordered by `updatedAt desc`
 **And** each item includes `id`, `name`, `createdAt`, `updatedAt`, and `contentPreview` (first 200 chars of `content`)
 
 **Given** `search` query param is provided (e.g., `?search=senior`)
@@ -86,12 +92,12 @@ So that I can refine my reusable material over time.
 
 **Given** the new `name` is already taken by another non-deleted template of this user
 **When** the request is processed
-**Then** `409 Conflict`
+**Then** `409 Conflict` from database-backed per-user uniqueness enforcement
 
 **Given** the template belongs to another user
 **Then** `403 Forbidden`
 
-**Given** updated `content` violates 50–10000 char bounds
+**Given** updated `content` violates 50-10000 char bounds
 **Then** `400 Bad Request` with field-level error on `content`
 
 ---
@@ -116,4 +122,3 @@ So that my library stays tidy.
 **Then** the cover letter is NOT deleted; `templateId` reference remains for historical context
 
 ---
-

--- a/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
+++ b/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
@@ -2,6 +2,12 @@
 
 Users can write job-specific cover letters tied to a vacancy, optionally seeded from a template, with one letter permitted per vacancy per user.
 
+## Readiness Constraints From Epic 1 Retrospective
+
+- The "one cover letter per vacancy per user" rule must be enforced by a database constraint on active records and mapped to `409 Conflict` through the shared exception pipeline.
+- Concurrent create integration coverage is required for duplicate vacancy submissions because request-level checks alone do not close the race.
+- Protected endpoints in this epic follow the shared JWT session policy from Epic 1 instead of assuming bearer-only transport.
+
 ### Story 5.1: Create Cover Letter
 
 As a **job seeker**,
@@ -20,7 +26,7 @@ So that I can submit a tailored application.
 
 **Given** the user already has a (non-deleted) cover letter for the same `vacancyId`
 **When** `POST /api/v1/cover-letters` is called again with the same `vacancyId`
-**Then** `409 Conflict`
+**Then** `409 Conflict` from database-backed per-user/per-vacancy uniqueness enforcement
 
 **Given** `vacancyId` references a vacancy that does not exist
 **When** the request is processed

--- a/_bmad-output/planning-artifacts/epics/overview.md
+++ b/_bmad-output/planning-artifacts/epics/overview.md
@@ -1,4 +1,10 @@
 # Overview
 
 This document provides the complete epic and story breakdown for Jobnecto Phase B, decomposing the requirements from the PRD and Architecture decisions into implementable stories.
-
+
+## Readiness Adjustments After Epic 1 Retrospective
+
+- Shared auth policy: browser authentication flows issue JWTs via HTTP-only cookies; any non-browser client flow must explicitly document `Authorization: Bearer` transport and token renewal behavior before implementation.
+- Password handling: passwords are never stored in plaintext; hashing and any required migration/backfill work must be planned before later epics depend on authenticated production-grade user accounts.
+- Uniqueness and concurrency: any business rule that returns `409 Conflict` must be enforced by a database constraint and mapped through global exception handling, with concurrent create/update integration coverage where races are plausible.
+- Secrets policy: planning artifacts may reference configuration keys and local config files, but must not embed live credentials or secrets.

--- a/_bmad-output/planning-artifacts/epics/requirements-inventory.md
+++ b/_bmad-output/planning-artifacts/epics/requirements-inventory.md
@@ -15,12 +15,12 @@ FR10: User can list their own education records (non-paginated, ordered by `grad
 FR11: User can retrieve a single education record via `GET /api/v1/educations/{id}`; returns `404` if not found.
 FR12: User can update any education field via `PUT /api/v1/educations/{id}`; returns `200 OK`; `404` if not found.
 FR13: User can soft-delete an education record via `DELETE /api/v1/educations/{id}`; returns `204 No Content`.
-FR14: User can create a cover letter template with `name` (unique per user) and `content` (50–10000 chars) via `POST /api/v1/cover-letter-templates`; returns `201 Created`.
+FR14: User can create a cover letter template with `name` (unique per user) and `content` (50-10000 chars) via `POST /api/v1/cover-letter-templates`; returns `201 Created`.
 FR15: User can list their cover letter templates (paginated, searchable by `name`, ordered by `updatedAt desc`) via `GET /api/v1/cover-letter-templates`; returns `200 OK` with content preview (first 200 chars).
 FR16: User can retrieve a single cover letter template with full `content` via `GET /api/v1/cover-letter-templates/{id}`; returns `404` if not found.
 FR17: User can update a cover letter template's `name` or `content` via `PUT /api/v1/cover-letter-templates/{id}`; name uniqueness re-validated if changed; returns `200 OK`.
 FR18: User can soft-delete a cover letter template via `DELETE /api/v1/cover-letter-templates/{id}`; returns `204 No Content`.
-FR19: User can create a job-specific cover letter with `vacancyId` (required, must exist), `content` (50–10000 chars), and optional `templateId` via `POST /api/v1/cover-letters`; one letter per vacancy per user; returns `201 Created`.
+FR19: User can create a job-specific cover letter with `vacancyId` (required, must exist), `content` (50-10000 chars), and optional `templateId` via `POST /api/v1/cover-letters`; one letter per vacancy per user; returns `201 Created`.
 FR20: User can list their cover letters (paginated, ordered by `createdAt desc`) via `GET /api/v1/cover-letters`; includes `vacancyTitle` from linked vacancy; returns `200 OK`.
 FR21: User can retrieve a single cover letter with full `content`, `vacancyId`, `templateId`, and linked vacancy details via `GET /api/v1/cover-letters/{id}`; returns `404` if not found.
 FR22: User can update cover letter `content` (cannot change `vacancyId` after creation) via `PUT /api/v1/cover-letters/{id}`; returns `200 OK`.
@@ -35,7 +35,7 @@ FR28: All mutation handlers must verify resource ownership before allowing chang
 
 NFR1: API response SLA: list endpoints < 200ms, detail endpoints < 100ms, `POST /api/v1/vacancies/filter` < 500ms (for typical dataset).
 NFR2: All input must be validated via FluentValidation pipeline before handlers execute; field-level error messages returned in RFC 7808 Problem Details format.
-NFR3: ≥ 85% code coverage on Application layer handlers and validators (measured by xUnit + FluentAssertions).
+NFR3: >= 85% code coverage on Application layer handlers and validators (measured by xUnit + FluentAssertions).
 NFR4: Full async/await chain with `CancellationToken` propagation on all public async methods (handlers, repositories, EF calls).
 NFR5: Soft-deleted records excluded from ALL queries via EF Core global query filters on `DbContext.OnModelCreating`; never accidentally exposed.
 NFR6: Build must pass: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` with zero warnings.
@@ -44,20 +44,23 @@ NFR8: No nullable reference type warnings suppressed without documented justific
 NFR9: OpenAPI spec auto-generated for all Phase B endpoints with request/response schemas, status codes (200, 201, 204, 400, 404, 409, 422, 500), and example bodies.
 NFR10: Pagination: `pageSize` min 1, max 100, default 20; request body max 1MB.
 NFR11: Zero breaking changes to Domain model entities after Phase B is complete.
+NFR12: Passwords must be stored only as one-way salted hashes; plaintext passwords are never persisted or returned, and any migration/backfill required to reach that state is part of auth readiness.
+NFR13: Any business rule surfaced as `409 Conflict` must be backed by a database-level uniqueness constraint and at least one integration test that exercises concurrent create/update attempts.
 
 ### Additional Requirements (from Architecture)
 
 - **MediatR CQRS**: All operations route through MediatR `IRequest`/`IRequestHandler`; Commands for writes, Queries for reads; no direct service calls in API layer.
-- **Two-layer validation**: FluentValidation fires in MediatR pipeline (field format/length) → handler performs DB-dependent checks (uniqueness, FK existence, ownership).
+- **Two-layer validation**: FluentValidation fires in MediatR pipeline (field format/length) -> handler performs DB-dependent checks (uniqueness, FK existence, ownership).
 - **Repository + UnitOfWork pattern**: All `IXxxRepository` interfaces in `JobNecto.Application`; implementations in `JobNecto.Infrastructure`; `IUnitOfWork` aggregates all repos and exposes `SaveChangesAsync()`.
 - **Exception handling middleware**: `ExceptionHandlingMiddleware` maps domain exceptions (`UserNotFoundException`, `DuplicateEmailException`, etc.) to RFC 7808 Problem Details responses; no raw stack traces exposed.
 - **Soft-delete entities**: `Resume`, `Education`, `CoverLetterTemplate`, `CoverLetter`, `Vacancy` extend `SoftDeletableEntity` with `IsDeleted` (bool) + `DeletedAt` (DateTime?).
-- **EF Core cascade rules**: User→Resume `ON DELETE CASCADE` (hard); Resume→CoverLetter `ON DELETE CASCADE` (hard); soft-delete cascades (Resume→CoverLetters) handled in handlers.
-- **UserId injection pattern**: Phase B uses JWT bearer token; `UserId` is stored as a claim in the token and extracted via `GetCurrentUserId()` helper in controllers from `HttpContext.User`. Handlers receive `UserId` as a parameter — no handler changes needed if token structure evolves.
+- **EF Core cascade rules**: User->Resume `ON DELETE CASCADE` (hard); Resume->CoverLetter `ON DELETE CASCADE` (hard); soft-delete cascades (Resume->CoverLetters) handled in handlers.
+- **UserId injection pattern**: Phase B uses JWT-based authentication; browser flows issue an HTTP-only auth cookie, and any non-browser client flow must explicitly document `Authorization: Bearer` transport plus token renewal behavior. `UserId` is stored as a claim in the token and extracted via `GetCurrentUserId()` helper in controllers from `HttpContext.User`. Handlers receive `UserId` as a parameter - no handler changes needed if token structure evolves.
 - **Clean Architecture boundaries**: Domain layer is persistence-ignorant (no EF references); Application layer has no EF direct calls; Infrastructure implements all persistence concerns.
 - **Migrations**: All EF Core migrations in `JobNecto.Infrastructure`; `AddInfrastructure()` DI extension called in `Program.cs`.
 - **OpenAPI**: All controllers use Swashbuckle attributes; spec accessible at `/openapi/v1.json`.
 - **Audit logging**: All hard-delete operations logged with timestamp, `userId`, and affected record summary.
+- **Secrets management**: Planning artifacts and repository docs may reference configuration keys or local config files, but must not embed live credentials or secrets.
 
 ### UX Design Requirements
 
@@ -93,4 +96,3 @@ FR25: Epic 4 - Filter vacancies
 FR26: Epic 4 - Get vacancy detail
 FR27: Epic 2 - User-scoped data isolation
 FR28: Epic 1 - Ownership enforcement infrastructure
-

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -257,16 +257,17 @@ A job seeker can:
 - User can register with `loginName`, `email`, `password`, and optional profile fields (`phone`, `location`, `about`, `avatar`)
 - Email validation: must be valid email format; must be unique across the system
 - Phone validation (if provided): must be valid E.164 format (e.g., `+1234567890`)
-- Password: minimum 8 characters (actual strength rules TBD in Phase C when hashing is implemented)
+- Password: minimum 8 characters; persisted values must be one-way salted hashes (never plaintext)
 - `loginName`: must be unique, alphanumeric + underscore, 3-20 characters
 - On success: return `201 Created` with user object (exclude password); set JWT token as HTTP-Only secure cookie (SameSite=Strict)
+- Non-browser clients use `Authorization: Bearer` for protected APIs and renew active sessions through `POST /api/v1/users/token/refresh`; expired/invalid sessions must re-authenticate.
 - On validation error: return `400 Bad Request` with field-level error messages
 - On duplicate email/loginName: return `409 Conflict` with message
 
 **Validation Rules:**
 - `email`: Required, valid format, unique
 - `loginName`: Required, 3-20 chars, alphanumeric + underscore, unique
-- `password`: Required, minimum 8 characters (Phase C: add strength rules)
+- `password`: Required, minimum 8 characters; persisted values must be one-way salted hashes
 - `phone`: Optional, E.164 format if provided
 - `avatar`: Optional, URL or base64 data
 
@@ -714,7 +715,7 @@ User (1)
 
 ## Ownership & Authorization Model
 
-**Principle:** Every resource has a clear owner. Phase B includes JWT bearer token authentication; `UserId` is extracted from the token claim and used for all ownership checks.
+**Principle:** Every resource has a clear owner. Phase B uses JWT-based sessions; browser flows use HTTP-only secure cookies and non-browser clients use `Authorization: Bearer`. `UserId` is extracted from token claims and used for all ownership checks. Token renewal contract: authenticated clients call `POST /api/v1/users/token/refresh`; if refresh is rejected due to expired/invalid credentials, the client re-authenticates.
 
 **Ownership Rules:**
 
@@ -732,12 +733,12 @@ User (1)
 - **Query Filtering:** All list endpoints MUST filter by `userId` automatically
   - Example: `GET /api/v1/resumes` returns only resumes where `Resume.UserId == CurrentUserId`
   - This must be enforced at the repository or query handler level, not just API level
-  - In Phase B, `UserId` is extracted from the JWT bearer token claim (`sub` or `userId`)
+  - In Phase B, `UserId` is extracted from authenticated JWT claims (`sub` or `userId`) regardless of whether transport is cookie or bearer
 
 - **Validation:** Write operations MUST verify ownership before allowing mutation
   - Example: `PUT /api/v1/resumes/{id}` verifies the resume's `UserId` matches the current user
 
-- **Authorization Layer:** Phase B uses JWT bearer tokens; `UserId` claim drives all ownership checks; Phase C adds role-based authorization and token refresh
+- **Authorization Layer:** Phase B uses JWT-based sessions with explicit transport policy (cookie for browser, bearer for non-browser); `UserId` claim drives all ownership checks; Phase C adds role-based authorization and extended token lifecycle controls.
 
 ---
 
@@ -816,9 +817,10 @@ Phase B development assumes Phase A is **complete**:
 
 - **No external job sources yet** — Vacancies are assumed to exist in the database (manually seeded or Phase D will sync them)
 - **No LLM integration** — LLM endpoints NOT included in Phase B; Phase D adds `/analyze` and cover letter generation
-- **Authentication** — Phase B includes JWT bearer token authentication; `UserId` stored as a claim; Phase C adds role-based authorization and token refresh
+- **Authentication** — Phase B includes JWT-based sessions; browser flows issue HTTP-only secure cookies and non-browser clients use `Authorization: Bearer`; `UserId` is stored as a claim and extracted uniformly. Phase B renewal contract is `POST /api/v1/users/token/refresh` for active sessions; expired sessions re-authenticate. Phase C adds role-based authorization and extended refresh controls.
 - **No third-party OAuth** — Phase B cannot connect to HeadHunter/LinkedIn; Phase D adds OAuth
 - **PostgreSQL connection string** — Assumed available; see `appsettings.local.json` under `ConnectionStrings:Default` for the local connection string
+- **Secrets handling** — Planning artifacts may reference configuration keys and local config file paths, but must not embed live credentials or secrets
 
 ---
 
@@ -833,6 +835,8 @@ Phase B development assumes Phase A is **complete**:
 | Resume | `title` | Per user | Same user cannot have 2 resumes with same title |
 | CoverLetterTemplate | `name` | Per user | Same user cannot have 2 templates with same name |
 | CoverLetter | `(vacancyId, userId)` | Per vacancy per user | Only one cover letter allowed per vacancy per user |
+
+All uniqueness rules above must be enforced by database-level unique constraints and mapped to `409 Conflict` at the API boundary. For race-prone create/update paths, add at least one integration test that exercises concurrent requests.
 
 **Referential Integrity:**
 

--- a/backend/src/JobNecto.API/Contracts/Auth/RefreshAccessTokenResult.cs
+++ b/backend/src/JobNecto.API/Contracts/Auth/RefreshAccessTokenResult.cs
@@ -1,0 +1,24 @@
+namespace JobNecto.API.Contracts.Auth;
+
+/// <summary>
+/// Response contract for issuing a renewed access token.
+/// </summary>
+public sealed class RefreshAccessTokenResult
+{
+    /// <summary>
+    /// Newly issued JWT access token for non-browser bearer transport.
+    /// </summary>
+    public string AccessToken { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Token type for the access token field.
+    /// </summary>
+    public string TokenType { get; init; } = "Bearer";
+
+    /// <summary>
+    /// Renewal policy for API clients.
+    /// </summary>
+    public string RenewalPolicy { get; init; } =
+        "Call POST /api/v1/users/token/refresh while currently authenticated. " +
+        "If refresh fails due to expired or invalid credentials, re-authenticate.";
+}

--- a/backend/src/JobNecto.API/Contracts/Auth/RefreshAccessTokenResult.cs
+++ b/backend/src/JobNecto.API/Contracts/Auth/RefreshAccessTokenResult.cs
@@ -7,6 +7,7 @@ public sealed class RefreshAccessTokenResult
 {
     /// <summary>
     /// Newly issued JWT access token for non-browser bearer transport.
+    /// Empty for browser cookie transport.
     /// </summary>
     public string AccessToken { get; init; } = string.Empty;
 

--- a/backend/src/JobNecto.API/Controllers/UsersController.cs
+++ b/backend/src/JobNecto.API/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 using JobNecto.Application.Users;
 using JobNecto.Application.Interfaces;
+using JobNecto.API.Contracts.Auth;
 using JobNecto.API.Infrastructure;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -51,5 +52,33 @@ public class UsersController : ControllerBase
 
         // Return created response with Location header
         return Created("/api/v1/users/me", result);
+    }
+
+    /// <summary>
+    /// Issues a renewed JWT for authenticated clients.
+    /// Browser clients continue to receive the token via HTTP-only cookie; non-browser clients
+    /// can consume the returned token body and send it in <c>Authorization: Bearer</c>.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Renewed access token contract.</returns>
+    [HttpPost("token/refresh")]
+    [Authorize]
+    [ProducesResponseType(typeof(RefreshAccessTokenResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<RefreshAccessTokenResult>> RefreshToken(CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Unauthorized();
+        }
+
+        var token = await _jwtService.GenerateTokenAsync(userId);
+        _cookieAuthService.SetAuthCookie(Response, token);
+
+        return Ok(new RefreshAccessTokenResult
+        {
+            AccessToken = token
+        });
     }
 }

--- a/backend/src/JobNecto.API/Controllers/UsersController.cs
+++ b/backend/src/JobNecto.API/Controllers/UsersController.cs
@@ -58,6 +58,7 @@ public class UsersController : ControllerBase
     /// Issues a renewed JWT for authenticated clients.
     /// Browser clients continue to receive the token via HTTP-only cookie; non-browser clients
     /// can consume the returned token body and send it in <c>Authorization: Bearer</c>.
+    /// The response body token is returned only when the request used bearer transport.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Renewed access token contract.</returns>
@@ -78,7 +79,17 @@ public class UsersController : ControllerBase
 
         return Ok(new RefreshAccessTokenResult
         {
-            AccessToken = token
+            AccessToken = UsesBearerTransport(Request) ? token : string.Empty
         });
+    }
+
+    private static bool UsesBearerTransport(HttpRequest request)
+    {
+        if (!request.Headers.TryGetValue("Authorization", out var authorizationHeader))
+        {
+            return false;
+        }
+
+        return authorizationHeader.ToString().StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/backend/src/JobNecto.API/Infrastructure/ExceptionHandling/GlobalExceptionHandler.cs
+++ b/backend/src/JobNecto.API/Infrastructure/ExceptionHandling/GlobalExceptionHandler.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
 using FluentValidation;
 using JobNecto.Application.Exceptions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
+using Npgsql;
 
 namespace JobNecto.API.Infrastructure.ExceptionHandling;
 
@@ -83,6 +85,12 @@ public class GlobalExceptionHandler : IExceptionHandler
                 problemDetails.Detail = conflictException.Message;
                 break;
 
+            case DbUpdateException dbUpdateException when IsUniqueConstraintViolation(dbUpdateException):
+                problemDetails.Status = StatusCodes.Status409Conflict;
+                problemDetails.Title = "Conflict";
+                problemDetails.Detail = "A unique constraint was violated.";
+                break;
+
             default:
                 problemDetails.Status = StatusCodes.Status500InternalServerError;
                 problemDetails.Title = "Internal Server Error";
@@ -106,5 +114,18 @@ public class GlobalExceptionHandler : IExceptionHandler
             contentType: "application/problem+json", 
             cancellationToken);
         return true;
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException exception)
+    {
+        if (exception.InnerException is PostgresException postgresException)
+        {
+            return postgresException.SqlState == PostgresErrorCodes.UniqueViolation;
+        }
+
+        var message = exception.InnerException?.Message ?? exception.Message;
+        return message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase)
+               || message.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+               || message.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/backend/src/JobNecto.API/Infrastructure/OpenApiCollectionExtensions.cs
+++ b/backend/src/JobNecto.API/Infrastructure/OpenApiCollectionExtensions.cs
@@ -1,0 +1,50 @@
+using Microsoft.OpenApi;
+
+namespace JobNecto.API.Infrastructure;
+
+/// <summary>
+/// OpenAPI configuration extensions for documenting authentication transport policy.
+/// </summary>
+public static class OpenApiCollectionExtensions
+{
+    /// <summary>
+    /// Registers OpenAPI document generation and adds explicit security scheme
+    /// documentation for cookie and bearer authentication transports.
+    /// </summary>
+    public static IServiceCollection AddApiOpenApi(this IServiceCollection services)
+    {
+        services.AddOpenApi("v1", options =>
+        {
+            options.AddDocumentTransformer((document, _, _) =>
+            {
+                document.Components ??= new OpenApiComponents();
+                document.Components.SecuritySchemes = new Dictionary<string, IOpenApiSecurityScheme>
+                {
+                    ["CookieAuth"] = new OpenApiSecurityScheme
+                    {
+                        Type = SecuritySchemeType.ApiKey,
+                        In = ParameterLocation.Cookie,
+                        Name = CookieAuthService.CookieName,
+                        Description =
+                            "Browser transport. JWT is issued as an HTTP-only cookie. " +
+                            "Use POST /api/v1/users/token/refresh to renew while still authenticated."
+                    },
+                    ["BearerAuth"] = new OpenApiSecurityScheme
+                    {
+                        Type = SecuritySchemeType.Http,
+                        Scheme = "bearer",
+                        BearerFormat = "JWT",
+                        Description =
+                            "Non-browser transport. Send Authorization: Bearer <token>. " +
+                            "Renew with POST /api/v1/users/token/refresh before expiry; " +
+                            "if already expired and refresh is rejected, re-authenticate."
+                    }
+                };
+
+                return Task.CompletedTask;
+            });
+        });
+
+        return services;
+    }
+}

--- a/backend/src/JobNecto.API/Program.cs
+++ b/backend/src/JobNecto.API/Program.cs
@@ -7,7 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true);
 
-builder.Services.AddOpenApi();
+builder.Services.AddApiOpenApi();
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddJwtAuthentication(builder.Configuration);
 builder.Services.AddApplication();

--- a/backend/src/JobNecto.Application/Interfaces/IPasswordHasher.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IPasswordHasher.cs
@@ -1,0 +1,29 @@
+namespace JobNecto.Application.Interfaces;
+
+/// <summary>
+/// Provides one-way password hashing and verification primitives for authentication flows.
+/// </summary>
+public interface IPasswordHasher
+{
+    /// <summary>
+    /// Generates a salted one-way hash for the provided password.
+    /// </summary>
+    /// <param name="password">Plaintext password from user input.</param>
+    /// <returns>Persistable password hash.</returns>
+    string HashPassword(string password);
+
+    /// <summary>
+    /// Verifies a plaintext password against a stored password hash.
+    /// </summary>
+    /// <param name="hashedPassword">Persisted hash.</param>
+    /// <param name="providedPassword">Plaintext password provided by a client.</param>
+    /// <returns><c>true</c> when the provided password matches the hash; otherwise <c>false</c>.</returns>
+    bool VerifyHashedPassword(string hashedPassword, string providedPassword);
+
+    /// <summary>
+    /// Checks whether a persisted value is a supported hash format for this hasher.
+    /// </summary>
+    /// <param name="value">Persisted password value.</param>
+    /// <returns><c>true</c> when the value is in this hasher's expected hash format.</returns>
+    bool IsHashSupportedFormat(string value);
+}

--- a/backend/src/JobNecto.Application/Users/CreateUserCommand.cs
+++ b/backend/src/JobNecto.Application/Users/CreateUserCommand.cs
@@ -19,7 +19,7 @@ public class CreateUserCommand : IRequest<CreateUserResult>
     public string Email { get; set; } = null!;
 
     /// <summary>
-    /// Plain-text password. (Password hardening is out of scope for this story.)
+    /// Plain-text password supplied by the client; hashed before persistence and never returned in API responses.
     /// </summary>
     public string Password { get; set; } = null!;
 

--- a/backend/src/JobNecto.Application/Users/CreateUserCommandHandler.cs
+++ b/backend/src/JobNecto.Application/Users/CreateUserCommandHandler.cs
@@ -11,13 +11,15 @@ namespace JobNecto.Application.Users;
 public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, CreateUserResult>
 {
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IPasswordHasher _passwordHasher;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CreateUserCommandHandler"/> class.
     /// </summary>
-    public CreateUserCommandHandler(IUnitOfWork unitOfWork)
+    public CreateUserCommandHandler(IUnitOfWork unitOfWork, IPasswordHasher passwordHasher)
     {
         _unitOfWork = unitOfWork;
+        _passwordHasher = passwordHasher;
     }
 
     /// <summary>
@@ -42,8 +44,11 @@ public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, Creat
             throw new ConflictException($"User with login '{request.LoginName}' already exists.");
         }
 
+        // Hash password before mapping to persistence entity.
+        var hashedPassword = _passwordHasher.HashPassword(request.Password);
+
         // Create entity
-        var user = request.ToEntity();
+        var user = request.ToEntity(hashedPassword);
 
         // Add and save
         await _unitOfWork.UserRepository.CreateAsync(user, cancellationToken);

--- a/backend/src/JobNecto.Application/Users/Mappers/UserMappers.cs
+++ b/backend/src/JobNecto.Application/Users/Mappers/UserMappers.cs
@@ -14,10 +14,13 @@ public static class UserMappers
     /// Maps a CreateUserCommand (request DTO) to a User domain entity.
     /// Handles field name mapping: loginName -> Login, about -> AboutMe, location string -> Location enum.
     /// </summary>
-    public static User ToEntity(this CreateUserCommand command)
+    public static User ToEntity(this CreateUserCommand command, string passwordHash)
     {
         if (command == null)
             throw new ArgumentNullException(nameof(command));
+
+        if (string.IsNullOrWhiteSpace(passwordHash))
+            throw new ArgumentException("Password hash cannot be empty.", nameof(passwordHash));
 
         // Parse location enum if provided; set only when parsing succeeds, otherwise keep null.
         Location? location = null;
@@ -33,7 +36,7 @@ public static class UserMappers
         {
             Login = command.LoginName,
             Email = command.Email,
-            Password = command.Password,
+            Password = passwordHash,
             Phone = command.Phone,
             Location = location,
             AboutMe = command.About,

--- a/backend/src/JobNecto.Infrastructure/DI.cs
+++ b/backend/src/JobNecto.Infrastructure/DI.cs
@@ -32,6 +32,7 @@ public static class InfrastructureCollectionExtensions
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddSingleton<IJwtTokenService, JwtTokenService>();
+        services.AddSingleton<IPasswordHasher, Pbkdf2PasswordHasher>();
 
         return services;
     }

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260422212528_IncreaseUserPasswordHashLength.Designer.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260422212528_IncreaseUserPasswordHashLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JobNecto.Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JobNecto.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422212528_IncreaseUserPasswordHashLength")]
+    partial class IncreaseUserPasswordHashLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260422212528_IncreaseUserPasswordHashLength.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260422212528_IncreaseUserPasswordHashLength.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobNecto.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseUserPasswordHashLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Password",
+                table: "Users",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Password",
+                table: "Users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+        }
+    }
+}

--- a/backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs
@@ -5,7 +5,7 @@ namespace JobNecto.Infrastructure.Persistance;
 
 public class AppDbContext : DbContext
 {
-    public AppDbContext(DbContextOptions options)
+    public AppDbContext(DbContextOptions<AppDbContext> options)
         : base(options) { }
 
     public DbSet<User> Users { get; set; }

--- a/backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs
@@ -5,7 +5,7 @@ namespace JobNecto.Infrastructure.Persistance;
 
 public class AppDbContext : DbContext
 {
-    public AppDbContext(DbContextOptions<AppDbContext> options)
+    public AppDbContext(DbContextOptions options)
         : base(options) { }
 
     public DbSet<User> Users { get; set; }

--- a/backend/src/JobNecto.Infrastructure/Persistance/Config/UserConfiguration.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/Config/UserConfiguration.cs
@@ -32,7 +32,7 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
 
         builder.HasIndex(u => u.Login).IsUnique().HasFilter("\"IsDeleted\" = FALSE");
 
-        builder.Property(u => u.Password).IsRequired().HasMaxLength(50);
+        builder.Property(u => u.Password).IsRequired().HasMaxLength(256);
 
         builder.Property(u => u.Email).IsRequired().IsUnicode().HasMaxLength(50);
 

--- a/backend/src/JobNecto.Infrastructure/Services/Pbkdf2PasswordHasher.cs
+++ b/backend/src/JobNecto.Infrastructure/Services/Pbkdf2PasswordHasher.cs
@@ -1,0 +1,106 @@
+using System.Security.Cryptography;
+using System.Globalization;
+using JobNecto.Application.Interfaces;
+
+namespace JobNecto.Infrastructure.Services;
+
+/// <summary>
+/// PBKDF2-based password hasher that uses per-password random salt and SHA-256.
+/// </summary>
+public sealed class Pbkdf2PasswordHasher : IPasswordHasher
+{
+    private const string FormatMarker = "pbkdf2-sha256";
+    private const int SaltSizeBytes = 16;
+    private const int HashSizeBytes = 32;
+    private const int Iterations = 100_000;
+    private const int MaxSupportedIterations = 1_000_000;
+
+    /// <inheritdoc />
+    public string HashPassword(string password)
+    {
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            throw new ArgumentException("Password cannot be empty.", nameof(password));
+        }
+
+        var salt = new byte[SaltSizeBytes];
+        RandomNumberGenerator.Fill(salt);
+
+        var hash = Rfc2898DeriveBytes.Pbkdf2(
+            password,
+            salt,
+            Iterations,
+            HashAlgorithmName.SHA256,
+            HashSizeBytes);
+
+        return string.Join('$',
+            FormatMarker,
+            Iterations,
+            Convert.ToBase64String(salt),
+            Convert.ToBase64String(hash));
+    }
+
+    /// <inheritdoc />
+    public bool VerifyHashedPassword(string hashedPassword, string providedPassword)
+    {
+        if (string.IsNullOrWhiteSpace(hashedPassword) || string.IsNullOrWhiteSpace(providedPassword))
+        {
+            return false;
+        }
+
+        if (!TryParseHash(hashedPassword, out var iterations, out var salt, out var expectedHash))
+        {
+            return false;
+        }
+
+        var actualHash = Rfc2898DeriveBytes.Pbkdf2(
+            providedPassword,
+            salt,
+            iterations,
+            HashAlgorithmName.SHA256,
+            expectedHash.Length);
+
+        return CryptographicOperations.FixedTimeEquals(actualHash, expectedHash);
+    }
+
+    /// <inheritdoc />
+    public bool IsHashSupportedFormat(string value)
+    {
+        return TryParseHash(value, out _, out _, out _);
+    }
+
+    private static bool TryParseHash(
+        string hashedPassword,
+        out int iterations,
+        out byte[] salt,
+        out byte[] expectedHash)
+    {
+        iterations = 0;
+        salt = Array.Empty<byte>();
+        expectedHash = Array.Empty<byte>();
+
+        var parts = hashedPassword.Split('$');
+        if (parts.Length != 4 || !string.Equals(parts[0], FormatMarker, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out iterations)
+            || iterations < Iterations
+            || iterations > MaxSupportedIterations)
+        {
+            return false;
+        }
+
+        try
+        {
+            salt = Convert.FromBase64String(parts[2]);
+            expectedHash = Convert.FromBase64String(parts[3]);
+            return salt.Length == SaltSizeBytes && expectedHash.Length == HashSizeBytes;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/ExceptionHandlingTests.cs
+++ b/backend/tests/JobNecto.Tests/API/ExceptionHandlingTests.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using FluentValidation.Results;
 using JobNecto.API;
 using JobNecto.Application.Exceptions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -48,6 +49,14 @@ public class TestEndpointsStartupFilter : IStartupFilter
                 endpoints.MapGet("/test-conflict", () =>
                 {
                     throw new ConflictException("Resource already exists.");
+                });
+
+                endpoints.MapGet("/test-db-unique-conflict", () =>
+                {
+                    throw new DbUpdateException(
+                        "duplicate key value violates unique constraint \"IX_Users_Email\"",
+                        new InvalidOperationException(
+                            "duplicate key value violates unique constraint \"IX_Users_Email\""));
                 });
 
                 endpoints.MapGet("/test-generic", () =>
@@ -167,6 +176,23 @@ public class ExceptionHandlingTests : IClassFixture<ExceptionHandlingFactory>
         document!["status"]!.GetValue<int>().Should().Be(409);
         document["title"]!.GetValue<string>().Should().Be("Conflict");
         document["detail"]!.GetValue<string>().Should().Be("Resource already exists.");
+        document["traceId"]!.GetValue<string>().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Get_TestDbUniqueConflict_Returns409()
+    {
+        var response = await _client.GetAsync("/test-db-unique-conflict");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var json = await response.Content.ReadAsStringAsync();
+        var document = JsonNode.Parse(json);
+
+        document!["status"]!.GetValue<int>().Should().Be(409);
+        document["title"]!.GetValue<string>().Should().Be("Conflict");
+        document["detail"]!.GetValue<string>().Should().Be("A unique constraint was violated.");
         document["traceId"]!.GetValue<string>().Should().NotBeNullOrEmpty();
     }
 

--- a/backend/tests/JobNecto.Tests/API/UsersControllerConcurrencyTests.cs
+++ b/backend/tests/JobNecto.Tests/API/UsersControllerConcurrencyTests.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JobNecto.Application.Users;
+using JobNecto.Infrastructure.Persistance;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Xunit.Abstractions;
+
+namespace JobNecto.Tests.API;
+
+public class UsersControllerConcurrencyTests : IClassFixture<UsersControllerConcurrencyFactory>
+{
+    private readonly UsersControllerConcurrencyFactory _factory;
+    private readonly ITestOutputHelper _output;
+
+    public UsersControllerConcurrencyTests(
+        UsersControllerConcurrencyFactory factory,
+        ITestOutputHelper output)
+    {
+        _factory = factory;
+        _output = output;
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentDuplicateRequests_ReturnsOneCreatedAndOneConflict()
+    {
+        if (!await _factory.TryInitializeSchemaAsync())
+        {
+            _output.WriteLine("Skipped real-database concurrency assertion because PostgreSQL test database was unavailable.");
+            return;
+        }
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var login = "race" + Guid.NewGuid().ToString("N")[..8];
+        var email = Guid.NewGuid().ToString("N")[..8] + "@example.com";
+
+        var requestA = new CreateUserCommand
+        {
+            LoginName = login,
+            Email = email,
+            Password = "Password123!"
+        };
+
+        var requestB = new CreateUserCommand
+        {
+            LoginName = login,
+            Email = email,
+            Password = "Password123!"
+        };
+
+        var responseTasks = new[]
+        {
+            client.PostAsJsonAsync("/api/v1/users", requestA),
+            client.PostAsJsonAsync("/api/v1/users", requestB)
+        };
+
+        await Task.WhenAll(responseTasks);
+
+        var responses = responseTasks.Select(task => task.Result).ToArray();
+        responses.Count(r => r.StatusCode == HttpStatusCode.Created).Should().Be(1);
+        responses.Count(r => r.StatusCode == HttpStatusCode.Conflict).Should().Be(1);
+
+        var conflictResponse = responses.Single(r => r.StatusCode == HttpStatusCode.Conflict);
+        var body = await conflictResponse.Content.ReadAsStringAsync();
+        var problem = JsonNode.Parse(body);
+
+        problem.Should().NotBeNull();
+        problem!["status"]!.GetValue<int>().Should().Be(409);
+        problem["title"]!.GetValue<string>().Should().Be("Conflict");
+        problem["traceId"]!.GetValue<string>().Should().NotBeNullOrEmpty();
+    }
+}
+
+public sealed class UsersControllerConcurrencyFactory : WebApplicationFactory<Program>
+{
+    private const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=JobNectoTest;Username=test;Password=test";
+
+    private readonly string _baseConnectionString;
+    private readonly string _schemaName;
+    private string? _scopedConnectionString;
+    private bool _schemaInitialized;
+
+    public UsersControllerConcurrencyFactory()
+    {
+        _baseConnectionString = Environment.GetEnvironmentVariable("JOBNECTO_TEST_POSTGRES")
+            ?? DefaultConnectionString;
+        _schemaName = "users_concurrency_" + Guid.NewGuid().ToString("N");
+    }
+
+    public async Task<bool> TryInitializeSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        if (_schemaInitialized)
+        {
+            return true;
+        }
+
+        try
+        {
+            await EnsureSchemaExistsAsync(cancellationToken);
+
+            var builder = new NpgsqlConnectionStringBuilder(_baseConnectionString)
+            {
+                SearchPath = _schemaName
+            };
+
+            _scopedConnectionString = builder.ConnectionString;
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseNpgsql(
+                    _scopedConnectionString,
+                    npgsql => npgsql.MigrationsAssembly("JobNecto.Infrastructure"))
+                .Options;
+
+            await using var dbContext = new AppDbContext(options);
+            await dbContext.Database.MigrateAsync(cancellationToken);
+
+            _schemaInitialized = true;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Test");
+        builder.UseSetting(
+            "ConnectionStrings:Postgres",
+            _scopedConnectionString ?? _baseConnectionString);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await DropSchemaAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task EnsureSchemaExistsAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(_baseConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{_schemaName}\";";
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task DropSchemaAsync()
+    {
+        if (!_schemaInitialized)
+        {
+            return;
+        }
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(_baseConnectionString);
+            await connection.OpenAsync();
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"DROP SCHEMA IF EXISTS \"{_schemaName}\" CASCADE;";
+            await command.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/UsersControllerTests.cs
+++ b/backend/tests/JobNecto.Tests/API/UsersControllerTests.cs
@@ -96,6 +96,41 @@ public class UsersControllerTests : IClassFixture<JobNectoApiFactory>
     }
 
     [Fact]
+    public async Task RefreshToken_WithCookieTransport_Returns200AndRenewsCookieWithoutBodyToken()
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var command = new CreateUserCommand
+        {
+            LoginName = "refreshcookie" + Guid.NewGuid().ToString("N")[..8],
+            Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+            Password = "Password123!"
+        };
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/users", command);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var cookieToken = createResponse.Headers
+            .GetValues("Set-Cookie")
+            .First()
+            .Split(';', StringSplitOptions.TrimEntries)
+            .First(x => x.StartsWith("auth-token=", StringComparison.OrdinalIgnoreCase));
+
+        var refreshRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/users/token/refresh");
+        refreshRequest.Headers.TryAddWithoutValidation("Cookie", cookieToken);
+
+        var refreshResponse = await client.SendAsync(refreshRequest);
+
+        refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        refreshResponse.Headers.Should().ContainKey("Set-Cookie");
+
+        var refreshResult = await refreshResponse.Content.ReadFromJsonAsync<RefreshAccessTokenResult>();
+        refreshResult.Should().NotBeNull();
+        refreshResult!.AccessToken.Should().BeEmpty();
+        refreshResult.TokenType.Should().Be("Bearer");
+        refreshResult.RenewalPolicy.Should().Contain("token/refresh");
+    }
+
+    [Fact]
     public async Task RefreshToken_WithoutAuthentication_Returns401()
     {
         var client = _factory.CreateClient();

--- a/backend/tests/JobNecto.Tests/API/UsersControllerTests.cs
+++ b/backend/tests/JobNecto.Tests/API/UsersControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using JobNecto.API.Contracts.Auth;
 using JobNecto.Application.Users;
 using Microsoft.AspNetCore.Mvc.Testing;
 
@@ -40,6 +41,7 @@ public class UsersControllerTests : IClassFixture<JobNectoApiFactory>
         cookieHeader.Should().Contain("auth-token=");
         cookieHeader.ToLower().Should().Contain("httponly");
         cookieHeader.ToLower().Should().Contain("samesite=strict");
+        cookieHeader.ToLower().Should().Contain("secure");
     }
 
     [Fact]
@@ -56,5 +58,50 @@ public class UsersControllerTests : IClassFixture<JobNectoApiFactory>
         var response = await client.PostAsJsonAsync("/api/v1/users", command);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithBearerTransport_Returns200AndRenewsCookieAndBodyToken()
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var command = new CreateUserCommand
+        {
+            LoginName = "refresh" + Guid.NewGuid().ToString("N")[..8],
+            Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+            Password = "Password123!"
+        };
+
+        var createResponse = await client.PostAsJsonAsync("/api/v1/users", command);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var originalCookie = createResponse.Headers.GetValues("Set-Cookie").First();
+        var originalToken = originalCookie
+            .Split(';', StringSplitOptions.TrimEntries)
+            .First(x => x.StartsWith("auth-token=", StringComparison.OrdinalIgnoreCase))
+            .Substring("auth-token=".Length);
+
+        var refreshRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/users/token/refresh");
+        refreshRequest.Headers.Authorization = new("Bearer", originalToken);
+
+        var refreshResponse = await client.SendAsync(refreshRequest);
+
+        refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        refreshResponse.Headers.Should().ContainKey("Set-Cookie");
+
+        var refreshResult = await refreshResponse.Content.ReadFromJsonAsync<RefreshAccessTokenResult>();
+        refreshResult.Should().NotBeNull();
+        refreshResult!.TokenType.Should().Be("Bearer");
+        refreshResult.AccessToken.Should().NotBeNullOrWhiteSpace();
+        refreshResult.RenewalPolicy.Should().Contain("token/refresh");
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithoutAuthentication_Returns401()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.PostAsync("/api/v1/users/token/refresh", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/backend/tests/JobNecto.Tests/Application/Users/CreateUserCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Users/CreateUserCommandHandlerTests.cs
@@ -11,14 +11,16 @@ public class CreateUserCommandHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
     private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly Mock<IPasswordHasher> _passwordHasherMock;
     private readonly CreateUserCommandHandler _handler;
 
     public CreateUserCommandHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
         _userRepoMock = new Mock<IUserRepository>();
+        _passwordHasherMock = new Mock<IPasswordHasher>();
         _uowMock.Setup(x => x.UserRepository).Returns(_userRepoMock.Object);
-        _handler = new CreateUserCommandHandler(_uowMock.Object);
+        _handler = new CreateUserCommandHandler(_uowMock.Object, _passwordHasherMock.Object);
     }
 
     [Fact]
@@ -30,15 +32,31 @@ public class CreateUserCommandHandlerTests
             Email = "test@example.com",
             Password = "password123"
         };
+
+        var createdUser = default(User);
+        const string hashedPassword = "hashed-password";
+
+        _passwordHasherMock
+            .Setup(x => x.HashPassword(command.Password))
+            .Returns(hashedPassword);
+
         _userRepoMock.Setup(x => x.GetByEmailAsync(command.Email, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
         _userRepoMock.Setup(x => x.GetByLoginAsync(command.LoginName, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
+        _userRepoMock
+            .Setup(x => x.CreateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((user, _) => createdUser = user)
+            .ReturnsAsync((User user, CancellationToken _) => user);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
         result.Should().NotBeNull();
         result.LoginName.Should().Be(command.LoginName);
+        createdUser.Should().NotBeNull();
+        createdUser!.Password.Should().Be(hashedPassword);
+        createdUser.Password.Should().NotBe(command.Password);
+        _passwordHasherMock.Verify(x => x.HashPassword(command.Password), Times.Once);
         _userRepoMock.Verify(x => x.CreateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
         _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -54,6 +72,7 @@ public class CreateUserCommandHandlerTests
 
         await act.Should().ThrowAsync<ConflictException>()
             .WithMessage($"User with email '{command.Email}' already exists.");
+        _passwordHasherMock.Verify(x => x.HashPassword(It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -69,5 +88,14 @@ public class CreateUserCommandHandlerTests
 
         await act.Should().ThrowAsync<ConflictException>()
             .WithMessage($"User with login '{command.LoginName}' already exists.");
+        _passwordHasherMock.Verify(x => x.HashPassword(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void CreateUserResult_DoesNotExposePasswordField()
+    {
+        var passwordProperty = typeof(CreateUserResult).GetProperty("Password");
+
+        passwordProperty.Should().BeNull();
     }
 }

--- a/backend/tests/JobNecto.Tests/Infrastructure/Security/Pbkdf2PasswordHasherTests.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/Security/Pbkdf2PasswordHasherTests.cs
@@ -75,4 +75,19 @@ public class Pbkdf2PasswordHasherTests
 
         _hasher.IsHashSupportedFormat(malformed).Should().BeFalse();
     }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("-1")]
+    [InlineData("+100000")]
+    [InlineData("100000.5")]
+    [InlineData("100,000")]
+    public void IsHashSupportedFormat_WithMalformedIterationToken_ReturnsFalse(string iterationToken)
+    {
+        var salt = Convert.ToBase64String(new byte[16]);
+        var hash = Convert.ToBase64String(new byte[32]);
+        var malformed = $"pbkdf2-sha256${iterationToken}${salt}${hash}";
+
+        _hasher.IsHashSupportedFormat(malformed).Should().BeFalse();
+    }
 }

--- a/backend/tests/JobNecto.Tests/Infrastructure/Security/Pbkdf2PasswordHasherTests.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/Security/Pbkdf2PasswordHasherTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using JobNecto.Infrastructure.Services;
+
+namespace JobNecto.Tests.Infrastructure.Security;
+
+public class Pbkdf2PasswordHasherTests
+{
+    private readonly Pbkdf2PasswordHasher _hasher = new();
+
+    [Fact]
+    public void HashPassword_SameInput_ProducesDifferentHashes()
+    {
+        const string password = "Password123!";
+
+        var firstHash = _hasher.HashPassword(password);
+        var secondHash = _hasher.HashPassword(password);
+
+        firstHash.Should().NotBe(secondHash);
+    }
+
+    [Fact]
+    public void VerifyHashedPassword_WithCorrectPassword_ReturnsTrue()
+    {
+        const string password = "Password123!";
+        var hash = _hasher.HashPassword(password);
+
+        var isValid = _hasher.VerifyHashedPassword(hash, password);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void VerifyHashedPassword_WithWrongPassword_ReturnsFalse()
+    {
+        var hash = _hasher.HashPassword("Password123!");
+
+        var isValid = _hasher.VerifyHashedPassword(hash, "WrongPassword!");
+
+        isValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyHashedPassword_WithInvalidHashFormat_ReturnsFalse()
+    {
+        var isValid = _hasher.VerifyHashedPassword("not-a-valid-hash", "Password123!");
+
+        isValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsHashSupportedFormat_WithValidAndInvalidValues_ReturnsExpectedResult()
+    {
+        var hash = _hasher.HashPassword("Password123!");
+
+        _hasher.IsHashSupportedFormat(hash).Should().BeTrue();
+        _hasher.IsHashSupportedFormat("plain-text-password").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsHashSupportedFormat_WithTooFewIterations_ReturnsFalse()
+    {
+        var salt = Convert.ToBase64String(new byte[16]);
+        var hash = Convert.ToBase64String(new byte[32]);
+        var weakHash = $"pbkdf2-sha256$1${salt}${hash}";
+
+        _hasher.IsHashSupportedFormat(weakHash).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsHashSupportedFormat_WithUndersizedPayload_ReturnsFalse()
+    {
+        var undersizedSalt = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+        var undersizedHash = Convert.ToBase64String(new byte[] { 4, 5, 6 });
+        var malformed = $"pbkdf2-sha256$100000${undersizedSalt}${undersizedHash}";
+
+        _hasher.IsHashSupportedFormat(malformed).Should().BeFalse();
+    }
+}

--- a/backend/tests/JobNecto.Tests/Infrastructure/UserRepositorytests.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/UserRepositorytests.cs
@@ -31,4 +31,24 @@ public class UserRepositoryTests : EditableRepositoryTestsBase<User, UserReposit
     {
         fromDb.Email.Should().Be("original@example.com");
     }
+
+    [Fact]
+    public void UserModel_HasUniqueIndexes_ForEmailAndLogin()
+    {
+        using var context = CreateContext();
+        var entityType = context.Model.FindEntityType(typeof(User));
+
+        entityType.Should().NotBeNull();
+
+        var uniqueIndexPropertySets = entityType!
+            .GetIndexes()
+            .Where(index => index.IsUnique)
+            .Select(index => index.Properties.Select(p => p.Name).ToArray())
+            .ToList();
+
+        uniqueIndexPropertySets.Should().Contain(set =>
+            set.Length == 1 && set[0] == nameof(User.Email));
+        uniqueIndexPropertySets.Should().Contain(set =>
+            set.Length == 1 && set[0] == nameof(User.Login));
+    }
 }


### PR DESCRIPTION
## Summary
This PR delivers Story 1.5 in three logical commits:

1. **Auth core hardening**
- Introduce `IPasswordHasher` and PBKDF2-based implementation.
- Hash passwords in create-user flow before persistence.
- Increase stored password hash length via EF migration.

2. **API transport and conflict behavior**
- Add refresh-token response contract and refresh endpoint wiring.
- Add OpenAPI auth scheme metadata for cookie and bearer usage.
- Map unique constraint `DbUpdateException` to HTTP 409.
- Add integration coverage for refresh behavior and concurrent duplicate creation handling.

3. **Docs and planning alignment**
- Update Story 1.5 implementation artifact and sprint/retro artifacts.
- Synchronize architecture/PRD/epic references with final implementation decisions.

## Product Decision Applied
- Removed runtime legacy password backfill path as overkill for this greenfield environment (no existing users), and aligned implementation docs accordingly.

## Validation
- `dotnet build e:/apps/Jobnecto/backend/JobNecto.slnx`
- `dotnet test e:/apps/Jobnecto/backend/JobNecto.slnx --no-build`
- Test summary: **124 passed, 0 failed**