### PR TITLE
Implement story 2.2 list resumes endpoint and align cursor pagination docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,22 @@ JobNecto is a .NET 10 backend API for job vacancy aggregation and matching. Clea
 - No user-facing routes exist yet; 404 on root is expected.
 
 
+### Key Reference Files — When to Read Them
+
+| File | Read when |
+|------|----------|
+| `_bmad-output/planning-artifacts/prd.md` | Implementing a feature; clarifying what a feature must do; writing or reviewing stories |
+| `_bmad-output/planning-artifacts/architecture.md` | Designing new components; choosing patterns, abstractions, or infrastructure; validating Clean Architecture boundaries |
+| `_bmad-output/planning-artifacts/epics/requirements-inventory.md` | Checking non-functional requirements (security, performance, pagination, validation rules) before implementation |
+| `_bmad-output/agent-learnings.md` | Starting any non-trivial task; before writing tests; when a mistake was made — check if a lesson already covers it |
+
+### Agent Pushback Rule
+
+- Do **not** agree with every user suggestion. Only agree when the suggestion is technically sound and consistent with the project's architecture, conventions, and requirements.
+- If a user suggestion is clearly wrong, introduces a regression, violates Clean Architecture, or contradicts a documented decision — **say so explicitly** before proceeding. Provide a brief, direct reason.
+- Do not silently implement something incorrect just to comply. A short correction is always preferable to silent wrong work.
+- If the user insists after being informed, acknowledge the override and proceed, but note any risks.
+
 ### Custom Agent Skills
 
 - **Function Comments**: Use the `@[/function-comments]` skill from `.agents/skills/function-comments/SKILL.md` to add C# XML docs (`/// <summary>`, `<param>`, `<returns>`) to functions that benefit from documentation. Skip trivial code per the skill.
@@ -134,9 +150,10 @@ After a feature is implemented and merged, the agent **MUST** update the followi
 1. **`JOBNECTO_BACKEND_ROADMAP.md`** — Update completed features, mark as done, adjust timeline for remaining items.
 2. **`_bmad-output/planning-artifacts/prd.md`** — Reflect completed features, update feature status, adjust scope if needed.
 3. **`_bmad-output/planning-artifacts/architecture.md`** — Update if implementation changed from design, document any architectural decisions made during implementation.
-4. **`_bmad-output/implementation-artifacts/sprint-status.yaml`** — Mark completed stories/epics as done, update sprint metrics, remove merged items.
-5. **`README.md`** — Update feature list, API capabilities, or usage examples if the new feature is user-facing.
-6. **Project context files** (`_bmad-output/project-context.md`, etc.) — Update project state, completed features, and current status.
+4. **`_bmad-output/planning-artifacts/epics/requirements-inventory.md`** — Update if NFRs changed or new constraints were introduced during implementation.
+5. **`_bmad-output/implementation-artifacts/sprint-status.yaml`** — Mark completed stories/epics as done, update sprint metrics, remove merged items.
+6. **`README.md`** — Update feature list, API capabilities, or usage examples if the new feature is user-facing.
+7. **Project context files** (`_bmad-output/project-context.md`, etc.) — Update project state, completed features, and current status.
 
 ### Update Procedure
 

--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,16 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-04-28 - Explicitly test DateTime kind/offset behavior for cursor pagination
+
+**Trigger:** User correction
+**Context:** Story 2.2 cursor pagination review surfaced risk around `lastSeenUpdatedAt` DateTime kind normalization.
+**Wrong action:** I validated pagination happy paths and cursor progression but did not include adversarial checks for `DateTimeKind.Unspecified` / local-time cursor inputs.
+**Root cause:** I over-focused on acceptance-criteria coverage and existing repository tests, and under-weighted cross-boundary serialization/timezone edge cases.
+**Correct behavior:** For cursor fields that include timestamps, always add or review tests for kind/offset mismatch and normalize inputs at API boundary when needed.
+**Pattern / trigger:** API cursor parameters containing DateTime combined with strict equality/order comparisons in repository queries.
+**Generalize?** Yes
+
 ### 2026-04-28 - Prefer separate handler file when implementing new request handlers
 
 **Trigger:** User correction

--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,16 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-04-28 - Prefer separate handler file when implementing new request handlers
+
+**Trigger:** User correction
+**Context:** Story 2.2 implementation for list resumes used `ListResumesQuery` and `ListResumesQueryHandler` in one file.
+**Wrong action:** I kept query + handler together in a single file instead of splitting handler into a dedicated file.
+**Root cause:** I followed the story wording (`same file or sibling`) and optimized for minimal churn, but did not prioritize long-term maintainability/readability preference.
+**Correct behavior:** Prefer separate files for non-trivial handlers (e.g., `ListResumesQuery.cs` + `ListResumesHandler.cs`) unless there is an explicit convention to keep them together.
+**Pattern / trigger:** New feature slice adds MediatR request + handler and the handler contains business mapping/paging logic.
+**Generalize?** Yes
+
 ### 2026-04-28 - Avoid escaped quotes inside C# interpolation expressions
 
 **Trigger:** Test failure

--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,16 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-04-28 - Avoid escaped quotes inside C# interpolation expressions
+
+**Trigger:** Test failure
+**Context:** Added cursor-pagination integration test in `backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs`.
+**Wrong action:** I inserted `ToString(\"o\")` inside a C# interpolated expression, producing invalid syntax and compile-time failures.
+**Root cause:** I carried patch-string escaping into target C# code instead of writing the literal as `ToString("o")`.
+**Correct behavior:** When patching source code, verify language-level string literals directly in the target file and avoid transport-layer escaping artifacts.
+**Pattern / trigger:** Any patch that injects nested string literals inside interpolation or lambda expressions.
+**Generalize?** Yes
+
 ### 2026-04-25 - Verify review findings against concrete code paths
 
 **Trigger:** User correction

