### PR TITLE
Story 2.5: Soft-delete resume endpoint

### DIFF
--- a/_bmad-output/implementation-artifacts/2-5-delete-resume.md
+++ b/_bmad-output/implementation-artifacts/2-5-delete-resume.md
@@ -1,0 +1,114 @@
+# Story 2.5: Delete Resume
+
+Status: review
+
+## Story
+
+As a job seeker,
+I want to soft-delete a resume I no longer need,
+so that it disappears from my list without permanent data loss.
+
+## Acceptance Criteria
+
+1. `DELETE /api/v1/resumes/{id}` requires a valid JWT token. Unauthenticated requests return `401 Unauthorized`.
+2. Given a valid JWT token and a resume ID that belongs to the current user, returns `204 No Content`; `IsDeleted` is set to `true` and `DeletedAt` is set to now.
+3. After soft-delete, `GET /api/v1/resumes` does not include the deleted resume.
+4. After soft-delete, `GET /api/v1/resumes/{id}` returns `404 Not Found`.
+5. If the resume does not exist, `DELETE /api/v1/resumes/{id}` returns `404 Not Found`.
+6. If the resume belongs to a different user, `DELETE /api/v1/resumes/{id}` returns `403 Forbidden`.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Define Application delete contract and validation (AC: 2, 5, 6)
+  - [x] Create `DeleteResumeCommand.cs` in `backend/src/JobNecto.Application/Resumes/` with `ResumeId` and `UserId` set by route/auth context.
+  - [x] Create `Validators/DeleteResumeCommandValidator.cs` with `ResumeId` and `UserId` non-empty checks.
+
+- [x] Task 2: Implement handler ownership and soft-delete flow (AC: 2, 5, 6)
+  - [x] Create `DeleteResumeCommandHandler.cs` in `backend/src/JobNecto.Application/Resumes/`.
+  - [x] Load resume via `_unitOfWork.ResumeRepository.GetByIdAsync(request.ResumeId, cancellationToken)`.
+  - [x] Enforce ownership: if `resume.UserId != request.UserId`, throw `ForbiddenException`.
+  - [x] Set `resume.IsDeleted = true` and `resume.DeletedAt = DateTime.UtcNow`.
+  - [x] Persist via `_unitOfWork.ResumeRepository.UpdateAsync(resume, cancellationToken)` and `_unitOfWork.SaveChangesAsync(cancellationToken)`.
+
+- [x] Task 3: Expose HTTP endpoint (AC: 1, 2, 5, 6)
+  - [x] Update `backend/src/JobNecto.API/Controllers/ResumesController.cs` with `[HttpDelete("{id:guid}")]` action.
+  - [x] Add response contracts for `204`, `401`, `403`, and `404`.
+  - [x] Extract `UserId` via `HttpContext.GetCurrentUserId()` and return `Unauthorized()` on parse failure.
+  - [x] Dispatch command via MediatR and return `NoContent()`.
+
+- [x] Task 4: Add handler unit tests (AC: 2, 5, 6)
+  - [x] Create `backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs`.
+  - [x] Verify owned delete sets soft-delete fields and persists once.
+  - [x] Verify missing resume propagates `NotFoundException`.
+  - [x] Verify cross-user delete throws `ForbiddenException` and does not persist.
+
+- [x] Task 5: Extend API integration tests (AC: 1-6)
+  - [x] Extend `backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs` with:
+    - [x] delete without token -> `401`
+    - [x] owned delete -> `204`
+    - [x] non-existent id -> `404`
+    - [x] cross-user delete -> `403`
+    - [x] list excludes deleted resume after delete
+    - [x] detail returns `404` after delete
+
+- [x] Task 6: Verification gates
+  - [x] Run targeted tests for delete flow.
+  - [x] Run full suite: `dotnet test backend/JobNecto.slnx`.
+  - [x] Run CI parity build/test with Release + warn-as-error.
+
+## Dev Notes
+
+### Technical Requirements
+
+- Keep Clean Architecture boundaries: API -> Application -> Domain.
+- Reuse existing `IUnitOfWork` + `IEditableRepository<Resume>` abstractions.
+- Do not add migration/schema changes for this story.
+- Rely on global soft-delete query filter in `AppDbContext` for list/detail exclusion behavior.
+- `GlobalExceptionHandler` already maps:
+  - `NotFoundException` -> `404`
+  - `ForbiddenException` -> `403`
+
+### References
+
+- `_bmad-output/planning-artifacts/epics/epic-2-resume-education-management.md`
+- `_bmad-output/planning-artifacts/epics/requirements-inventory.md`
+- `backend/src/JobNecto.API/Controllers/ResumesController.cs`
+- `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`
+- `backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GitHub Copilot (GPT-5.3-Codex)
+
+### Debug Log References
+
+- `dotnet test backend/JobNecto.slnx --filter "FullyQualifiedName~DeleteResume"` (green, 3/3)
+- `runTests(mode=run)` (green, 223/223)
+- `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` (green)
+- `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror *> $null; Write-Host "EXIT:$LASTEXITCODE"` (EXIT:0)
+
+### Completion Notes List
+
+- Added `DeleteResumeCommand` and `DeleteResumeCommandValidator` to define a validated delete contract.
+- Added `DeleteResumeCommandHandler` with ownership enforcement (`ForbiddenException`) and soft-delete field mutation.
+- Added `DELETE /api/v1/resumes/{id}` endpoint in `ResumesController` with `204/401/403/404` contract.
+- Added `DeleteResumeCommandHandlerTests` to cover success, not found, and cross-user authorization behavior.
+- Extended `ResumesControllerTests` with Story 2.5 integration coverage, including post-delete list/detail behavior.
+- Verified targeted, full-suite, and Release warn-as-error CI-parity gates.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/2-5-delete-resume.md`
+- `backend/src/JobNecto.Application/Resumes/DeleteResumeCommand.cs`
+- `backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs`
+- `backend/src/JobNecto.Application/Resumes/Validators/DeleteResumeCommandValidator.cs`
+- `backend/src/JobNecto.API/Controllers/ResumesController.cs`
+- `backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs`
+- `backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs`
+
+## Change Log
+
+- 2026-05-01: Created Story 2.5 implementation artifact and task checklist.
+- 2026-05-01: Implemented Story 2.5 endpoint/application flow, added unit/integration tests, and completed verification gates.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-04-30T00:00:00Z
+# last_updated: 2026-05-01T00:00:00Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -49,7 +49,7 @@ development_status:
   2-2-list-resumes: done
   2-3-get-resume-detail: done
   2-4-update-resume: done
