### PR TITLE
docs(architecture): Epic 2 architecture revision (2026-05-05)

### DIFF
--- a/_bmad-output/placeholder.txt
+++ b/_bmad-output/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md
+++ b/_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md
@@ -59,7 +59,7 @@ public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, Creat
         // Handler receives already-validated request from pipeline
         // Handler focuses on business logic, not validation
         var user = new User { /* ... */ };
-        _unitOfWork.Users.Add(user);
+        await _unitOfWork.UserRepository.CreateAsync(user, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
         return new CreateUserResponse { Id = user.Id };
     }
@@ -70,7 +70,9 @@ public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand, Creat
 
 ### Decision 2: Validation Pipeline
 
-**Decision:** Two-layer validation: **FluentValidation (field-level) → Handler (business rules)**
+**Decision:** Two-layer validation: **FluentValidation (field-level) -> Handler (business rules)**
+
+**Epic 2 implementation note:** Validator behavior is correct enough for shipped Resume/Education endpoints, but deferred work identified repeated edge cases. For new stories, validators must explicitly decide null, empty-string, and whitespace semantics; cross-field rules should use stable client-facing error keys when the API contract requires structured field errors.
 
 **Layer 1: FluentValidation (pre-handler)**
 
@@ -108,9 +110,8 @@ public class CreateUserCommandValidator : AbstractValidator<CreateUserCommand>
 public async Task<CreateUserResponse> Handle(CreateUserCommand request, CancellationToken ct)
 {
     // Check uniqueness (requires DB query)
-    var existingUser = await _unitOfWork.Users
-        .FirstOrDefaultAsync(u => u.Email == request.Email, ct);
-    if (existingUser != null)
+    var emailExists = await _unitOfWork.UserRepository.ExistsByEmailAsync(request.Email, ct);
+    if (emailExists)
         throw new DuplicateEmailException(request.Email);
     
     // Create user...
@@ -119,6 +120,8 @@ public async Task<CreateUserResponse> Handle(CreateUserCommand request, Cancella
 ```
 
 **Error Response Format (from validation failures):**
+
+**Uniqueness rule:** Any uniqueness rule exposed to clients as `409 Conflict` must be backed by a database unique constraint. Handler pre-checks and validators may improve error messages, but they are not sufficient for race-prone create/update paths.
 
 ```json
 {
@@ -137,82 +140,53 @@ public async Task<CreateUserResponse> Handle(CreateUserCommand request, Cancella
 
 ### Decision 3: Repository Pattern
 
-**Decision:** Repository interfaces defined in Application layer; implementations in Infrastructure. Repositories encapsulate query logic.
+**Decision:** Repository interfaces are defined in the Application layer; implementations live in Infrastructure. The current Epic 2 baseline uses generic repository abstractions for common CRUD/list behavior, with specialized repository interfaces only where a resource needs distinct query behavior.
 
-**Application Layer (Interfaces):**
+**Epic 2 implementation note:** Earlier architecture text described one bespoke repository interface per aggregate. The implemented code now uses `IRepository<T>` and `IEditableRepository<T>` for Resume, Education, and similar editable resources. `IUserRepository` and `IVacancyRepository` remain specialized because they need user lookup and vacancy filtering behavior.
 
-```csharp
-namespace JobNecto.Application.Repositories;
-
-public interface IUserRepository
-{
-    Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
-    Task<User?> GetByEmailAsync(string email, CancellationToken cancellationToken = default);
-    Task<User?> GetByLoginNameAsync(string loginName, CancellationToken cancellationToken = default);
-    Task AddAsync(User user, CancellationToken cancellationToken = default);
-    Task UpdateAsync(User user, CancellationToken cancellationToken = default);
-}
-
-public interface IResumeRepository
-{
-    Task<Resume?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
-    Task<IEnumerable<Resume>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
-    Task<PagedResult<Resume>> GetAsync(PagedQuery pagedQuery, CancellationToken cancellationToken = default);
-    Task AddAsync(Resume resume, CancellationToken cancellationToken = default);
-    Task UpdateAsync(Resume resume, CancellationToken cancellationToken = default);
-}
-
-// Similar for Education, CoverLetterTemplate, CoverLetter, Vacancy repositories
-```
-
-**Infrastructure Layer (Implementation Pattern):**
+**Current Application Layer Interfaces:**
 
 ```csharp
-namespace JobNecto.Infrastructure.Repositories;
-
-public class UserRepository : IUserRepository
+public interface IRepository<T>
+    where T : BaseEntity
 {
-    private readonly AppDbContext _context;
-    
-    public UserRepository(AppDbContext context) => _context = context;
-    
-    public async Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        return await _context.Users
-            .AsNoTracking()
-            .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
-    }
-    
-    public async Task<User?> GetByEmailAsync(string email, CancellationToken cancellationToken = default)
-    {
-        return await _context.Users
-            .AsNoTracking()
-            .FirstOrDefaultAsync(u => u.Email == email, cancellationToken);
-    }
-    
-    public async Task AddAsync(User user, CancellationToken cancellationToken = default)
-    {
-        // No need for explicit add; UnitOfWork tracks changes
-        await _context.Users.AddAsync(user, cancellationToken);
-    }
+    Task<T> GetByIdAsync(Guid id, CancellationToken ct);
+    Task<PagedResult<T>> GetAsync(PagedQuery pagedQuery, CancellationToken ct);
+    Task<T> CreateAsync(T entity, CancellationToken ct);
+    Task<Guid> DeleteAsync(Guid id, CancellationToken ct);
+    Task<bool> IsExistsAsync(Guid id, CancellationToken ct);
+}
+
+public interface IEditableRepository<T> : IRepository<T>
+    where T : BaseEntity
+{
+    Task<T> UpdateAsync(T entity, CancellationToken ct);
 }
 ```
 
-**UnitOfWork Integration:**
+**Current UnitOfWork exposure after Epic 2:**
 
 ```csharp
 public interface IUnitOfWork : IAsyncDisposable
 {
-    IUserRepository Users { get; }
-    IResumeRepository Resumes { get; }
-    IEducationRepository Educations { get; }
-    ICoverLetterTemplateRepository CoverLetterTemplates { get; }
-    ICoverLetterRepository CoverLetters { get; }
-    IVacancyRepository Vacancies { get; }
-    
-    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+    IUserRepository UserRepository { get; }
+    IVacancyRepository VacancyRepository { get; }
+    IEditableRepository<CoverLetter> CoverLetterRepository { get; }
+    IEditableRepository<Resume> ResumeRepository { get; }
+    IEditableRepository<Education> EducationRepository { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken ct);
+    Task BeginTransactionAsync(CancellationToken ct);
+    Task CommitTransactionAsync(CancellationToken ct);
+    Task RollbackTransactionAsync(CancellationToken ct);
 }
 ```
+
+**Current Pagination/User-Scoping Pattern:**
+
+`PagedQuery.UserId` is the current mechanism for user-scoped list queries. `BaseRepository<T>.GetAsync` detects a `UserId` property and applies the filter when present. This is accepted for the current codebase, but it is also listed in deferred work because it mixes ownership filtering into a Domain value object.
+
+For Epic 3 and later, prefer the generic repository path unless the resource needs a real specialized query. Do not introduce bespoke repository interfaces only for naming symmetry.
 
 **Handler Usage (UnitOfWork hides repositories):**
 
@@ -220,13 +194,13 @@ public interface IUnitOfWork : IAsyncDisposable
 public async Task<CreateResumeResponse> Handle(CreateResumeCommand req, CancellationToken ct)
 {
     // Verify ownership
-    var user = await _unitOfWork.Users.GetByIdAsync(req.UserId, ct);
-    if (user == null)
-        throw new UserNotFoundException(req.UserId);
+    var userExists = await _unitOfWork.UserRepository.IsExistsAsync(req.UserId, ct);
+    if (!userExists)
+        throw new NotFoundException($"User with id {req.UserId} not found");
     
     // Create resume
     var resume = new Resume { UserId = req.UserId, Title = req.Title, /* ... */ };
-    await _unitOfWork.Resumes.AddAsync(resume, ct);
+    await _unitOfWork.ResumeRepository.CreateAsync(resume, ct);
     await _unitOfWork.SaveChangesAsync(ct);
     
     return new CreateResumeResponse { Id = resume.Id };
@@ -336,7 +310,7 @@ public class ExceptionHandlingMiddleware
 public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken)
 {
     // Pass cancellationToken to all async operations
-    var user = await _unitOfWork.Users.GetByIdAsync(id, cancellationToken);
+    var user = await _unitOfWork.UserRepository.GetByIdAsync(id, cancellationToken);
     await _unitOfWork.SaveChangesAsync(cancellationToken);
 }
 ```
@@ -388,6 +362,8 @@ public async Task Handle_ValidRequest_CreatesUser()
 
 **Decision:** EF Core global query filters to exclude soft-deleted records from all queries; PostgreSQL cascade rules enforce referential integrity; logging on hard-deletes for audit.
 
+**Epic 2 implementation note:** Resume and Education soft deletes are implemented by setting `IsDeleted = true` and `DeletedAt = DateTime.UtcNow`, then relying on EF Core global query filters for exclusion. RowVersion/optimistic locking is not part of the current entity model and should be treated as future hardening, not as completed Phase B infrastructure.
+
 **Entity Pattern (Domain Layer):**
 
 ```csharp
@@ -401,8 +377,6 @@ public class Resume : SoftDeletableEntity
 {
     public Guid UserId { get; set; }
     public string Title { get; set; } = string.Empty;
-    [Timestamp] // Optimistic locking for Phase C concurrency safety
-    public byte[] RowVersion { get; set; }
     // other properties...
 }
 ```
@@ -433,19 +407,26 @@ public class AppDbContext : DbContext
             .HasQueryFilter(v => !v.IsDeleted);
         
         // PostgreSQL cascade rules for hard-deletes
-        // User → Resume cascade hard-delete
+        // User -> Resume cascade hard-delete
         modelBuilder.Entity<Resume>()
             .HasOne<User>()
             .WithMany()
             .HasForeignKey(r => r.UserId)
             .OnDelete(DeleteBehavior.Cascade); // Hard-delete when User is deleted
-        
-        // Resume → CoverLetter cascade hard-delete
-        modelBuilder.Entity<CoverLetter>()
-            .HasOne<Resume>()
+
+        // User -> Education cascade hard-delete
+        modelBuilder.Entity<Education>()
+            .HasOne<User>()
             .WithMany()
-            .HasForeignKey(cl => cl.ResumeId)
-            .OnDelete(DeleteBehavior.Cascade); // Hard-delete when Resume is hard-deleted
+            .HasForeignKey(e => e.UserId)
+            .OnDelete(DeleteBehavior.Cascade); // Hard-delete when User is deleted
+        
+        // User -> CoverLetter cascade hard-delete
+        modelBuilder.Entity<CoverLetter>()
+            .HasOne<User>()
+            .WithMany()
+            .HasForeignKey(cl => cl.UserId)
+            .OnDelete(DeleteBehavior.Cascade); // Hard-delete when User is deleted
     }
 }
 ```
@@ -455,26 +436,17 @@ public class AppDbContext : DbContext
 ```csharp
 public async Task<Unit> Handle(DeleteResumeCommand request, CancellationToken cancellationToken)
 {
-    var resume = await _unitOfWork.Resumes.GetByIdAsync(request.Id, cancellationToken);
-    if (resume == null)
-        throw new ResumeNotFoundException(request.Id);
+    var resume = await _unitOfWork.ResumeRepository.GetByIdAsync(request.ResumeId, cancellationToken);
     
     // Verify ownership
     if (resume.UserId != request.UserId)
-        throw new UnauthorizedAccessException();
+        throw new ForbiddenException("You do not have permission to delete this resume.");
     
     // Soft delete: mark as deleted and timestamp for TTL grace period
     resume.IsDeleted = true;
     resume.DeletedAt = DateTime.UtcNow;
     
-    // Cascade soft-delete to related CoverLetters
-    var relatedLetters = await _unitOfWork.CoverLetters.GetByResumeIdAsync(request.Id, cancellationToken);
-    foreach (var letter in relatedLetters.Where(l => !l.IsDeleted))
-    {
-        letter.IsDeleted = true;
-        letter.DeletedAt = DateTime.UtcNow;
-    }
-    
+    await _unitOfWork.ResumeRepository.UpdateAsync(resume, cancellationToken);
     await _unitOfWork.SaveChangesAsync(cancellationToken);
     
     return Unit.Value;
@@ -486,17 +458,15 @@ public async Task<Unit> Handle(DeleteResumeCommand request, CancellationToken ca
 ```csharp
 public async Task<Unit> Handle(HardDeleteUserCommand request, CancellationToken cancellationToken)
 {
-    var user = await _unitOfWork.Users.GetByIdAsync(request.UserId, cancellationToken);
-    if (user == null)
-        throw new UserNotFoundException(request.UserId);
+    var user = await _unitOfWork.UserRepository.GetByIdAsync(request.UserId, cancellationToken);
     
     // Log hard-delete for audit
     _logger.LogInformation(
         "Hard-deleting user {UserId} ({Email}). Cascade will delete all resumes, educations, and cover letters.",
         user.Id, user.Email);
     
-    // PostgreSQL cascade rules will hard-delete all related Resumes, CoverLetters automatically
-    _unitOfWork.Users.Remove(user);
+    // Future account-deletion stories must add the explicit hard-delete repository path.
+    await _unitOfWork.UserRepository.DeleteAsync(user.Id, cancellationToken);
     await _unitOfWork.SaveChangesAsync(cancellationToken);
     
     _logger.LogInformation("User {UserId} and all related data hard-deleted successfully.", user.Id);
@@ -509,11 +479,11 @@ public async Task<Unit> Handle(HardDeleteUserCommand request, CancellationToken 
 
 | Delete Type | Entity | Behavior | Cascades |
 |-------------|--------|----------|----------|
-| Soft Delete | Resume | Mark IsDeleted=true, set DeletedAt | CoverLetters soft-delete |
-| Soft Delete | Education | Mark IsDeleted=true, set DeletedAt | None (orphaned join table entries) |
+| Soft Delete | Resume | Mark IsDeleted=true, set DeletedAt | None in current Epic 2 implementation |
+| Soft Delete | Education | Mark IsDeleted=true, set DeletedAt | None |
 | Soft Delete | CoverLetter | Mark IsDeleted=true, set DeletedAt | None |
-| Hard Delete | Resume | Remove from DB (DELETE) | CoverLetters hard-delete (PostgreSQL FK) |
-| Hard Delete | User | Remove from DB (DELETE) | Resumes hard-delete (PostgreSQL FK); cascades to CoverLetters |
+| Hard Delete | User | Remove from DB (DELETE) | Resumes, Educations, CoverLetters, and CoverLetterTemplates hard-delete through PostgreSQL FK cascades |
+| Hard Delete | Vacancy | Remove from DB (DELETE) | CoverLetters hard-delete through PostgreSQL FK cascade |
 
 **Logging Strategy:**
 
@@ -535,22 +505,29 @@ public async Task<Unit> Handle(HardDeleteUserCommand request, CancellationToken 
 
 **Decision:** Handlers verify ownership before mutations; repository layer enforces user-scoped queries.
 
+**Epic 2 implementation note:** List queries are user-scoped through `PagedQuery.UserId` and `BaseRepository<T>.GetAsync`. Single-record handlers currently call `GetByIdAsync` first and then verify ownership in the handler. This preserves current contracts, but ownership-aware single-record access is a recommended Epic 3 decision before template detail/update/delete patterns multiply.
+
+**Response semantics after Epic 2:**
+
+- Cross-user detail reads should return `404 Not Found` when the API should not reveal existence.
+- Cross-user update/delete operations should return `403 Forbidden` when the story acceptance criteria require explicit forbidden mutation behavior.
+- User-owned list endpoints must always include the authenticated user ID from controller auth context.
+
 **Pattern: Ownership Check in Handler**
 
 ```csharp
 public async Task<Unit> Handle(UpdateResumeCommand request, CancellationToken ct)
 {
-    var resume = await _unitOfWork.Resumes.GetByIdAsync(request.Id, ct);
-    if (resume == null)
-        throw new ResumeNotFoundException(request.Id);
+    var resume = await _unitOfWork.ResumeRepository.GetByIdAsync(request.Id, ct);
     
     // CRITICAL: Verify ownership before mutation
     if (resume.UserId != request.UserId)
-        throw new UnauthorizedAccessException($"User {request.UserId} cannot modify resume {request.Id}");
+        throw new ForbiddenException($"User {request.UserId} cannot modify resume {request.Id}");
     
     // Update allowed
     resume.Title = request.Title;
     resume.Skills = request.Skills;
+    await _unitOfWork.ResumeRepository.UpdateAsync(resume, ct);
     await _unitOfWork.SaveChangesAsync(ct);
     
     return Unit.Value;
@@ -563,12 +540,16 @@ public async Task<Unit> Handle(UpdateResumeCommand request, CancellationToken ct
 // Query for lists always includes UserId filter
 public async Task<PagedResult<ResumeDto>> Handle(ListResumesQuery request, CancellationToken ct)
 {
-    // Repository returns only resumes for this user
-    var resumes = await _unitOfWork.Resumes.GetPaginatedByUserIdAsync(
-        request.UserId,  // User must be passed from request context
-        request.Page,
-        request.PageSize,
-        ct);
+    var pagedQuery = new PagedQuery
+    {
+        UserId = request.UserId,
+        LastSeenId = request.LastSeenId,
+        LastSeenUpdatedAt = request.LastSeenUpdatedAt,
+        PageSize = request.PageSize
+    };
+
+    // BaseRepository applies UserId filtering for entities that expose UserId.
+    var resumes = await _unitOfWork.ResumeRepository.GetAsync(pagedQuery, ct);
     
     return resumes;
 }

--- a/_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md
+++ b/_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md
@@ -164,6 +164,8 @@ public interface IEditableRepository<T> : IRepository<T>
 }
 ```
 
+**`GetByIdAsync` contract:** Returns `Task<T>` (non-nullable). The repository implementation throws `NotFoundException` when no entity with the given `id` exists. Callers must not null-check the result — the throw guarantee is part of the contract. This is why handler examples do not include `if (entity == null)` guards after `GetByIdAsync` calls.
+
 **Current UnitOfWork exposure after Epic 2:**
 
 ```csharp
@@ -318,11 +320,12 @@ public async Task<TResponse> Handle(TRequest request, CancellationToken cancella
 **Repository Async Pattern:**
 
 ```csharp
-public async Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+public async Task<User> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
 {
     return await _context.Users
         .AsNoTracking()
-        .FirstOrDefaultAsync(u => u.Id == id, cancellationToken); // Pass token
+        .FirstOrDefaultAsync(u => u.Id == id, cancellationToken)
+        ?? throw new NotFoundException($"User with id {id} not found");
 }
 ```
 

--- a/_bmad-output/planning-artifacts/architecture/epic-2-architecture-revision-2026-05-05.md
+++ b/_bmad-output/planning-artifacts/architecture/epic-2-architecture-revision-2026-05-05.md
@@ -1,0 +1,102 @@
+# Epic 2 Architecture Revision (2026-05-05)
+
+## Review Sources
+
+- `_bmad-output/implementation-artifacts/epic-2-retro-2026-05-05.md`
+- `_bmad-output/implementation-artifacts/deferred-work.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- Current architecture shards in `_bmad-output/planning-artifacts/architecture/`
+- Current backend code under `backend/src`
+
+## Current Implemented Baseline
+
+Epic 2 is complete at the architecture-pattern level. Resume and Education now use the same vertical-slice structure:
+
+- API controllers extract the authenticated user ID and construct MediatR commands/queries.
+- Application handlers own business flow, ownership checks, soft-delete marking, and response mapping.
+- FluentValidation handles request-shape validation before handlers run.
+- Infrastructure repositories use EF Core through generic repository abstractions and the UnitOfWork.
+- EF Core global query filters exclude soft-deleted resources.
+- User-owned list endpoints use cursor pagination with `PagedQuery.UserId`, `LastSeenId`, and `LastSeenUpdatedAt`.
+
+This confirms the Clean Architecture direction held through Epic 2. Domain entities remain persistence-ignorant, Application owns contracts and handlers, Infrastructure owns EF behavior, and API remains thin.
+
+## Corrections Applied To Architecture Docs
+
+The previous architecture text mixed intended future patterns with actual implemented patterns. This revision updates the docs to make these boundaries explicit:
+
+- Repository baseline is generic `IRepository<T>` / `IEditableRepository<T>` plus selected specialized interfaces where needed, not one bespoke repository interface per aggregate.
+- `PagedQuery.UserId` is the current pragmatic user-scoping mechanism for list endpoints, even though it remains a deferred design concern because it places ownership filtering in a Domain value object.
+- Single-record reads currently fetch by ID and then perform handler-level ownership checks. Ownership-aware `GetByIdForUserAsync` is not implemented yet.
+- RowVersion/optimistic locking is a future hardening direction, not a completed Epic 2 baseline.
+- `DateTime.UtcNow` and `DateTime` cursor timestamps remain the active pattern. A `DateTimeOffset` and clock-abstraction decision is still pending.
+- Cover letter template UnitOfWork exposure and per-user template-name uniqueness are Epic 3 work, not completed Phase B infrastructure.
+
+## Accepted Patterns After Epic 2
+
+- Keep `/api/v1/users/me` profile-only. Related resources belong on dedicated routes.
+- Use `404` for cross-user detail reads where existence should not leak.
+- Use `403` for cross-user mutations where stories require explicit forbidden mutation behavior.
+- Continue relying on EF global query filters for soft-delete exclusion.
+- Continue using generic repositories for CRUD-like user-owned resources unless a resource has query behavior that genuinely needs a specialized repository.
+- Continue mapping database uniqueness violations to `409 Conflict` for constraints that form part of the product contract.
+
+## Decisions Needed Before Epic 3
+
+### Template Name Uniqueness
+
+Epic 3 must enforce per-user cover letter template-name uniqueness with a database constraint. A validator or pre-check alone is not enough because concurrent requests can bypass it.
+
+Required direction:
+
+- Add a unique filtered index over `(UserId, Name)` or the actual template-name column used by the implementation.
+- Filter the index to active records if soft-deleted templates should not reserve names.
+- Add concurrent integration tests for create/update collisions.
+- Map unique-constraint violations to `409 Conflict`.
+
+### Ownership-Aware Single-Record Access
+
+Epic 2 detail handlers load the record by ID before checking ownership. This is behaviorally correct but creates unnecessary cross-user reads and spreads ownership logic across handlers.
+
+Recommended Epic 3 decision:
+
+- Introduce a narrowly scoped ownership-aware read helper or repository method when implementing template detail/update/delete.
+- Preserve current response semantics: cross-user detail read returns `404`; cross-user mutation returns `403` when required by acceptance criteria.
+- Do not refactor all existing Resume/Education handlers unless the change is intentionally scheduled.
+
+### Timestamp And Clock Policy
+
+Deferred work now repeats around `DateTime`, `DateTimeOffset`, cursor timestamp kind, and direct `DateTime.UtcNow`.
+
+Recommended project-level decision:
+
+- Store persisted timestamps consistently in UTC.
+- Normalize incoming cursor timestamps at the API/Application boundary before repository comparison.
+- Introduce an injectable clock before adding more time-sensitive handlers if tests begin depending on exact timestamps.
+- Treat `DateTimeOffset` migration as a separate cross-cutting change rather than a story-local edit.
+
+### Validator Checklist
+
+Epic 2 surfaced repeated validator edge cases: empty strings, whitespace, max length, enum bounds, and cross-field rules with weak property names.
+
+Recommended Epic 3 rule:
+
+- Every create/update story should explicitly decide null, empty, and whitespace semantics for each string field.
+- Cross-field validation errors should use a stable client-facing key, not an empty property name, when the API contract needs structured field errors.
+- Business uniqueness that is externally observable as conflict must be backed by a database constraint.
+
+## Production-Hardening Backlog
+
+These items should not be treated as blockers for starting Epic 3 unless the story directly depends on them, but they must be resolved before production readiness:
+
+- Cloudinary-not-configured behavior policy.
+- Conflict-detail privacy policy for submitted identifiers.
+- `DateTime` vs `DateTimeOffset` migration policy.
+- Idempotency support for retry-prone POST endpoints.
+- FK race handling between validation and persistence.
+- Behavior after `UpdateAsync` plus `SaveChangesAsync` failure leaves a tracked entity modified in the current scope.
+- Local verification blocker where retrospective build/test commands failed without useful diagnostics.
+
+## Architecture Verdict
+
+Epic 2 did not invalidate the Clean Architecture direction. The main documentation risk was drift: several shards described future or idealized patterns as if they were already implemented. The revised guidance is to keep the generic repository and vertical-slice baseline, make Epic 3 uniqueness database-backed from the start, and avoid copying the known timestamp and validator ambiguities into new resources without an explicit decision.

--- a/_bmad-output/planning-artifacts/architecture/implementation-checklist-for-phase-b.md
+++ b/_bmad-output/planning-artifacts/architecture/implementation-checklist-for-phase-b.md
@@ -1,38 +1,66 @@
 # Implementation Checklist for Phase B
 
-**Database & Entities:**
+This checklist was revised after Epic 2 completion on 2026-05-05. It distinguishes completed Phase B baseline work from hardening that remains deferred.
 
-- [ ] Add `IsDeleted` and `DeletedAt` timestamps to: Resume, Education, CoverLetterTemplate, CoverLetter, Vacancy
-- [ ] Add `[Timestamp]` RowVersion to all entities for optimistic locking
-- [ ] Configure global query filters for soft-delete entities
-- [ ] Configure PostgreSQL cascade rules in OnModelCreating (User→Resume→CoverLetter hard-deletes)
-- [ ] Create migration with all schema changes
+## Database & Entities
 
-**Handlers & Repositories:**
+- [x] Add `IsDeleted` and `DeletedAt` timestamps to soft-deletable entities.
+- [x] Configure global query filters for soft-delete entities.
+- [x] Create and maintain EF Core migrations through Infrastructure.
+- [x] Add partial unique indexes for active user login/email/phone constraints.
+- [ ] Add `[Timestamp]` / RowVersion optimistic locking where a future story requires lost-update protection.
+- [ ] Add Epic 3 database-backed per-user cover letter template-name uniqueness.
 
-- [ ] Implement user-scoped repository methods (GetByUserIdAsync, ListByUserIdAsync, etc.)
-- [ ] Keep `/api/v1/users/me` profile-only; serve related user-owned resources via dedicated user-scoped routes
-- [ ] Soft-delete handlers: Set IsDeleted=true, propagate cascade soft-deletes to children
-- [ ] All mutation handlers: Verify ownership before allowing changes (`403 Forbidden` when ownership is violated)
-- [ ] All query handlers: Filter by UserId in request (user sees only their own data)
+## Handlers & Repositories
 
-**Testing:**
+- [x] Keep `/api/v1/users/me` profile-only; serve related user-owned resources via dedicated user-scoped routes.
+- [x] Use generic `IRepository<T>` / `IEditableRepository<T>` for CRUD-like resources.
+- [x] Use specialized repository interfaces only for resources with distinct queries, such as users and vacancy filtering.
+- [x] Soft-delete handlers set `IsDeleted = true` and `DeletedAt = DateTime.UtcNow`.
+- [x] Mutation handlers verify ownership before allowing changes.
+- [x] List query handlers pass authenticated `UserId` into `PagedQuery`.
+- [ ] Decide whether Epic 3 introduces ownership-aware single-record access before implementing template detail/update/delete.
+- [ ] Decide whether `PagedQuery.UserId` remains acceptable long term or moves to an Application-layer query object.
+- [ ] Expose cover letter template persistence through UnitOfWork as part of Epic 3 implementation.
 
-- [ ] Soft-delete audit fixtures: Verify deleted data excluded from queries but exists in DB
-- [ ] Ownership violation suite: Run against all mutation handlers
-- [ ] Cascade soft-delete tests: Resume soft-delete→CoverLetter soft-delete
-- [ ] Cascade hard-delete tests (future): User hard-delete→Resume hard-delete→CoverLetter hard-delete
-- [ ] CancellationToken timeout tests: At least one per resource
+## Testing
 
-**Logging & Audit:**
+- [x] Resume and Education handler/API tests cover core create/list/detail/update/delete behavior.
+- [x] Ownership behavior is covered for shipped Resume and Education endpoints.
+- [x] Soft-delete behavior is covered for shipped Resume and Education endpoints.
+- [x] Conflict handling has database unique-constraint mapping and concurrency coverage for implemented user constraints.
+- [ ] Add Epic 3 concurrent create/update tests for per-user template-name uniqueness.
+- [ ] Diagnose current local `dotnet test backend/JobNecto.slnx` and Release build failures recorded in the Epic 2 retrospective.
+- [ ] Add cursor pagination end-to-end tests where endpoint-level coverage is still deferred.
+- [ ] Add explicit soft-delete exclusion tests for endpoints where coverage currently relies on repository/global-filter tests.
 
-- [ ] Log all hard-delete operations with timestamp, user ID, affected records
-- [ ] Application logs or database audit table (depending on compliance needs)
+## Validation & Error Policy
 
-**Phase C Readiness:**
+- [x] FluentValidation pipeline runs before handlers.
+- [x] Global exception handling returns RFC 7808 Problem Details.
+- [x] Database uniqueness violations map to `409 Conflict`.
+- [ ] Create a validator checklist for null, empty-string, whitespace, max-length, enum, and cross-field rules.
+- [ ] Decide privacy policy for conflict details that include submitted identifiers.
+- [ ] Decide Cloudinary-not-configured behavior policy.
 
-- [ ] JWT claim extraction and transport policy in Phase B can be extended to role-based controls in Phase C without handler refactoring
-- [ ] Handlers already receive UserId as parameter; no refactoring needed
-- [ ] Ownership checks are centralized per handler; easy to audit for Phase C
+## Time, Transactions, And Reliability
 
-These decisions are codified to ensure **consistency across all Phase B endpoints** and to make your developers' jobs straightforward: follow the patterns, and the architecture handles the rest.
+- [x] Creation/update/delete handlers set timestamps explicitly where current tests require provider-independent values.
+- [ ] Define project timestamp policy: `DateTime` vs `DateTimeOffset`, cursor timestamp kind handling, and UTC normalization.
+- [ ] Decide whether to introduce an injectable clock for time-sensitive handlers and tests.
+- [ ] Decide FK race handling between validation and persistence.
+- [ ] Decide whether repository update/save failure behavior needs cleanup of tracked dirty entities after failed `SaveChangesAsync`.
+- [ ] Decide idempotency support for retry-prone POST endpoints.
+
+## Logging & Audit
+
+- [x] Add `DbCommandTimingInterceptor` for slow database query monitoring.
+- [ ] Define production audit requirements for hard-delete operations.
+- [ ] Implement hard-delete audit trail when account deletion or administrative purge stories are scheduled.
+
+## Phase C / Later Readiness
+
+- [x] JWT claim extraction and transport policy can be extended to role-based controls without changing the handler shape.
+- [x] Handlers receive authenticated user ID as input rather than reading HTTP context directly.
+- [x] Ownership checks are easy to audit per handler.
+- [ ] Add role/authorization policy documentation when Phase C introduces non-owner access paths.

--- a/_bmad-output/planning-artifacts/architecture/index.md
+++ b/_bmad-output/planning-artifacts/architecture/index.md
@@ -1,18 +1,20 @@
-# Architecture Decision Document — Jobnecto Phase B
+# Architecture Decision Document - Jobnecto Phase B
 
 ## Navigation Index
 
 The architecture document is organized into the following shards:
 
-1. **[Post-Merge Implementation Status (2026-05-05)](post-merge-implementation-status-2026-04-30.md)** — Current state of Phase B implementation; which stories are merged and what infrastructure is in place
-2. **[Project Context Analysis](project-context-analysis.md)** — Requirements overview, technical constraints, and cross-cutting concerns (ownership, soft deletes, validation, filtering, async, migrations, OpenAPI)
-3. **[Core Architectural Decisions](core-architectural-decisions.md)** — Detailed architectural decisions: MediatR request/handler structure, validation strategy, repository pattern, error handling, soft deletes, ownership model, concurrency control
-4. **[Summary of Architectural Decisions](summary-of-architectural-decisions.md)** — Quick reference table of all decisions, approaches, and key benefits
-5. **[Implementation Checklist for Phase B](implementation-checklist-for-phase-b.md)** — Database & entity setup, handlers & repositories, testing requirements, logging & audit, Phase C readiness
+1. **[Post-Merge Implementation Status (2026-05-05)](post-merge-implementation-status-2026-04-30.md)** - Current state of Phase B implementation; which stories are merged and what infrastructure is in place
+2. **[Epic 2 Architecture Revision (2026-05-05)](epic-2-architecture-revision-2026-05-05.md)** - Audit of architecture docs after Epic 2; confirms implemented baseline, stale assumptions, and Epic 3 guardrails
+3. **[Project Context Analysis](project-context-analysis.md)** - Requirements overview, technical constraints, and cross-cutting concerns (ownership, soft deletes, validation, filtering, async, migrations, OpenAPI)
+4. **[Core Architectural Decisions](core-architectural-decisions.md)** - Detailed architectural decisions: MediatR request/handler structure, validation strategy, repository pattern, error handling, soft deletes, ownership model, concurrency control
+5. **[Summary of Architectural Decisions](summary-of-architectural-decisions.md)** - Quick reference table of all decisions, approaches, and key benefits
+6. **[Implementation Checklist for Phase B](implementation-checklist-for-phase-b.md)** - Completed Phase B checklist plus deferred hardening items
 
 ## How to Use
 
-- **Starting a story?** Read `project-context-analysis.md` to understand constraints and requirements
-- **Designing a new component?** Check `core-architectural-decisions.md` for patterns and decision rationale
-- **Need a quick reference?** Use `summary-of-architectural-decisions.md`
-- **Implementing Phase B features?** Use `implementation-checklist-for-phase-b.md` to ensure consistency
+- **Starting a story?** Read `project-context-analysis.md` to understand constraints and requirements.
+- **Starting Epic 3?** Read `epic-2-architecture-revision-2026-05-05.md` first for decisions that must not be copied blindly from Epic 2.
+- **Designing a new component?** Check `core-architectural-decisions.md` for patterns and decision rationale.
+- **Need a quick reference?** Use `summary-of-architectural-decisions.md`.
+- **Reviewing Phase B feature closure?** Use `implementation-checklist-for-phase-b.md` to distinguish completed work from deferred hardening.

--- a/_bmad-output/planning-artifacts/architecture/index.md
+++ b/_bmad-output/planning-artifacts/architecture/index.md
@@ -4,7 +4,7 @@
 
 The architecture document is organized into the following shards:
 
-1. **[Post-Merge Implementation Status (2026-05-05)](post-merge-implementation-status-2026-04-30.md)** - Current state of Phase B implementation; which stories are merged and what infrastructure is in place
+1. **[Post-Merge Implementation Status (2026-04-30)](post-merge-implementation-status-2026-04-30.md)** - Current state of Phase B implementation; which stories are merged and what infrastructure is in place
 2. **[Epic 2 Architecture Revision (2026-05-05)](epic-2-architecture-revision-2026-05-05.md)** - Audit of architecture docs after Epic 2; confirms implemented baseline, stale assumptions, and Epic 3 guardrails
 3. **[Project Context Analysis](project-context-analysis.md)** - Requirements overview, technical constraints, and cross-cutting concerns (ownership, soft deletes, validation, filtering, async, migrations, OpenAPI)
 4. **[Core Architectural Decisions](core-architectural-decisions.md)** - Detailed architectural decisions: MediatR request/handler structure, validation strategy, repository pattern, error handling, soft deletes, ownership model, concurrency control

--- a/_bmad-output/planning-artifacts/architecture/post-merge-implementation-status-2026-04-30.md
+++ b/_bmad-output/planning-artifacts/architecture/post-merge-implementation-status-2026-04-30.md
@@ -7,4 +7,6 @@
 - Token transport policy is explicit: browser flows rely on HTTP-only secure cookies; bearer clients can consume body tokens from refresh responses.
 - Architecture decisions around conflict handling are enforced in production code (`DbUpdateException` unique-constraint mapping to HTTP 409) and concurrency integration tests.
 - DB Command Timing: Added `DbCommandTimingInterceptor` to JobNecto.Infrastructure to monitor and log slow database queries (merged in story 2-4).
+- Epic 2 retrospective is complete and identifies the architecture as stable, with follow-up decisions needed for ownership-aware single-record reads, timestamp/clock policy, validator edge-case policy, and database-backed uniqueness for Epic 3 cover letter templates.
+- Current verification caveat: the Epic 2 retrospective recorded local `dotnet test backend/JobNecto.slnx` and Release build attempts failing without useful diagnostics. Treat implementation logs as positive evidence, but diagnose local solution-runner behavior before relying on a fresh green gate.
 

--- a/_bmad-output/planning-artifacts/architecture/project-context-analysis.md
+++ b/_bmad-output/planning-artifacts/architecture/project-context-analysis.md
@@ -5,6 +5,7 @@
 **Functional Requirements (Phase B):**
 
 - 6 primary domain resources: User (Profile), Resume, Education, CoverLetterTemplate, CoverLetter, Vacancy
+- Epic 2 delivered complete Resume and Education CRUD endpoints. CoverLetterTemplate, CoverLetter, and Vacancy endpoint work remains scheduled for later epics.
 - `GET /api/v1/users/me` returns only core user profile fields; related resources are fetched via dedicated resource routes
 - CRUD operations on user-owned resources (User, Resume, Education, Template, Letter)
 - Read-only operations on shared resources (Vacancy browsing and filtering)
@@ -17,7 +18,7 @@
 - Soft delete strategy with EF Core global query filters (data persists in DB but excluded from queries)
 - Ownership model: Each user sees only their own data with JWT-based session claims already in use; architecture remains extensible for Phase C role-based controls
 - Validation: FluentValidation pipeline before handlers reach business logic; field-level error responses
-- Test coverage requirement: ≥85% code coverage on Application handlers and validators
+- Test coverage requirement: at least 85% code coverage on Application handlers and validators
 - Async throughout: Full async/await chain with CancellationToken support on public APIs
 
 **Scale & Complexity:**
@@ -40,7 +41,7 @@
 
 **Architecture Constraints:**
 
-- Clean Architecture enforced: API → Application → Domain ← Infrastructure
+- Clean Architecture enforced: API -> Application -> Domain <- Infrastructure
 - Domain layer must be persistence-ignorant (no EF Core references)
 - Application layer contains handlers, validators, repository interfaces
 - Infrastructure layer implements repositories, EF configurations, migrations
@@ -57,7 +58,7 @@
 
 - UnitOfWork pattern implemented with `SaveChangesAsync()` and `DisposeAsync()`
 - All repository interfaces defined in Application layer
-- PostgreSQL connection available — see `appsettings.local.json` under `ConnectionStrings:Default` for the local connection string
+- PostgreSQL connection available - see `appsettings.local.json` under `ConnectionStrings:Default` for the local connection string
 - EF Core migrations system functional
 - `AddInfrastructure()` DI registration wired in `Program.cs`
 
@@ -80,6 +81,7 @@
 - Architecture standardizes JWT session transport (HTTP-only secure cookie for browser clients; `Authorization: Bearer` for non-browser clients) and must support Phase C role-based extension without refactoring core patterns
 - Design pattern: ownership check delegated to handler, not API layer
 - **UserId source:** Generated during user registration (profile creation); Phase B uses JWT-based sessions with `UserId` stored as a claim and extracted in controllers from `HttpContext.User`
+- **Epic 2 baseline:** List endpoints are user-scoped through `PagedQuery.UserId`; detail/update/delete handlers fetch by ID and then enforce ownership in handler code. Ownership-aware single-record repository access is a candidate Epic 3 refinement.
 
 **2. Soft Delete Consistency**
 
@@ -88,11 +90,10 @@
 - Soft-deleted records excluded from ALL queries unless explicitly requested
 - Single source of truth: query filters prevent accidental data exposure across entire application
 - **Cascade Hard-Delete Rules (PostgreSQL-level):**
-  - User hard-deleted → all their Resumes cascade hard-delete
-  - Resume soft-deleted → all related CoverLetters cascade soft-delete
-  - Resume hard-deleted → all related CoverLetters cascade hard-delete
-  - Education soft-deleted → no cascades (Resume remains; Education just filtered out)
-- **Logging:** All hard-delete operations are logged for audit/compliance purposes
+  - User hard-deleted -> Resumes, Educations, CoverLetters, and CoverLetterTemplates cascade hard-delete
+  - Vacancy hard-deleted -> related CoverLetters cascade hard-delete
+  - Resume and Education soft-delete operations do not currently cascade to other resources
+- **Logging:** Hard-delete audit requirements remain a production-readiness decision; implement full audit logging when hard-delete/account-deletion stories are scheduled
 - **Grace Period (Future - Phase E):** TTL implemented in Phase E; soft-deleted records eligible for hard-delete after 1 month
 
 **3. Validation & Error Handling**
@@ -103,6 +104,8 @@
 - HTTP status codes: 200, 201, 204 (success); 400, 404, 409, 422, 500 (errors)
 - Field-level errors: `{ "email": ["must be valid format"], "phone": ["already in use"] }`
 - Any business rule exposed as `409 Conflict` must be enforced by a database-level unique constraint, with DB unique-violation mapped through global exception handling and at least one concurrent-request integration test on race-prone endpoints.
+- Epic 3 cover letter template-name uniqueness must follow this rule with a per-user database unique constraint; validator-only enforcement is not acceptable.
+- Validator policy still needs a checklist for null, empty-string, whitespace, max-length, enum, and cross-field error-key semantics.
 
 **4. Complex Filtering Architecture**
 
@@ -119,13 +122,20 @@
 - EF Core async methods: `ToListAsync()`, `FirstOrDefaultAsync()`, `SaveChangesAsync()`
 - Database context should be disposed via `await using` in tests
 
+**5a. Timestamp Policy**
+
+- Current implementation uses `DateTime` and direct `DateTime.UtcNow` in handlers.
+- Persisted timestamps are treated as UTC by convention.
+- Cursor pagination uses `lastSeenUpdatedAt`; timestamp kind/offset normalization is deferred and should be decided before this pattern spreads further.
+- `DateTimeOffset` adoption and injectable clock support are project-level decisions, not story-local changes.
+
 **6. Database Migrations & Relationships**
 
 - Migrations live in Infrastructure; tracked via EF Core schema history
-- Entity relationships: 1:N (User→Resume, User→Education, Resume→CoverLetter), M:N (Resume↔Education via join table)
+- Entity relationships: 1:N (User -> Resume, User -> Education, User -> CoverLetter, User -> CoverLetterTemplate, Vacancy -> CoverLetter), M:N (Resume <-> Education via join table)
 - **Cascade Rules (EF Core + PostgreSQL):**
-  - User → Resume: ON DELETE CASCADE (hard-delete when user deleted)
-  - Resume → CoverLetter: ON DELETE CASCADE (hard-delete when resume deleted)
+  - User -> Resume, Education, CoverLetter, CoverLetterTemplate: ON DELETE CASCADE (hard-delete when user deleted)
+  - Vacancy -> CoverLetter: ON DELETE CASCADE (hard-delete when vacancy deleted)
   - Soft deletes use EF Core global filters; cascades handled in OnModelCreating
   - PostgreSQL foreign keys enforce referential integrity; EF tracks related entities
 - ResumeEducations join table: supports M:N linkage without direct references; cascade soft-deletes to join table entries
@@ -136,4 +146,4 @@
 - Every endpoint must have clear request/response models for auto-documentation
 - Status codes documented in swagger attributes (200, 201, 400, 404, 422, etc.)
 - Models exported to `/openapi/v1.json` for frontend code generation
-
+

--- a/_bmad-output/planning-artifacts/architecture/project-context-analysis.md
+++ b/_bmad-output/planning-artifacts/architecture/project-context-analysis.md
@@ -122,14 +122,14 @@
 - EF Core async methods: `ToListAsync()`, `FirstOrDefaultAsync()`, `SaveChangesAsync()`
 - Database context should be disposed via `await using` in tests
 
-**5a. Timestamp Policy**
+**6. Timestamp Policy**
 
 - Current implementation uses `DateTime` and direct `DateTime.UtcNow` in handlers.
 - Persisted timestamps are treated as UTC by convention.
 - Cursor pagination uses `lastSeenUpdatedAt`; timestamp kind/offset normalization is deferred and should be decided before this pattern spreads further.
 - `DateTimeOffset` adoption and injectable clock support are project-level decisions, not story-local changes.
 
-**6. Database Migrations & Relationships**
+**7. Database Migrations & Relationships**
 
 - Migrations live in Infrastructure; tracked via EF Core schema history
 - Entity relationships: 1:N (User -> Resume, User -> Education, User -> CoverLetter, User -> CoverLetterTemplate, Vacancy -> CoverLetter), M:N (Resume <-> Education via join table)
@@ -140,7 +140,7 @@
   - PostgreSQL foreign keys enforce referential integrity; EF tracks related entities
 - ResumeEducations join table: supports M:N linkage without direct references; cascade soft-deletes to join table entries
 
-**7. OpenAPI Documentation**
+**8. OpenAPI Documentation**
 
 - Swashbuckle auto-generates OpenAPI spec from attributes and models
 - Every endpoint must have clear request/response models for auto-documentation

--- a/_bmad-output/planning-artifacts/architecture/summary-of-architectural-decisions.md
+++ b/_bmad-output/planning-artifacts/architecture/summary-of-architectural-decisions.md
@@ -1,15 +1,15 @@
 # Summary of Architectural Decisions
 
-| Decision | Approach | Key Benefit |
-|----------|----------|------------|
-| Request Handling | MediatR Commands/Queries | Consistent request flow, testable business logic |
-| Validation | FluentValidation + Handler layer | Separation of concerns, reusable validators |
-| Data Access | Repository pattern with UnitOfWork | Abstraction from EF Core, testable with in-memory |
-| Errors | RFC 7808 Problem Details | Standardized, frontend-friendly error format |
-| Async | Full chain with CancellationToken | Graceful timeout handling, responsive API |
-| Soft Delete + Cascades | EF Core global filters + PostgreSQL FK cascades + Audit logging | Data safety, referential integrity, compliance trail |
-| Ownership Model | User-scoped repositories + Handler ownership checks | Only users see their own resumes; Phase C ready |
-| Concurrency Control | Optimistic locking (RowVersion/Timestamp) | Prevents lost updates under concurrent load |
-
----
-
+| Decision | Current Approach After Epic 2 | Key Benefit | Status |
+|----------|-------------------------------|-------------|--------|
+| Request Handling | MediatR commands/queries per vertical slice | Consistent request flow, testable business logic | Active |
+| Validation | FluentValidation for request shape plus handler/business checks | Separation of concerns, reusable validators | Active; needs checklist hardening |
+| Data Access | Generic `IRepository<T>` / `IEditableRepository<T>` with UnitOfWork; specialized repositories only for distinct query behavior | Keeps CRUD resources simple while allowing custom queries where justified | Active |
+| Errors | RFC 7808 Problem Details through global exception handling | Standardized, frontend-friendly error format | Active |
+| Conflict Handling | Product-level uniqueness must be database-backed and mapped to `409 Conflict` | Race-safe API contract under concurrent requests | Active; must apply to Epic 3 templates |
+| Async | Full async chain with CancellationToken propagation | Graceful timeout handling, responsive API | Active |
+| Soft Delete | EF Core global query filters plus `IsDeleted` / `DeletedAt` markers | Deleted data is excluded consistently without handler-level filters everywhere | Active |
+| Ownership Model | User-scoped list queries through `PagedQuery.UserId`; handler ownership checks for detail and mutations | Users only access their own resources; route/API layer stays thin | Active with deferred design concern |
+| Single-Record Ownership Reads | Current handlers fetch by ID, then check ownership | Behavior is correct; implementation is easy to audit | Accepted for Epic 2; revisit before Epic 3 detail/update/delete |
+| Timestamp Policy | `DateTime` persisted in UTC by convention; direct `DateTime.UtcNow` in handlers; cursor uses `LastSeenUpdatedAt` | Simple and consistent with current code | Deferred hardening: DateTimeOffset/clock/cursor normalization |
+| Concurrency Control | Database unique constraints for uniqueness races; no RowVersion baseline yet | Prevents known uniqueness races | Partial; RowVersion remains future hardening |


### PR DESCRIPTION
This PR revises architecture shards after Epic 2 completion.

Summary:
- Update `core-architectural-decisions.md`, `implementation-checklist-for-phase-b.md`, `index.md`, `post-merge-implementation-status-2026-04-30.md`, `project-context-analysis.md`, `summary-of-architectural-decisions.md`.
- Add `epic-2-architecture-revision-2026-05-05.md` documenting accepted patterns and Epic 3 decisions.

Files are under `_bmad-output/planning-artifacts/architecture/`.