--- a/_bmad-output/implementation-artifacts/2-2-list-resumes.md
+++ b/_bmad-output/implementation-artifacts/2-2-list-resumes.md
@@ -1,0 +1,277 @@
+# Story 2.2: List Resumes
+
+Status: done
+
+## Story
+
+As a job seeker,
+I want to see all my resumes in a paginated list,
+So that I can quickly navigate to the one I need.
+
+## Acceptance Criteria
+
+1. `GET /api/v1/resumes` requires a valid JWT token. Unauthenticated requests return `401 Unauthorized`.
+2. Returns `200 OK` with a paginated response: `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }` — only the current user's non-deleted resumes, ordered by `updatedAt desc`, `pageSize` defaulting to 20.
+3. The `pageSize` query param (optional) configures page size; capped at 100. Values < 1 or invalid are treated as default (20).
+4. Cursor-based pagination: optional `lastSeenId` (Guid) and `lastSeenUpdatedAt` (DateTime) query params are passed to advance the page window.
+5. If the user has no resumes, returns `200 OK` with `{ totalCount: 0, items: [] }`.
+6. Resumes belonging to a different user are **never** returned regardless of cursor or page size.
+7. Soft-deleted resumes (flagged `IsDeleted = true`) are excluded — enforced by EF Core global query filters.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Define the Application query contract (AC: 2, 3, 4)
+  - [x] Create `ListResumesQuery.cs` in `backend/src/JobNecto.Application/Resumes/`.
+  - [x] Declare `ListResumesQuery : IRequest<PagedResult<ResumeResult>>` with properties: `UserId` (Guid, `[JsonIgnore]`), `PageSize` (int, default 20), `LastSeenId` (Guid?), `LastSeenUpdatedAt` (DateTime?).
+  - [x] Implement `ListResumesQueryHandler : IRequestHandler<ListResumesQuery, PagedResult<ResumeResult>>` in the same file or as a sibling file.
+  - [x] In the handler: cap `pageSize` at 100 (Math.Min), build `PagedQuery { UserId = request.UserId, PageSize = capped, LastSeenId = request.LastSeenId, LastSeenUpdatedAt = request.LastSeenUpdatedAt }`.
+  - [x] Call `_unitOfWork.ResumeRepository.GetAsync(pagedQuery, cancellationToken)` and project each entity to `ResumeResult` via `resume.ToResumeResult()` from `ResumeMappers`.
+  - [x] Return a new `PagedResult<ResumeResult>` reconstructed with the projected items list, and the same `TotalCount`, `LastSeenId`, `LastSeenUpdatedAt`, `PageSize`, `HasNext` from the repository result.
+
+- [x] Task 2: Expose API endpoint (AC: 1, 2, 3, 4, 5)
+  - [x] Open `backend/src/JobNecto.API/Controllers/ResumesController.cs`.
+  - [x] Add `GET` action `ListAsync([FromQuery] int pageSize = 20, [FromQuery] Guid? lastSeenId = null, [FromQuery] DateTime? lastSeenUpdatedAt = null, CancellationToken cancellationToken = default)`.
+  - [x] Decorate with `[HttpGet]`, `[ProducesResponseType(typeof(PagedResult<ResumeResult>), 200)]`, `[ProducesResponseType(401)]`.
+  - [x] Extract `UserId` from JWT context using `HttpContext.GetCurrentUserId()` (same pattern as `Create` action in same controller).
+  - [x] Build and send `ListResumesQuery` via `_mediator.Send(query, cancellationToken)`.
+  - [x] Return `Ok(result)`.
+
+- [x] Task 3: Verification and Testing (AC: 1–7)
+  - [x] Add unit tests for `ListResumesQueryHandler` in `backend/tests/JobNecto.Tests/Application/Resumes/ListResumesHandlerTests.cs`.
+    - [x] Test: correct `PagedQuery` is forwarded to repository (UserId, PageSize capping, cursors).
+    - [x] Test: handler maps returned `Resume` entities to `ResumeResult` correctly.
+    - [x] Test: empty repository result returns `PagedResult` with empty items.
+    - [x] Test: `pageSize` > 100 is capped at 100.
+  - [x] Add integration tests in `backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs`.
+    - [x] Test: `GET /api/v1/resumes` without token returns `401`.
+    - [x] Test: `GET /api/v1/resumes` with valid token and no resumes returns `200` with `{ totalCount: 0, items: [] }`.
+    - [x] Test: `GET /api/v1/resumes` returns only the authenticated user's resumes (not another user's).
+    - [x] Test: `pageSize` query param is respected (returns correct count).
+    - [x] Test: `pageSize` > 100 is capped (response `pageSize` ≤ 100).
+  - [x] Verify `dotnet test backend/JobNecto.slnx` passes.
+
+## Dev Notes
+
+### Pagination Format Decision
+
+The project uses **cursor-based pagination** exclusively, implemented via `PagedQuery` + `PagedResult<T>` in `JobNecto.Domain.ValueObjects.Pagination`:
+
+```csharp
+// Domain/ValueObjects/Pagination.cs
+public record PagedQuery
+{
+    public Guid? UserId { get; init; } = null;
+    public Guid? LastSeenId { get; init; } = null;
+    public DateTime? LastSeenUpdatedAt { get; init; } = null;
+    public int PageSize { get; init; } = 20;
+}
+
+public record PagedResult<BaseEntity>(
+    IReadOnlyList<BaseEntity> Items,
+    int TotalCount,
+    Guid? LastSeenId,
+    DateTime? LastSeenUpdatedAt,
+    int PageSize,
+    bool HasNext
+)
+```
+
+The `BaseRepository<T>.GetAsync(PagedQuery, ct)` (Infrastructure) automatically:
+
+- Filters by `UserId` when `PagedQuery.UserId` is set (via reflection on EF model property)
+- Applies cursor window using `LastSeenId` / `LastSeenUpdatedAt`
+- Orders by `updatedAt desc, id desc`
+- Counts total matching records (respecting global soft-delete filters)
+
+The `ResumeRepository` in Infrastructure **overrides** `GetAsync` with user-scoped filtering to enforce that cursor positions from foreign users are ignored (see `ResumeRepositoryTests.GetAsync_WithForeignCursorAndUserId_IgnoresCursorOutsideUserScope`).
+
+### Handler Pattern
+
+Replicate the handler pattern from `CreateResumeCommandHandler`:
+
+```csharp
+// Application/Resumes/ListResumesQueryHandler.cs
+public class ListResumesQueryHandler : IRequestHandler<ListResumesQuery, PagedResult<ResumeResult>>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ListResumesQueryHandler(IUnitOfWork unitOfWork) => _unitOfWork = unitOfWork;
+
+    public async Task<PagedResult<ResumeResult>> Handle(ListResumesQuery request, CancellationToken cancellationToken)
+    {
+        var cappedPageSize = Math.Min(Math.Max(1, request.PageSize), 100);
+
+        var pagedQuery = new PagedQuery
+        {
+            UserId = request.UserId,
+            PageSize = cappedPageSize,
+            LastSeenId = request.LastSeenId,
+            LastSeenUpdatedAt = request.LastSeenUpdatedAt,
+        };
+
+        var result = await _unitOfWork.ResumeRepository.GetAsync(pagedQuery, cancellationToken);
+
+        var projectedItems = result.Items.Select(r => r.ToResumeResult()).ToList();
+
+        return new PagedResult<ResumeResult>(
+            projectedItems,
+            result.TotalCount,
+            result.LastSeenId,
+            result.LastSeenUpdatedAt,
+            result.PageSize,
+            result.HasNext
+        );
+    }
+}
+```
+
+### Controller Pattern
+
+Add to the **existing** `ResumesController.cs` (do NOT create a new controller):
+
+```csharp
+[HttpGet]
+[ProducesResponseType(typeof(PagedResult<ResumeResult>), StatusCodes.Status200OK)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+public async Task<ActionResult<PagedResult<ResumeResult>>> ListAsync(
+    [FromQuery] int pageSize = 20,
+    [FromQuery] Guid? lastSeenId = null,
+    [FromQuery] DateTime? lastSeenUpdatedAt = null,
+    CancellationToken cancellationToken = default)
+{
+    var userIdValue = HttpContext.GetCurrentUserId();
+    if (!Guid.TryParse(userIdValue, out var userId))
+        return Unauthorized();
+
+    var query = new ListResumesQuery
+    {
+        UserId = userId,
+        PageSize = pageSize,
+        LastSeenId = lastSeenId,
+        LastSeenUpdatedAt = lastSeenUpdatedAt,
+    };
+
+    var result = await _mediator.Send(query, cancellationToken);
+    return Ok(result);
+}
+```
+
+### Integration Test Pattern
+
+Follow `UsersControllerTests.cs` — use `JobNectoApiFactory` (WebApplicationFactory + InMemory DB). To authenticate:
+
+1. `POST /api/v1/users` to create a user (response includes `Set-Cookie: auth-token=...`).
+2. Include cookie on subsequent requests via `WebApplicationFactoryClientOptions { HandleCookies = true }` or manually set `Authorization: Bearer <token>`.
+3. Seed resumes by calling `POST /api/v1/resumes` for that authenticated user.
+
+### Unit Test Pattern
+
+Follow `CreateResumeCommandHandlerTests.cs`:
+
+- Mock `IUnitOfWork` with `Mock<IUnitOfWork>`.
+- Mock `IEditableRepository<Resume>` (which is what `ResumeRepository` implements — the UoW exposes it as `IEditableRepository<Resume>`).
+- Setup `_uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object)`.
+- For list handler: setup `_resumeRepoMock.Setup(x => x.GetAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(pagedResult)`.
+
+### Important File Paths
+
+| Purpose | Path |
+| --- | --- |
+| Query + Handler | `backend/src/JobNecto.Application/Resumes/ListResumesQuery.cs` |
+| Existing mapper | `backend/src/JobNecto.Application/Resumes/Mappers/ResumeMappers.cs` |
+| Existing result DTO | `backend/src/JobNecto.Application/Resumes/CreateResumeCommand.cs` (`ResumeResult` class defined here) |
+| Existing controller | `backend/src/JobNecto.API/Controllers/ResumesController.cs` |
+| Existing auth helper | `backend/src/JobNecto.API/Infrastructure/AuthContext.cs` (extension method `GetCurrentUserId()`) |
+| UoW interface | `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs` (`ResumeRepository` as `IEditableRepository<Resume>`) |
+| Pagination types | `backend/src/JobNecto.Domain/ValueObjects/Pagination.cs` |
+| Resume entity | `backend/src/JobNecto.Domain/Entities/Resume.cs` |
+| Resume repository | `backend/src/JobNecto.Infrastructure/Repositories/ResumeRepository.cs` |
+| Unit tests (resume) | `backend/tests/JobNecto.Tests/Application/Resumes/` |
+| API test factory | `backend/tests/JobNecto.Tests/API/JobNectoApiFactory.cs` |
+
+### Namespace Rules
+
+Per project convention, namespaces must match folder structure:
+
+- `ListResumesQuery.cs` → `namespace JobNecto.Application.Resumes;`
+- `ListResumesHandlerTests.cs` → `namespace JobNecto.Tests.Application.Resumes;` (match existing `CreateResumeCommandHandlerTests.cs`)
+- Integration test file → check existing `UsersControllerTests.cs` — uses `namespace JobNecto.Tests.API;`
+
+### Soft Delete
+
+EF Core global query filters on `AppDbContext.OnModelCreating` exclude entities where `IsDeleted == true` automatically. **Do NOT** manually add `.Where(r => !r.IsDeleted)` — it is already applied globally.
+
+### Dependency Injection
+
+No new DI wiring needed. MediatR auto-discovers handlers registered via `AddMediatR(typeof(CreateResumeCommand).Assembly)` in `Program.cs` / Infrastructure DI setup.
+
+### Project Structure Notes
+
+- `ResumeResult` DTO lives inside `CreateResumeCommand.cs` (not a separate file) — this is the existing pattern in the Resumes feature slice. The `ListResumesQuery` handler should **reuse** this class (already imported via namespace) and NOT define a separate list-specific DTO.
+- Do not add a `page` property to `PagedResult<T>` — it is a Domain value object and should not be changed for a single endpoint. If the product needs `page` in the response, expose it from the handler as a computed value in a wrapper, but this is not required by this story.
+
+### Previous Story Learnings (from 2.1 / Epic 1)
+
+- **Enum handling**: `WorkLocationType`, `Experience`, `Currency` are stored as enums in the domain entity and mapped to/from strings in `ResumeMappers.ToResumeResult()`. Use that mapper as-is.
+- **UserId extraction**: Use `HttpContext.GetCurrentUserId()` extension (lives in `JobNecto.API.Infrastructure.AuthContext`). Parse with `Guid.TryParse`, return `Unauthorized()` on parse failure — same pattern as `Create` action.
+- **IEditableRepository mock**: When unit-testing, `IUnitOfWork.ResumeRepository` is typed as `IEditableRepository<Resume>` (not a dedicated `IResumeRepository`). Mock as `Mock<IEditableRepository<Resume>>`.
+- **Test isolation**: Use unique in-memory DB names per test (`Guid.NewGuid().ToString()`). Use `await using` for `AppDbContext` disposal.
+- **Avoid namespace collisions**: The test files in `JobNecto.Tests` do not declare an explicit `namespace` in some cases (e.g., `ResumeRepositoryTests.cs`) — check the files you're adding near and be consistent.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md` — Story 2.2]
+- [Source: `backend/src/JobNecto.Domain/ValueObjects/Pagination.cs`]
+- [Source: `backend/src/JobNecto.Application/Interfaces/IRepository.cs`]
+- [Source: `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`]
+- [Source: `backend/src/JobNecto.Application/Resumes/CreateResumeCommand.cs`]
+- [Source: `backend/src/JobNecto.Application/Resumes/CreateResumeCommandHandler.cs`]
+- [Source: `backend/src/JobNecto.Application/Resumes/Mappers/ResumeMappers.cs`]
+- [Source: `backend/src/JobNecto.API/Controllers/ResumesController.cs`]
+- [Source: `backend/src/JobNecto.Infrastructure/Repositories/BaseRepository.cs`]
+- [Source: `backend/src/JobNecto.Infrastructure/Repositories/ResumeRepository.cs`]
+- [Source: `backend/tests/JobNecto.Tests/API/JobNectoApiFactory.cs`]
+- [Source: `backend/tests/JobNecto.Tests/API/UsersControllerTests.cs`]
+- [Source: `backend/tests/JobNecto.Tests/Application/Resumes/CreateResumeCommandHandlerTests.cs`]
+- [Source: `backend/tests/JobNecto.Tests/Infrastructure/ResumeRepositoryTests.cs`]
+- [Source: `_bmad-output/implementation-artifacts/2-1-create-resume.md`]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GitHub Copilot (Claude Sonnet 4.6)
+
+### Debug Log References
+
+- Full test suite: 192 tests, 0 failed (run: 2026-04-28)
+- Full test suite: 193 tests, 0 failed after review patches (run: 2026-04-28)
+
+### Review Findings
+
+- [x] **D1 (dismissed)** — Partial cursor validation: silent half-cursor behavior accepted by product decision (2026-04-28)
+- [x] **P1 (patch)** — AC 3 violation: `pageSize < 1` floors to `1` instead of default `20` — fixed: `request.PageSize < 1 ? 20 : Math.Min(request.PageSize, 100)`
+- [x] **P2 (patch)** — Unit test renamed to `Handle_PageSizeBelowOne_DefaultsToTwenty`; assertion updated to `.Be(20)`
+- [x] **P3 (patch)** — Added `List_WithPageSizeBelowOne_DefaultsToTwenty` integration test seeding 3 resumes and asserting `pageSize=20`
+- [x] **P4 (patch)** — `List_WithPageSizeAbove100_IsCappedAt100` now seeds 3 resumes and asserts `result!.PageSize.Should().Be(100)` precisely
+- [x] **W1 (defer)** — Cursor pagination not tested end-to-end (AC 4) — deferred, pre-existing test strategy; covered in `ResumeRepositoryTests`
+- [x] **W2 (defer)** — Soft-delete exclusion not tested on this endpoint (AC 7) — deferred, pre-existing test strategy; global EF filter coverage in `ResumeRepositoryTests`
+- [x] **W3 (defer)** — `DateTime` kind ambiguity on `lastSeenUpdatedAt` cursor — deferred, pre-existing cross-cutting architectural decision
+
+### Completion Notes List
+
+- Implemented `ListResumesQuery` + `ListResumesQueryHandler` in a single file (`ListResumesQuery.cs`), following the existing feature-slice pattern.
+- `pageSize` is clamped to `[1, 100]` using `Math.Min(Math.Max(1, pageSize), 100)` in the handler.
+- Added `ListAsync` GET action to existing `ResumesController` — no new controller created.
+- Added `using JobNecto.Domain.ValueObjects;` import to `ResumesController.cs` for `PagedResult<T>`.
+- 6 unit tests covering: query forwarding, pageSize capping (above 100 and below 1), empty result, entity→DTO projection, metadata preservation.
+- 5 integration tests covering: 401 without token, empty list, user isolation (other user's resumes excluded), pageSize respected, pageSize > 100 capped.
+- No new DI registration needed — MediatR auto-discovers the handler via existing assembly scan.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/2-2-list-resumes.md`
+- `backend/src/JobNecto.Application/Resumes/ListResumesQuery.cs`
+- `backend/src/JobNecto.API/Controllers/ResumesController.cs`
+- `backend/tests/JobNecto.Tests/Application/Resumes/ListResumesHandlerTests.cs`
+- `backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs`

--- a/_bmad-output/implementation-artifacts/2-2-list-resumes.md
+++ b/_bmad-output/implementation-artifacts/2-2-list-resumes.md
@@ -12,7 +12,7 @@ So that I can quickly navigate to the one I need.
 
 1. `GET /api/v1/resumes` requires a valid JWT token. Unauthenticated requests return `401 Unauthorized`.
 2. Returns `200 OK` with a paginated response: `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }` — only the current user's non-deleted resumes, ordered by `updatedAt desc`, `pageSize` defaulting to 20.
-3. The `pageSize` query param (optional) configures page size; capped at 100. Values < 1 or invalid are treated as default (20).
+3. The `pageSize` query param (optional) configures page size; capped at 100. Values < 1 are treated as default (20). Non-numeric/invalid format values (e.g., `pageSize=abc`) return `400 Bad Request` via automatic model binding validation.
 4. Cursor-based pagination: optional `lastSeenId` (Guid) and `lastSeenUpdatedAt` (DateTime) query params are passed to advance the page window.
 5. If the user has no resumes, returns `200 OK` with `{ totalCount: 0, items: [] }`.
 6. Resumes belonging to a different user are **never** returned regardless of cursor or page size.
@@ -47,6 +47,7 @@ So that I can quickly navigate to the one I need.
     - [x] Test: `GET /api/v1/resumes` with valid token and no resumes returns `200` with `{ totalCount: 0, items: [] }`.
     - [x] Test: `GET /api/v1/resumes` returns only the authenticated user's resumes (not another user's).
     - [x] Test: `pageSize` query param is respected (returns correct count).
+    - [x] Test: non-numeric `pageSize` returns `400 Bad Request`.
     - [x] Test: `pageSize` > 100 is capped (response `pageSize` ≤ 100).
   - [x] Verify `dotnet test backend/JobNecto.slnx` passes.
 
@@ -99,7 +100,8 @@ public class ListResumesQueryHandler : IRequestHandler<ListResumesQuery, PagedRe
 
     public async Task<PagedResult<ResumeResult>> Handle(ListResumesQuery request, CancellationToken cancellationToken)
     {
-        var cappedPageSize = Math.Min(Math.Max(1, request.PageSize), 100);
+        var normalizedPageSize = request.PageSize < 1 ? 20 : request.PageSize;  
+        var cappedPageSize = Math.Min(normalizedPageSize, 100);  
 
         var pagedQuery = new PagedQuery
         {
@@ -261,7 +263,7 @@ GitHub Copilot (Claude Sonnet 4.6)
 ### Completion Notes List
 
 - Implemented `ListResumesQuery` + `ListResumesQueryHandler` in a single file (`ListResumesQuery.cs`), following the existing feature-slice pattern.
-- `pageSize` is clamped to `[1, 100]` using `Math.Min(Math.Max(1, pageSize), 100)` in the handler.
+- In the handler, `pageSize` values below 1 default to 20; otherwise `pageSize` is capped at 100.
 - Added `ListAsync` GET action to existing `ResumesController` — no new controller created.
 - Added `using JobNecto.Domain.ValueObjects;` import to `ResumesController.cs` for `PagedResult<T>`.
 - 6 unit tests covering: query forwarding, pageSize capping (above 100 and below 1), empty result, entity→DTO projection, metadata preservation.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -12,3 +12,9 @@
 - **Empty-string `phone` clears value** — Design intent remains null/empty = clear field for partial-update semantics. Revisit if spec tightens empty-vs-null distinction.
 - **`loginName` min-length 3 vs AC wording** — Consistent with account-creation convention; update spec wording if minimum length is intended.
 - **Phone unique-index rollout policy** — Story 1.4 migration adds unique non-null `Users.Phone` index without inline legacy-data cleanup; release rollout should require pre-deploy duplicate-phone detection/remediation before applying migration in production.
+
+## Deferred from: code review of 2-2-list-resumes (2026-04-28)
+
+- **W1 — Cursor pagination end-to-end test** — No integration test seeds N resumes, passes a cursor, and asserts the next page is correct (AC 4). Current coverage lives in `ResumeRepositoryTests`; deferred as pre-existing test strategy.
+- **W2 — Soft-delete exclusion on `GET /api/v1/resumes`** — AC 7 is not asserted directly on this endpoint; relies on global EF filter coverage in `ResumeRepositoryTests`. Deferred as pre-existing test strategy.
+- **W3 — `DateTime` kind on cursor** — `lastSeenUpdatedAt` is bound as `DateTime` (not `DateTimeOffset`); unspecified-kind values from clients could cause cursor mismatches on UTC-stored timestamps. Cross-cutting architectural concern shared with W1 from story 1.3 deferred work.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-04-25T15:30:00Z
+# last_updated: 2026-04-27T00:00:00Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -46,7 +46,7 @@ development_status:
   # --- Epic 2: Resume & Education Management ---
   epic-2: in-progress
   2-1-create-resume: done
-  2-2-list-resumes: backlog
+  2-2-list-resumes: done
   2-3-get-resume-detail: backlog
   2-4-update-resume: backlog
   2-5-delete-resume: backlog

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -36,7 +36,7 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - CRUD operations on user-owned resources (User, Resume, Education, Template, Letter)
 - Read-only operations on shared resources (Vacancy browsing and filtering)
 - Filtering: Complex multi-criteria vacancy filtering via POST body (skills, location, salary, work type, etc.)
-- Paginated list operations with configurable page size (default 20, max 100)
+- Paginated list operations with cursor-based pagination (`lastSeenId` + `lastSeenUpdatedAt`); `pageSize` default 20, max 100
 
 **Non-Functional Requirements:**
 
@@ -136,7 +136,7 @@ _This document builds collaboratively through step-by-step discovery. We'll make
 - Vacancy filtering accepts POST body (not query params) to support multi-criteria queries
 - Filter object contains: skills[], location, salaryMin/Max, workLocationType[], etc.
 - AND logic between fields, OR logic within arrays (e.g., matches ANY skill)
-- Pagination included in filter object (page, pageSize)
+- Pagination included in filter object (`pageSize`, `lastSeenId`, `lastSeenUpdatedAt` cursor)
 - Design advantage: No URL length limits; type-safe filtering with request models
 
 **5. Async-First Pattern**
@@ -323,7 +323,7 @@ public interface IResumeRepository
 {
     Task<Resume?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<Resume>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
-    Task<PagedResult<Resume>> GetPaginatedByUserIdAsync(Guid userId, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<PagedResult<Resume>> GetAsync(PagedQuery pagedQuery, CancellationToken cancellationToken = default);
     Task AddAsync(Resume resume, CancellationToken cancellationToken = default);
     Task UpdateAsync(Resume resume, CancellationToken cancellationToken = default);
 }

--- a/_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md
+++ b/_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md
@@ -47,15 +47,15 @@ So that I can quickly navigate to the one I need.
 
 **Given** a valid JWT token
 **When** `GET /api/v1/resumes` is called with no query params
-**Then** `200 OK` with `{ total, page, pageSize, items }` - only this user's non-deleted resumes, ordered by `updatedAt desc`, `pageSize` defaulting to 20
+**Then** `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }` - only this user's non-deleted resumes, ordered by `updatedAt desc`, `pageSize` defaulting to 20
 
-**Given** `page` and `pageSize` query params are provided
+**Given** `pageSize`, `lastSeenId`, and `lastSeenUpdatedAt` cursor params are provided
 **When** the request is processed
-**Then** the correct slice is returned; `pageSize` is capped at 100
+**Then** the correct cursor window is returned; `pageSize` is capped at 100
 
 **Given** the user has no resumes
 **When** `GET /api/v1/resumes` is called
-**Then** `200 OK` with `{ total: 0, items: [] }`
+**Then** `200 OK` with `{ totalCount: 0, hasNext: false, items: [] }`
 
 **Given** another user's resume exists in the DB
 **When** this user calls `GET /api/v1/resumes`

--- a/_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md
+++ b/_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md
@@ -48,16 +48,16 @@ So that I can find the right template for a job application.
 
 **Given** a valid JWT token
 **When** `GET /api/v1/cover-letter-templates` is called with no query params
-**Then** `200 OK` with `{ total, page, pageSize, items }` - non-deleted templates owned by this user, ordered by `updatedAt desc`
+**Then** `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }` - non-deleted templates owned by this user, ordered by `updatedAt desc`
 **And** each item includes `id`, `name`, `createdAt`, `updatedAt`, and `contentPreview` (first 200 chars of `content`)
 
 **Given** `search` query param is provided (e.g., `?search=senior`)
 **When** the request is processed
 **Then** only templates whose `name` contains the search term (case-insensitive) are returned
 
-**Given** `pageSize` and `page` params are provided
+**Given** `pageSize`, `lastSeenId`, and `lastSeenUpdatedAt` cursor params are provided
 **When** the request is processed
-**Then** the correct slice is returned; `pageSize` capped at 100
+**Then** the correct cursor window is returned; `pageSize` capped at 100
 
 ---
 

--- a/_bmad-output/planning-artifacts/epics/epic-4-vacancy-browsing-filtering.md
+++ b/_bmad-output/planning-artifacts/epics/epic-4-vacancy-browsing-filtering.md
@@ -12,16 +12,16 @@ So that I can scan what's available without filtering.
 
 **Given** a valid JWT token
 **When** `GET /api/v1/vacancies` is called with no params
-**Then** `200 OK` with `{ total, page, pageSize, items }`, ordered by `createdAt desc`, `pageSize` defaulting to 20
+**Then** `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`, ordered by `createdAt desc`, `pageSize` defaulting to 20
 **And** each item includes: `id`, `title`, `company`, `workLocationType`, `location`, `salary`, `currency`, `createdAt`
 
-**Given** `page` and `pageSize` query params are provided
+**Given** `pageSize`, `lastSeenId`, and `lastSeenUpdatedAt` cursor params are provided
 **When** the request is processed
-**Then** correct slice is returned; `pageSize` capped at 100
+**Then** correct cursor window is returned; `pageSize` capped at 100
 
 **Given** no vacancies exist in the DB
 **When** `GET /api/v1/vacancies` is called
-**Then** `200 OK` with `{ total: 0, items: [] }`
+**Then** `200 OK` with `{ totalCount: 0, hasNext: false, items: [] }`
 
 ---
 
@@ -73,4 +73,4 @@ So that I can decide whether to apply.
 **Then** `404 Not Found`
 
 ---
-
+

--- a/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
+++ b/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
@@ -52,16 +52,16 @@ So that I can track all my job applications.
 
 **Given** a valid JWT token
 **When** `GET /api/v1/cover-letters` is called
-**Then** `200 OK` with `{ total, page, pageSize, items }` — non-deleted cover letters owned by this user, ordered by `createdAt desc`
+**Then** `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }` — non-deleted cover letters owned by this user, ordered by `createdAt desc`
 **And** each item includes: `id`, `vacancyId`, `vacancyTitle` (from linked vacancy), `createdAt`, `updatedAt`
 
-**Given** `page` and `pageSize` are provided
+**Given** `pageSize`, `lastSeenId`, and `lastSeenUpdatedAt` cursor params are provided
 **When** the request is processed
-**Then** correct slice returned; `pageSize` capped at 100
+**Then** correct cursor window returned; `pageSize` capped at 100
 
 **Given** the user has no cover letters
 **When** `GET /api/v1/cover-letters` is called
-**Then** `200 OK` with `{ total: 0, items: [] }`
+**Then** `200 OK` with `{ totalCount: 0, hasNext: false, items: [] }`
 
 ---
 

--- a/_bmad-output/planning-artifacts/epics/requirements-inventory.md
+++ b/_bmad-output/planning-artifacts/epics/requirements-inventory.md
@@ -42,7 +42,7 @@ NFR6: Build must pass: `dotnet build backend/JobNecto.slnx --configuration Relea
 NFR7: All tests must pass: `dotnet test backend/JobNecto.slnx --configuration Release --warnaserror`.
 NFR8: No nullable reference type warnings suppressed without documented justification.
 NFR9: OpenAPI spec auto-generated for all Phase B endpoints with request/response schemas, status codes (200, 201, 204, 400, 404, 409, 422, 500), and example bodies.