-  2-5-delete-resume: backlog
+  2-5-delete-resume: review
   2-6-create-education-record: backlog
   2-7-list-education-records: backlog
   2-8-get-update-delete-education-records: backlog

--- a/backend/src/JobNecto.API/Controllers/ResumesController.cs
+++ b/backend/src/JobNecto.API/Controllers/ResumesController.cs
@@ -146,4 +146,34 @@ public class ResumesController : ControllerBase
         var result = await _mediator.Send(command, cancellationToken);
         return Ok(result);
     }
+
+    /// <summary>
+    /// Soft-deletes an existing resume owned by the current authenticated user.
+    /// </summary>
+    /// <param name="id">The resume ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>No content when delete succeeds.</returns>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteAsync(
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (!Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        var command = new DeleteResumeCommand
+        {
+            ResumeId = id,
+            UserId = userId,
+        };
+
+        await _mediator.Send(command, cancellationToken);
+        return NoContent();
+    }
 }

--- a/backend/src/JobNecto.Application/Resumes/DeleteResumeCommand.cs
+++ b/backend/src/JobNecto.Application/Resumes/DeleteResumeCommand.cs
@@ -1,0 +1,22 @@
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.Resumes;
+
+/// <summary>
+/// Command for soft-deleting an existing resume.
+/// </summary>
+public class DeleteResumeCommand : IRequest<Unit>
+{
+    /// <summary>
+    /// Resume identifier from route.
+    /// </summary>
+    [JsonIgnore]
+    public Guid ResumeId { get; set; }
+
+    /// <summary>
+    /// Authenticated user identifier from security context.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+}

--- a/backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs
+++ b/backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs
@@ -1,0 +1,39 @@
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using MediatR;
+
+namespace JobNecto.Application.Resumes;
+
+/// <summary>
+/// Handles resume soft-delete requests.
+/// </summary>
+public class DeleteResumeCommandHandler : IRequestHandler<DeleteResumeCommand, Unit>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeleteResumeCommandHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public DeleteResumeCommandHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<Unit> Handle(DeleteResumeCommand request, CancellationToken cancellationToken)
+    {
+        var resume = await _unitOfWork.ResumeRepository.GetByIdAsync(request.ResumeId, cancellationToken);
+
+        if (resume.UserId != request.UserId)
+            throw new ForbiddenException("You do not have permission to delete this resume.");
+
+        resume.IsDeleted = true;
+        resume.DeletedAt = DateTime.UtcNow;
+
+        await _unitOfWork.ResumeRepository.UpdateAsync(resume, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/backend/src/JobNecto.Application/Resumes/Validators/DeleteResumeCommandValidator.cs
+++ b/backend/src/JobNecto.Application/Resumes/Validators/DeleteResumeCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace JobNecto.Application.Resumes.Validators;
+
+/// <summary>
+/// Validator for <see cref="DeleteResumeCommand"/>.
+/// </summary>
+public class DeleteResumeCommandValidator : AbstractValidator<DeleteResumeCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeleteResumeCommandValidator"/> class.
+    /// </summary>
+    public DeleteResumeCommandValidator()
+    {
+        RuleFor(x => x.ResumeId)
+            .NotEmpty().WithMessage("resumeId is required.");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("userId is required.");
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
+++ b/backend/tests/JobNecto.Tests/API/ResumesControllerTests.cs
@@ -109,6 +109,17 @@ public class ResumesControllerTests
         return await client.SendAsync(request);
     }
 
+    private static async Task<HttpResponseMessage> DeleteResumeAsync(
+        HttpClient client,
+        string authCookie,
+        Guid resumeId)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/resumes/{resumeId}");
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+
+        return await client.SendAsync(request);
+    }
+
     // ──────────────────────────────────────────────────────────────────
     //  AC 1: Authentication required
     // ──────────────────────────────────────────────────────────────────
@@ -671,6 +682,103 @@ public class ResumesControllerTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Contain("At least one updatable field must be provided.");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  Story 2.5: DELETE /api/v1/resumes/{id}
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.DeleteAsync($"/api/v1/resumes/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Delete_OwnedResume_Returns204_AndDeletedResumeIsHiddenFromListAndDetail()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+        var created = await CreateResumeAsync(client, authCookie, "Delete Me");
+
+        var deleteResponse = await DeleteResumeAsync(client, authCookie, created.Id);
+
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var detailResponse = await GetResumeByIdAsync(client, authCookie, created.Id);
+        detailResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var listResponse = await GetResumesAsync(client, authCookie);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await listResponse.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PagedResult<ResumeResult>>(body, JsonOpts);
+
+        result.Should().NotBeNull();
+        result!.Items.Should().NotContain(x => x.Id == created.Id);
+    }
+
+    [Fact]
+    public async Task Delete_NonExistentId_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+
+        var response = await DeleteResumeAsync(client, authCookie, Guid.NewGuid());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_EmptyResumeId_Returns400WithValidationErrors()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var authCookie = await CreateUserAndGetCookieAsync(client);
+
+        var response = await DeleteResumeAsync(client, authCookie, Guid.Empty);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("resumeId is required.");
+    }
+
+    [Fact]
+    public async Task Delete_ResumeBelongingToDifferentUser_Returns403()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false
+        });
+
+        var ownerCookie = await CreateUserAndGetCookieAsync(client, NewUserCommand("owner_delete"));
+        var created = await CreateResumeAsync(client, ownerCookie, "Owner Resume");
+
+        var attackerCookie = await CreateUserAndGetCookieAsync(client, NewUserCommand("attacker_delete"));
+        var response = await DeleteResumeAsync(client, attackerCookie, created.Id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 }
 