-NFR10: Pagination: `pageSize` min 1, max 100, default 20; request body max 1MB.
+NFR10: Pagination: cursor-based (`lastSeenId` + `lastSeenUpdatedAt`); `pageSize` min 1, max 100, default 20. Response shape: `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`. Request body max 1MB.
 NFR11: Zero breaking changes to Domain model entities after Phase B is complete.
 NFR12: Passwords must be stored only as one-way salted hashes; plaintext passwords are never persisted or returned, and any migration/backfill required to reach that state is part of auth readiness.
 NFR13: Any business rule surfaced as `409 Conflict` must be backed by a database-level uniqueness constraint and at least one integration test that exercises concurrent create/update attempts.

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -382,9 +382,9 @@ A job seeker can:
 
 **Acceptance Criteria:**
 - Return paginated list of user's resumes
-- Query params: `page` (1-indexed), `pageSize` (default 20, max 100)
+- Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `title`, `skills` (array), `salary`, `currency`, `workLocationType`, `updatedAt`
-- On success: return `200 OK` with `{ total, page, pageSize, items }`
+- On success: return `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`
 - Order by `updatedAt desc` (newest first)
 
 ---
@@ -491,11 +491,11 @@ A job seeker can:
 
 **Acceptance Criteria:**
 - Return paginated list of user's templates
-- Query params: `page` (1-indexed), `pageSize` (default 20)
+- Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `name`, `contentPreview` (first 200 chars), `createdAt`, `updatedAt`
 - Optional filter: `search` query param to search by name
 - Order by `updatedAt desc` (newest first)
-- On success: return `200 OK` with `{ total, page, pageSize, items }`
+- On success: return `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`
 
 ---
 
@@ -553,10 +553,10 @@ A job seeker can:
 
 **Acceptance Criteria:**
 - Return paginated list of user's cover letters
-- Query params: `page` (1-indexed), `pageSize` (default 20)
+- Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `vacancyId`, `vacancyTitle` (from linked Vacancy), `contentPreview` (first 200 chars), `createdAt`
 - Order by `createdAt desc` (newest first)
-- On success: return `200 OK` with `{ total, page, pageSize, items }`
+- On success: return `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`
 
 ---
 
@@ -599,10 +599,10 @@ A job seeker can:
 
 **Acceptance Criteria:**
 - Return paginated list of all vacancies (recent first)
-- Query params: `page` (1-indexed), `pageSize` (default 20, max 100)
+- Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `title`, `company`, `location`, `jobSource`, `salary`, `currency`, `matchScore`, `createdAt`
 - Order by `createdAt desc` (newest first)
-- On success: return `200 OK` with `{ total, page, pageSize, items }`
+- On success: return `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`
 
 ---
 