--- a/backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Application.Resumes;
+using JobNecto.Domain.Entities;
+using MediatR;
+using Moq;
+
+namespace JobNecto.Tests.Application.Resumes;
+
+public class DeleteResumeCommandHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<IEditableRepository<Resume>> _resumeRepoMock;
+    private readonly DeleteResumeCommandHandler _handler;
+
+    public DeleteResumeCommandHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _resumeRepoMock = new Mock<IEditableRepository<Resume>>();
+        _uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object);
+        _handler = new DeleteResumeCommandHandler(_uowMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_OwnedResume_SetsSoftDeleteFlagsAndPersists()
+    {
+        var userId = Guid.NewGuid();
+        var resume = new Resume
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Title = "Resume",
+            Skills = ["C#"],
+            IsDeleted = false,
+            DeletedAt = null,
+        };
+
+        var command = new DeleteResumeCommand
+        {
+            ResumeId = resume.Id,
+            UserId = userId,
+        };
+
+        _resumeRepoMock
+            .Setup(x => x.GetByIdAsync(resume.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resume);
+
+        _resumeRepoMock
+            .Setup(x => x.UpdateAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Resume entity, CancellationToken _) => entity);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Should().Be(Unit.Value);
+        resume.IsDeleted.Should().BeTrue();
+        resume.DeletedAt.Should().NotBeNull();
+        resume.DeletedAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
+
+        _resumeRepoMock.Verify(x => x.UpdateAsync(resume, It.IsAny<CancellationToken>()), Times.Once);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ResumeNotFound_PropagatesNotFoundException()
+    {
+        var resumeId = Guid.NewGuid();
+
+        var command = new DeleteResumeCommand
+        {
+            ResumeId = resumeId,
+            UserId = Guid.NewGuid(),
+        };
+
+        _resumeRepoMock
+            .Setup(x => x.GetByIdAsync(resumeId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("Resume", resumeId));
+
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _resumeRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_CrossUserDelete_ThrowsForbiddenException()
+    {
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+
+        var resume = new Resume
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            Title = "Owner resume",
+            Skills = ["C#"],
+        };
+
+        var command = new DeleteResumeCommand
+        {
+            ResumeId = resume.Id,
+            UserId = attackerId,
+        };
+
+        _resumeRepoMock
+            .Setup(x => x.GetByIdAsync(resume.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resume);
+
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _resumeRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandValidatorTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using JobNecto.Application.Resumes;
+using JobNecto.Application.Resumes.Validators;
+
+namespace JobNecto.Tests.Application.Resumes;
+
+public class DeleteResumeCommandValidatorTests
+{
+    private readonly DeleteResumeCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_EmptyResumeId_Fails()
+    {
+        var command = new DeleteResumeCommand
+        {
+            ResumeId = Guid.Empty,
+            UserId = Guid.NewGuid(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "ResumeId");
+    }
+
+    [Fact]
+    public void Validate_EmptyUserId_Fails()
+    {
+        var command = new DeleteResumeCommand
+        {
+            ResumeId = Guid.NewGuid(),
+            UserId = Guid.Empty,
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "UserId");
+    }
+
+    [Fact]
+    public void Validate_ValidCommand_Passes()
+    {
+        var command = new DeleteResumeCommand
+        {
+            ResumeId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Story 2.5: Delete Resume

As a job seeker, I want to soft-delete a resume I no longer need, so that it disappears from my list without permanent data loss.

### Implementation

#### Application Layer
- `DeleteResumeCommand`: Route/auth context identifiers with `[JsonIgnore]` properties
- `DeleteResumeCommandValidator`: Enforces non-empty `ResumeId` and `UserId`
- `DeleteResumeCommandHandler`: 
  - Loads resume via repository
  - Enforces ownership (throws `ForbiddenException` on cross-user attempt)
  - Sets `IsDeleted = true` and `DeletedAt = DateTime.UtcNow`
  - Persists via unit of work

#### API Layer
- `DELETE /api/v1/resumes/{id}` endpoint
- Response contracts: `204 No Content`, `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`
- Auth context extraction via `HttpContext.GetCurrentUserId()`

#### Testing
- **Unit tests** (`DeleteResumeCommandValidatorTests`):
  - Empty ResumeId → invalid
  - Empty UserId → invalid
  - Valid command → passes

- **Unit tests** (`DeleteResumeCommandHandlerTests`):
  - Owned resume soft-delete → sets flags, persists once
  - Missing resume → propagates `NotFoundException`
  - Cross-user delete → throws `ForbiddenException`, no persist

- **Integration tests** (`ResumesControllerTests.Delete_*`):
  - No token → `401`
  - Owned delete → `204`, excluded from list/detail
  - Non-existent ID → `404`
  - **Empty route ID → `400` with validation error** (review finding resolution)
  - Cross-user delete → `403`

### Acceptance Criteria

- ✅ AC1: Unauthenticated requests return `401 Unauthorized`
- ✅ AC2: Valid token + owned resume returns `204 No Content`, sets soft-delete flags
- ✅ AC3: After soft-delete, resume excluded from list
- ✅ AC4: After soft-delete, detail returns `404`
- ✅ AC5: Non-existent resume returns `404`
- ✅ AC6: Cross-user delete returns `403 Forbidden`

### Review Findings Resolution

1. **Added 400 response contract** to DELETE endpoint (was missing, causing OpenAPI contract mismatch)
2. **Added dedicated validator unit test suite** (was lacking direct test coverage)

### Test Results

- Targeted tests: `6/6 passed` (3 handler + 3 validator)
- Full suite: `232/232 passed`
- CI parity (Release): `dotnet build --warnaserror` ✅ + `dotnet test --warnaserror` ✅

### Architecture Notes

- Clean Architecture boundaries maintained (API → Application → Domain)
- Reuses existing `IUnitOfWork` + `IEditableRepository<Resume>` abstractions
- Leverages global soft-delete query filter in `AppDbContext` for list/detail exclusion
- Global exception handler maps `ForbiddenException` → 403, `NotFoundException` → 404