@@ -611,9 +611,9 @@ A job seeker can:
 **Acceptance Criteria:**
 - Accept POST request with filter object in body (not query params)
 - Filter criteria: `skills` (array, match any), `location` (string, partial match), `salaryMin` (number), `salaryMax` (number), `workLocationTypes` (array: remote/office/hybrid), `categories` (array), `experienceLevel` (enum), `excludeKeywords` (array)
-- Pagination: `page`, `pageSize` in filter body
+- Pagination: `pageSize`, `lastSeenId`, `lastSeenUpdatedAt` (cursor) in filter body
 - Return results matching ALL provided criteria (AND logic between fields; OR logic within arrays)
-- Return `200 OK` with same shape as List endpoint
+- Return `200 OK` with same shape as List endpoint: `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`
 - Return `400 Bad Request` if filter is malformed
 
 **Sample Request Body:**
@@ -627,8 +627,9 @@ A job seeker can:
   "categories": [],
   "experienceLevel": "mid",
   "excludeKeywords": [],
-  "page": 1,
-  "pageSize": 20
+  "pageSize": 20,
+  "lastSeenId": null,
+  "lastSeenUpdatedAt": null
 }
 ```
 

--- a/backend/src/JobNecto.API/Controllers/ResumesController.cs
+++ b/backend/src/JobNecto.API/Controllers/ResumesController.cs
@@ -76,6 +76,13 @@ public class ResumesController : ControllerBase
         if (!Guid.TryParse(userIdValue, out var userId))
             return Unauthorized();
 
+        if (lastSeenUpdatedAt.HasValue)
+        {
+            lastSeenUpdatedAt = lastSeenUpdatedAt.Value.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(lastSeenUpdatedAt.Value, DateTimeKind.Utc)
+                : lastSeenUpdatedAt.Value.ToUniversalTime();
+        }
+
         var query = new ListResumesQuery
         {
             UserId = userId,

--- a/backend/src/JobNecto.API/Controllers/ResumesController.cs
+++ b/backend/src/JobNecto.API/Controllers/ResumesController.cs
@@ -64,6 +64,7 @@ public class ResumesController : ControllerBase
     /// <returns>Paginated list of resumes for the current user.</returns>
     [HttpGet]
     [ProducesResponseType(typeof(PagedResult<ResumeResult>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<PagedResult<ResumeResult>>> ListAsync(
         [FromQuery] int pageSize = 20,

--- a/backend/src/JobNecto.API/Controllers/ResumesController.cs
+++ b/backend/src/JobNecto.API/Controllers/ResumesController.cs
@@ -1,5 +1,6 @@
 using JobNecto.API.Infrastructure;
 using JobNecto.Application.Resumes;
+using JobNecto.Domain.ValueObjects;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -51,5 +52,38 @@ public class ResumesController : ControllerBase
         // 4. Return 201 Created with Location header
         // Following the API pattern: /api/v1/resumes/{id}
         return Created($"/api/v1/resumes/{result.Id}", result);
+    }
+
+    /// <summary>
+    /// Returns a cursor-paginated list of resumes belonging to the current authenticated user.
+    /// </summary>
+    /// <param name="pageSize">Number of items per page (default 20, max 100).</param>
+    /// <param name="lastSeenId">Cursor: ID of the last seen resume from the previous page.</param>
+    /// <param name="lastSeenUpdatedAt">Cursor: UpdatedAt of the last seen resume from the previous page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Paginated list of resumes for the current user.</returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(PagedResult<ResumeResult>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<PagedResult<ResumeResult>>> ListAsync(
+        [FromQuery] int pageSize = 20,
+        [FromQuery] Guid? lastSeenId = null,
+        [FromQuery] DateTime? lastSeenUpdatedAt = null,
+        CancellationToken cancellationToken = default)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (!Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        var query = new ListResumesQuery
+        {
+            UserId = userId,
+            PageSize = pageSize,
+            LastSeenId = lastSeenId,
+            LastSeenUpdatedAt = lastSeenUpdatedAt,
+        };
+
+        var result = await _mediator.Send(query, cancellationToken);
+        return Ok(result);
     }
 }

--- a/backend/src/JobNecto.Application/Resumes/ListResumesHandler.cs
+++ b/backend/src/JobNecto.Application/Resumes/ListResumesHandler.cs
@@ -1,0 +1,52 @@
+using MediatR;
+using JobNecto.Application.Interfaces;
+using JobNecto.Application.Resumes.Mappers;
+using JobNecto.Domain.ValueObjects;
+
+namespace JobNecto.Application.Resumes;
+
+/// <summary>
+/// Handler for <see cref="ListResumesQuery"/>. Returns a cursor-paginated list of the user's resumes.
+/// </summary>
+public class ListResumesQueryHandler : IRequestHandler<ListResumesQuery, PagedResult<ResumeResult>>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ListResumesQueryHandler"/>.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work providing repository access.</param>
+    public ListResumesQueryHandler(IUnitOfWork unitOfWork) => _unitOfWork = unitOfWork;
+
+    /// <summary>
+    /// Handles the list resumes query: pages through user-scoped resume records and projects entities to DTOs.
+    /// </summary>
+    /// <param name="request">The query parameters including user ID, page size, and cursor values.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A paginated result of <see cref="ResumeResult"/> DTOs.</returns>
+    public async Task<PagedResult<ResumeResult>> Handle(ListResumesQuery request, CancellationToken cancellationToken)
+    {
+        var cappedPageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, 100);
+
+        var pagedQuery = new PagedQuery
+        {
+            UserId = request.UserId,
+            PageSize = cappedPageSize,
+            LastSeenId = request.LastSeenId,
+            LastSeenUpdatedAt = request.LastSeenUpdatedAt,
+        };
+
+        var result = await _unitOfWork.ResumeRepository.GetAsync(pagedQuery, cancellationToken);
+
+        var projectedItems = result.Items.Select(r => r.ToResumeResult()).ToList();
+
+        return new PagedResult<ResumeResult>(
+            projectedItems,
+            result.TotalCount,
+            result.LastSeenId,
+            result.LastSeenUpdatedAt,
+            result.PageSize,
+            result.HasNext
+        );
+    }
+}

--- a/backend/src/JobNecto.Application/Resumes/ListResumesQuery.cs
+++ b/backend/src/JobNecto.Application/Resumes/ListResumesQuery.cs
@@ -1,5 +1,3 @@
-using JobNecto.Application.Interfaces;
-using JobNecto.Application.Resumes.Mappers;
 using JobNecto.Domain.ValueObjects;
 using MediatR;
 using System.Text.Json.Serialization;
@@ -32,50 +30,4 @@ public class ListResumesQuery : IRequest<PagedResult<ResumeResult>>
     /// Cursor: UpdatedAt timestamp of the last seen resume. Used together with LastSeenId.
     /// </summary>
     public DateTime? LastSeenUpdatedAt { get; set; }
-}
-
-/// <summary>
-/// Handler for <see cref="ListResumesQuery"/>. Returns a cursor-paginated list of the user's resumes.
-/// </summary>
-public class ListResumesQueryHandler : IRequestHandler<ListResumesQuery, PagedResult<ResumeResult>>
-{
-    private readonly IUnitOfWork _unitOfWork;
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ListResumesQueryHandler"/>.
-    /// </summary>
-    /// <param name="unitOfWork">Unit of work providing repository access.</param>
-    public ListResumesQueryHandler(IUnitOfWork unitOfWork) => _unitOfWork = unitOfWork;
-
-    /// <summary>
-    /// Handles the list resumes query: pages through user-scoped resume records and projects entities to DTOs.
-    /// </summary>
-    /// <param name="request">The query parameters including user ID, page size, and cursor values.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A paginated result of <see cref="ResumeResult"/> DTOs.</returns>
-    public async Task<PagedResult<ResumeResult>> Handle(ListResumesQuery request, CancellationToken cancellationToken)
-    {
-        var cappedPageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, 100);
-
-        var pagedQuery = new PagedQuery
-        {
-            UserId = request.UserId,
-            PageSize = cappedPageSize,
-            LastSeenId = request.LastSeenId,
-            LastSeenUpdatedAt = request.LastSeenUpdatedAt,
-        };
-
-        var result = await _unitOfWork.ResumeRepository.GetAsync(pagedQuery, cancellationToken);
-
-        var projectedItems = result.Items.Select(r => r.ToResumeResult()).ToList();
-
-        return new PagedResult<ResumeResult>(
-            projectedItems,
-            result.TotalCount,
-            result.LastSeenId,
-            result.LastSeenUpdatedAt,
-            result.PageSize,
-            result.HasNext
-        );
-    }
 }

--- a/backend/src/JobNecto.Application/Resumes/ListResumesQuery.cs
+++ b/backend/src/JobNecto.Application/Resumes/ListResumesQuery.cs
@@ -1,0 +1,81 @@
+using JobNecto.Application.Interfaces;
+using JobNecto.Application.Resumes.Mappers;
+using JobNecto.Domain.ValueObjects;
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.Resumes;
+
+/// <summary>
+/// Query to retrieve a paginated list of resumes for the current user.
+/// </summary>
+public class ListResumesQuery : IRequest<PagedResult<ResumeResult>>
+{
+    /// <summary>
+    /// ID of the authenticated user making the request.
+    /// Set by the API controller from the current security context.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Number of items per page. Defaults to 20, capped at 100.
+    /// </summary>
+    public int PageSize { get; set; } = 20;
+
+    /// <summary>
+    /// Cursor: ID of the last seen resume. Used to advance the page window.
+    /// </summary>
+    public Guid? LastSeenId { get; set; }
+
+    /// <summary>
+    /// Cursor: UpdatedAt timestamp of the last seen resume. Used together with LastSeenId.
+    /// </summary>
+    public DateTime? LastSeenUpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Handler for <see cref="ListResumesQuery"/>. Returns a cursor-paginated list of the user's resumes.
+/// </summary>
+public class ListResumesQueryHandler : IRequestHandler<ListResumesQuery, PagedResult<ResumeResult>>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ListResumesQueryHandler"/>.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work providing repository access.</param>
+    public ListResumesQueryHandler(IUnitOfWork unitOfWork) => _unitOfWork = unitOfWork;
+
+    /// <summary>
+    /// Handles the list resumes query: pages through user-scoped resume records and projects entities to DTOs.
+    /// </summary>
+    /// <param name="request">The query parameters including user ID, page size, and cursor values.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A paginated result of <see cref="ResumeResult"/> DTOs.</returns>
+    public async Task<PagedResult<ResumeResult>> Handle(ListResumesQuery request, CancellationToken cancellationToken)
+    {
+        var cappedPageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, 100);
+
+        var pagedQuery = new PagedQuery
+        {
+            UserId = request.UserId,
+            PageSize = cappedPageSize,
+            LastSeenId = request.LastSeenId,
+            LastSeenUpdatedAt = request.LastSeenUpdatedAt,
+        };
+
+        var result = await _unitOfWork.ResumeRepository.GetAsync(pagedQuery, cancellationToken);
+
+        var projectedItems = result.Items.Select(r => r.ToResumeResult()).ToList();
+
+        return new PagedResult<ResumeResult>(
+            projectedItems,
+            result.TotalCount,
+            result.LastSeenId,
+            result.LastSeenUpdatedAt,
+            result.PageSize,
+            result.HasNext
+        );
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
+++ b/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
@@ -176,6 +176,51 @@ public class ResumesControllerTests
     }
 
     // ──────────────────────────────────────────────────────────────────
+    //  AC 4: cursor params return the next page window
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_WithCursorParams_ReturnsNextSlice()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+        await SeedResumesAsync(client, authCookie, 5);
+
+        var firstPageResponse = await GetResumesAsync(client, authCookie, "?pageSize=2");
+        firstPageResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var firstPageBody = await firstPageResponse.Content.ReadAsStringAsync();
+        var firstPage = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(firstPageBody, JsonOpts);
+
+        firstPage.Should().NotBeNull();
+        firstPage!.Items.Should().HaveCount(2);
+        firstPage.HasNext.Should().BeTrue();
+        firstPage.LastSeenId.Should().NotBeNull();
+        firstPage.LastSeenUpdatedAt.Should().NotBeNull();
+
+        var cursorQuery =
+            $"?pageSize=2&lastSeenId={firstPage.LastSeenId}&lastSeenUpdatedAt={Uri.EscapeDataString(firstPage.LastSeenUpdatedAt!.Value.ToString("o"))}";
+
+        var secondPageResponse = await GetResumesAsync(client, authCookie, cursorQuery);
+        secondPageResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var secondPageBody = await secondPageResponse.Content.ReadAsStringAsync();
+        var secondPage = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(secondPageBody, JsonOpts);
+
+        secondPage.Should().NotBeNull();
+        secondPage!.Items.Should().HaveCount(2);
+
+        var firstPageIds = firstPage.Items.Select(x => x.Id).ToHashSet();
+        var secondPageIds = secondPage.Items.Select(x => x.Id).ToHashSet();
+        secondPageIds.Intersect(firstPageIds).Should().BeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
     //  AC 3: pageSize < 1 treated as default (20)
     // ──────────────────────────────────────────────────────────────────
 

--- a/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
+++ b/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
@@ -220,6 +220,47 @@ public class ResumesControllerTests
         secondPageIds.Intersect(firstPageIds).Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task List_WithCursorTimestampWithoutTimezone_ReturnsNextSlice()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+        await SeedResumesAsync(client, authCookie, 5);
+
+        var firstPageResponse = await GetResumesAsync(client, authCookie, "?pageSize=2");
+        firstPageResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var firstPageBody = await firstPageResponse.Content.ReadAsStringAsync();
+        var firstPage = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(firstPageBody, JsonOpts);
+
+        firstPage.Should().NotBeNull();
+        firstPage!.Items.Should().HaveCount(2);
+        firstPage.LastSeenId.Should().NotBeNull();
+        firstPage.LastSeenUpdatedAt.Should().NotBeNull();
+
+        var timestampWithoutTimezone = firstPage.LastSeenUpdatedAt!.Value.ToString("yyyy-MM-ddTHH:mm:ss.fffffff");
+        var cursorQuery =
+            $"?pageSize=2&lastSeenId={firstPage.LastSeenId}&lastSeenUpdatedAt={Uri.EscapeDataString(timestampWithoutTimezone)}";
+
+        var secondPageResponse = await GetResumesAsync(client, authCookie, cursorQuery);
+        secondPageResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var secondPageBody = await secondPageResponse.Content.ReadAsStringAsync();
+        var secondPage = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(secondPageBody, JsonOpts);
+
+        secondPage.Should().NotBeNull();
+        secondPage!.Items.Should().HaveCount(2);
+
+        var firstPageIds = firstPage.Items.Select(x => x.Id).ToHashSet();
+        var secondPageIds = secondPage.Items.Select(x => x.Id).ToHashSet();
+        secondPageIds.Intersect(firstPageIds).Should().BeEmpty();
+    }
+
     // ──────────────────────────────────────────────────────────────────
     //  AC 3: pageSize < 1 treated as default (20)
     // ──────────────────────────────────────────────────────────────────

--- a/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
+++ b/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
@@ -1,0 +1,228 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using JobNecto.Application.Resumes;
+using JobNecto.Application.Users;
+using JobNecto.Domain.ValueObjects;
+
+namespace JobNecto.Tests.API;
+
+public class ResumesControllerTests
+{
+    // ──────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    private static CreateUserCommand NewUserCommand(string prefix = "user") => new()
+    {
+        LoginName = prefix + Guid.NewGuid().ToString("N")[..8],
+        Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+        Password = "Password123!"
+    };
+
+    private static CreateResumeCommand NewResumeCommand(string title = "Test Resume") => new()
+    {
+        Title = title,
+        Skills = ["C#", "SQL"],
+        WorkLocationType = "remote",
+    };
+
+    /// <summary>Creates a user and returns the auth-token cookie value (e.g. "auth-token=eyJ...").</summary>
+    private static async Task<string> CreateUserAndGetCookieAsync(HttpClient client, CreateUserCommand? cmd = null)
+    {
+        cmd ??= NewUserCommand();
+        var resp = await client.PostAsJsonAsync("/api/v1/users", cmd);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var authCookie = resp.Headers
+            .GetValues("Set-Cookie")
+            .Select(h => h.Split(';', StringSplitOptions.TrimEntries)
+                          .FirstOrDefault(p => p.StartsWith("auth-token=", StringComparison.OrdinalIgnoreCase)))
+            .First(c => !string.IsNullOrWhiteSpace(c));
+
+        authCookie.Should().NotBeNullOrWhiteSpace();
+        return authCookie!;
+    }
+
+    /// <summary>Sends an authenticated GET to /api/v1/resumes.</summary>
+    private static async Task<HttpResponseMessage> GetResumesAsync(
+        HttpClient client, string authCookie, string queryString = "")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/resumes{queryString}");
+        req.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(req);
+    }
+
+    /// <summary>Seeds n resumes for the authenticated user and returns the last posted title.</summary>
+    private static async Task SeedResumesAsync(HttpClient client, string authCookie, int count, string titlePrefix = "Resume")
+    {
+        for (var i = 1; i <= count; i++)
+        {
+            var cmd = NewResumeCommand($"{titlePrefix} {i}");
+            var req = new HttpRequestMessage(HttpMethod.Post, "/api/v1/resumes")
+            {
+                Content = JsonContent.Create(cmd)
+            };
+            req.Headers.TryAddWithoutValidation("Cookie", authCookie);
+            var resp = await client.SendAsync(req);
+            resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts =
+        new() { PropertyNameCaseInsensitive = true };
+
+    // ──────────────────────────────────────────────────────────────────
+    //  AC 1: Authentication required
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/v1/resumes");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  AC 5: No resumes → empty list
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_UserHasNoResumes_Returns200WithEmptyItems()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+
+        var resp = await GetResumesAsync(client, authCookie);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(body, JsonOpts);
+
+        result.Should().NotBeNull();
+        result!.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  AC 2: Returns only current user's resumes
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_ReturnsOnlyCurrentUserResumes_NotOtherUsers()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        // User A creates 2 resumes
+        var cookieA = await CreateUserAndGetCookieAsync(client, NewUserCommand("user_a"));
+        await SeedResumesAsync(client, cookieA, 2, "UserA Resume");
+
+        // User B creates 1 resume
+        var cookieB = await CreateUserAndGetCookieAsync(client, NewUserCommand("user_b"));
+        await SeedResumesAsync(client, cookieB, 1, "UserB Resume");
+
+        // User B should only see their own 1 resume
+        var resp = await GetResumesAsync(client, cookieB);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(body, JsonOpts);
+
+        result!.TotalCount.Should().Be(1);
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Title.Should().StartWith("UserB Resume");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  AC 3: pageSize query param is respected
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_WithPageSizeParam_ReturnsCorrectCount()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+        await SeedResumesAsync(client, authCookie, 5);
+
+        var resp = await GetResumesAsync(client, authCookie, "?pageSize=3");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(body, JsonOpts);
+
+        result!.Items.Should().HaveCount(3);
+        result.TotalCount.Should().Be(5);
+        result.HasNext.Should().BeTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  AC 3: pageSize < 1 treated as default (20)
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_WithPageSizeBelowOne_DefaultsToTwenty()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+        await SeedResumesAsync(client, authCookie, 3);
+
+        var resp = await GetResumesAsync(client, authCookie, "?pageSize=0");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(body, JsonOpts);
+
+        result!.PageSize.Should().Be(20);
+        result.Items.Should().HaveCount(3); // all 3 fit within the default page
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  AC 3: pageSize > 100 is capped
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_WithPageSizeAbove100_IsCappedAt100()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+        await SeedResumesAsync(client, authCookie, 3);
+
+        var resp = await GetResumesAsync(client, authCookie, "?pageSize=500");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(body, JsonOpts);
+
+        result!.PageSize.Should().Be(100);
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
+++ b/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
@@ -202,6 +202,26 @@ public class ResumesControllerTests
     }
 
     // ──────────────────────────────────────────────────────────────────
+    //  AC 3: non-numeric pageSize returns 400 (ApiController model binding)
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_WithInvalidPageSizeFormat_Returns400()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+
+        var resp = await GetResumesAsync(client, authCookie, "?pageSize=abc");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
     //  AC 3: pageSize > 100 is capped
     // ──────────────────────────────────────────────────────────────────
 

--- a/backend/tests/JobNecto.Tests/Application/Resumes/ListResumesHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/ListResumesHandlerTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Application.Resumes;
+using JobNecto.Domain.Entities;
+using JobNecto.Domain.ValueObjects;
+using Moq;
+
+namespace JobNecto.Tests.Application.Resumes;
+
+public class ListResumesHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<IEditableRepository<Resume>> _resumeRepoMock;
+    private readonly ListResumesQueryHandler _handler;
+
+    public ListResumesHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _resumeRepoMock = new Mock<IEditableRepository<Resume>>();
+        _uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object);
+        _handler = new ListResumesQueryHandler(_uowMock.Object);
+    }
+
+    private static PagedResult<Resume> MakePagedResult(IReadOnlyList<Resume> items, bool hasNext = false) =>
+        new(items, items.Count, items.LastOrDefault()?.Id, items.LastOrDefault()?.UpdatedAt, 20, hasNext);
+
+    [Fact]
+    public async Task Handle_ForwardsCorrectPagedQueryToRepository()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var lastSeenId = Guid.NewGuid();
+        var lastSeenUpdatedAt = DateTime.UtcNow.AddMinutes(-5);
+
+        var query = new ListResumesQuery
+        {
+            UserId = userId,
+            PageSize = 10,
+            LastSeenId = lastSeenId,
+            LastSeenUpdatedAt = lastSeenUpdatedAt,
+        };
+
+        PagedQuery? capturedQuery = null;
+        _resumeRepoMock
+            .Setup(x => x.GetAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(MakePagedResult([]));
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.UserId.Should().Be(userId);
+        capturedQuery.PageSize.Should().Be(10);
+        capturedQuery.LastSeenId.Should().Be(lastSeenId);
+        capturedQuery.LastSeenUpdatedAt.Should().Be(lastSeenUpdatedAt);
+    }
+
+    [Fact]
+    public async Task Handle_PageSizeAbove100_IsCappedAt100()
+    {
+        // Arrange
+        var query = new ListResumesQuery
+        {
+            UserId = Guid.NewGuid(),
+            PageSize = 999,
+        };
+
+        PagedQuery? capturedQuery = null;
+        _resumeRepoMock
+            .Setup(x => x.GetAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(MakePagedResult([]));
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        capturedQuery!.PageSize.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task Handle_PageSizeBelowOne_DefaultsToTwenty()
+    {
+        // Arrange
+        var query = new ListResumesQuery
+        {
+            UserId = Guid.NewGuid(),
+            PageSize = 0,
+        };
+
+        PagedQuery? capturedQuery = null;
+        _resumeRepoMock
+            .Setup(x => x.GetAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(MakePagedResult([]));
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert — AC 3: values < 1 treated as default (20)
+        capturedQuery!.PageSize.Should().Be(20);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyRepository_ReturnsEmptyPagedResult()
+    {
+        // Arrange
+        var query = new ListResumesQuery { UserId = Guid.NewGuid() };
+
+        _resumeRepoMock
+            .Setup(x => x.GetAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakePagedResult([]));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+        result.HasNext.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_MapsEntitiesToResumeResult()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var resume = new Resume
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Title = "Backend Dev",
+            Skills = ["C#", "SQL"],
+            WorkLocationType = Domain.Enums.WorkLocationType.Remote,
+        };
+
+        _resumeRepoMock
+            .Setup(x => x.GetAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakePagedResult([resume]));
+
+        var query = new ListResumesQuery { UserId = userId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(1);
+        var item = result.Items[0];
+        item.Id.Should().Be(resume.Id);
+        item.Title.Should().Be(resume.Title);
+        item.Skills.Should().BeEquivalentTo(resume.Skills);
+    }
+
+    [Fact]
+    public async Task Handle_PreservesPagedResultMetadata()
+    {
+        // Arrange
+        var lastSeenId = Guid.NewGuid();
+        var lastSeenUpdatedAt = DateTime.UtcNow;
+
+        var pagedResult = new PagedResult<Resume>([], 42, lastSeenId, lastSeenUpdatedAt, 20, true);
+
+        _resumeRepoMock
+            .Setup(x => x.GetAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pagedResult);
+
+        var query = new ListResumesQuery { UserId = Guid.NewGuid() };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.TotalCount.Should().Be(42);
+        result.LastSeenId.Should().Be(lastSeenId);
+        result.LastSeenUpdatedAt.Should().Be(lastSeenUpdatedAt);
+        result.PageSize.Should().Be(20);
+        result.HasNext.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements Story 2.2 (List Resumes) end-to-end and updates project planning/instruction documents to consistently use cursor-based pagination.

## What changed
- Added `ListResumesQuery` and `ListResumesQueryHandler` in Application layer
- Added `GET /api/v1/resumes` endpoint to `ResumesController`
- Added unit tests for handler behavior and paging rules
- Added API integration tests for auth, user scoping, and page size semantics
- Updated story artifact and sprint/deferred tracking docs
- Updated PRD/architecture/epics/requirements docs from offset pagination to cursor pagination
- Updated AGENTS workflow guidance and mandatory document update list

## Validation
- `dotnet test backend/JobNecto.slnx` passed

## Commits
- `feat(resumes): implement story 2.2 list resumes endpoint`
- `docs: align pagination spec and agent workflow guidance`