### PR TITLE
refactor(repository-contract): separate soft delete repository contract from editable repositories

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -36,6 +36,11 @@
 
 - **Concurrent FK race between validation and persist** — Race where a user may be deleted between validator check and `SaveChangesAsync`, producing FK violations. Deferred: infra/transaction isolation decision required (handle via DB constraint mapping or stronger transactional guarantees).
 
+## Deferred from: code review of r-1-separate-soft-delete-repository-contract (2026-05-06)
+
+- **CancellationToken unused in SoftDeleteAsync** — Both `SoftDeletableRepository<T>.SoftDeleteAsync` and `VacancyRepository.SoftDeleteAsync` accept `ct` but never use it. Pre-existing pattern: `EditableRepository.UpdateAsync` has identical behavior. Revisit when a clock/cancellation hardening pass is done across all repository methods.
+- **`DateTime.UtcNow` hardcoded in SoftDeletableRepository/VacancyRepository** — No clock abstraction; same as pre-existing pattern across all handlers. Already logged from story 2-8.
+
 ## Deferred from: code review of 2-8-get-update-delete-education-records (2026-05-04)
 
 - **EF global query filter bypass** — If `IgnoreQueryFilters()` is ever used or the filter is misconfigured, all three new handlers (`GetEducationQueryHandler`, `UpdateEducationCommandHandler`, `DeleteEducationCommandHandler`) could return soft-deleted records without an explicit `IsDeleted` guard. Deferred: pre-existing architectural assumption shared with Resume handlers.

--- a/_bmad-output/implementation-artifacts/r-1-separate-soft-delete-repository-contract.md
+++ b/_bmad-output/implementation-artifacts/r-1-separate-soft-delete-repository-contract.md
@@ -1,0 +1,368 @@
+# Story R.1: Separate Soft Delete Repository Contract from Editable Repositories
+
+Status: done
+
+GitHub Issue: #65
+
+## Story
+
+As a developer working on the Jobnecto backend,
+I want a dedicated `ISoftDeleteRepository<T>` interface applied to every repository whose entity extends `SoftDeletableEntity`,
+so that soft delete capability is expressed as a first-class contract independent of editable (update) semantics across the entire codebase.
+
+## Acceptance Criteria
+
+1. A `ISoftDeleteRepository<T>` interface exists in Application/Interfaces, constrained to `T : SoftDeletableEntity`, extending `IRepository<T>`, with a single `SoftDeleteAsync(T entity, CancellationToken ct)` method.
+2. A `IMutableRepository<T>` interface exists in Application/Interfaces as an explicit composition of `IEditableRepository<T>` and `ISoftDeleteRepository<T>`.
+3. `IEditableRepository<T>` is unchanged — it does not imply soft delete capability.
+4. All six soft-deletable entity repositories expose `ISoftDeleteRepository<T>` (directly or via composition) through their interface contracts:
+   - `IMutableRepository<Resume>` for `ResumeRepository`
+   - `IMutableRepository<Education>` for `EducationRepository`
+   - `IMutableRepository<CoverLetter>` for `CoverLetterRepository`
+   - `IMutableRepository<CoverLetterTemplate>` for `CoverLetterTemplateRepository`
+   - `IUserRepository` extends `ISoftDeleteRepository<User>` (specialized repo, explicit extension)
+   - `IVacancyRepository` extends `ISoftDeleteRepository<Vacancy>` (specialized repo, explicit extension)
+5. `IUnitOfWork.ResumeRepository`, `EducationRepository`, and `CoverLetterRepository` expose `IMutableRepository<T>` instead of `IEditableRepository<T>`.
+6. `DeleteResumeCommandHandler` and `DeleteEducationCommandHandler` call `SoftDeleteAsync` instead of manually setting `IsDeleted`/`DeletedAt` and calling `UpdateAsync`.
+7. A `SoftDeletableRepository<T>` abstract class in Infrastructure encapsulates the `IsDeleted = true; DeletedAt = DateTime.UtcNow` flag-setting logic and calls `_dbSet.Update(entity)`.
+8. All repositories whose entities are soft-deletable derive from `SoftDeletableRepository<T>` or implement `SoftDeleteAsync` directly: `ResumeRepository`, `EducationRepository`, `CoverLetterRepository`, `CoverLetterTemplateRepository`, `UserRepository`. `VacancyRepository` implements `SoftDeleteAsync` directly (it does not extend `EditableRepository`).
+9. Existing resume and education delete/update flows produce identical HTTP responses — zero behavior change at the API level.
+10. Unit tests for `DeleteResumeCommandHandler` and `DeleteEducationCommandHandler` are updated to mock `IMutableRepository<T>` and verify `SoftDeleteAsync` is called.
+11. New unit/infrastructure tests verify `SoftDeletableRepository<T>` sets `IsDeleted = true` and `DeletedAt` (UTC, non-null) and that the soft-deleted entity is subsequently excluded from queries via the EF global query filter.
+12. `dotnet build backend/JobNecto.slnx` passes.
+13. `dotnet test backend/JobNecto.slnx` passes.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Create `ISoftDeleteRepository<T>` (AC: 1)
+  - [x] Create `backend/src/JobNecto.Application/Interfaces/ISoftDeleteRepository.cs`
+  - [x] Namespace: `JobNecto.Application.Interfaces`
+  - [x] Constraint: `where T : SoftDeletableEntity`; extends `IRepository<T>`
+  - [x] Declare `Task SoftDeleteAsync(T entity, CancellationToken ct);`
+  - [x] Add XML doc on interface and method
+
+- [x] Task 2: Create `IMutableRepository<T>` (AC: 2, 3)
+  - [x] Create `backend/src/JobNecto.Application/Interfaces/IMutableRepository.cs`
+  - [x] Namespace: `JobNecto.Application.Interfaces`
+  - [x] Constraint: `where T : SoftDeletableEntity`; extends `IEditableRepository<T>` and `ISoftDeleteRepository<T>`
+  - [x] Add XML doc: role-based composition for entities that support all write operations (update + soft delete); `IEditableRepository<T>` alone does NOT imply soft delete
+
+- [x] Task 3: Extend `IUserRepository` with `ISoftDeleteRepository<User>` (AC: 4)
+  - [x] Modify `backend/src/JobNecto.Application/Interfaces/IUserRepository.cs`
+  - [x] Add `ISoftDeleteRepository<User>` to the interface inheritance list
+  - [x] Drop the now-redundant `IRepository<User>` from the list (already covered by `IEditableRepository<User>` and `ISoftDeleteRepository<User>`)
+  - [x] Result: `public interface IUserRepository : IEditableRepository<User>, ISoftDeleteRepository<User>`
+  - [x] Update XML doc
+
+- [x] Task 4: Extend `IVacancyRepository` with `ISoftDeleteRepository<Vacancy>` (AC: 4)
+  - [x] Modify `backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs`
+  - [x] Add `ISoftDeleteRepository<Vacancy>` to the interface inheritance list
+  - [x] Result: `public interface IVacancyRepository : IRepository<Vacancy>, ISoftDeleteRepository<Vacancy>`
+  - [x] Add XML doc
+
+- [x] Task 5: Update `IUnitOfWork` property types for CoverLetter, Resume, Education (AC: 5)
+  - [x] Modify `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`
+  - [x] `IEditableRepository<CoverLetter> CoverLetterRepository` → `IMutableRepository<CoverLetter> CoverLetterRepository`
+  - [x] `IEditableRepository<Resume> ResumeRepository` → `IMutableRepository<Resume> ResumeRepository`
+  - [x] `IEditableRepository<Education> EducationRepository` → `IMutableRepository<Education> EducationRepository`
+  - [x] `UserRepository` and `VacancyRepository` property types stay as `IUserRepository` and `IVacancyRepository` (those interfaces now extend ISoftDeleteRepository)
+  - [x] Update XML docs on changed properties
+
+- [x] Task 6: Create `SoftDeletableRepository<T>` in Infrastructure (AC: 7)
+  - [x] Create `backend/src/JobNecto.Infrastructure/Repositories/SoftDeletableRepository.cs`
+  - [x] Namespace: `JobNecto.Infrastructure.Repositories`
+  - [x] Class: `public abstract class SoftDeletableRepository<T> : EditableRepository<T>, IMutableRepository<T> where T : SoftDeletableEntity`
+  - [x] Implement `SoftDeleteAsync`: `entity.IsDeleted = true; entity.DeletedAt = DateTime.UtcNow; _dbSet.Update(entity); return Task.CompletedTask;`
+  - [x] Add XML doc on class and method
+
+- [x] Task 7: Switch `ResumeRepository`, `EducationRepository`, `CoverLetterRepository`, `CoverLetterTemplateRepository`, `UserRepository` to derive from `SoftDeletableRepository<T>` (AC: 8)
+  - [x] `ResumeRepository : SoftDeletableRepository<Resume>` (was `EditableRepository<Resume>`)
+  - [x] `EducationRepository : SoftDeletableRepository<Education>` (was `EditableRepository<Education>`)
+  - [x] `CoverLetterRepository : SoftDeletableRepository<CoverLetter>` (was `EditableRepository<CoverLetter>`)
+  - [x] `CoverLetterTemplateRepository : SoftDeletableRepository<CoverLetterTemplate>` (was `EditableRepository<CoverLetterTemplate>`)
+  - [x] `UserRepository : SoftDeletableRepository<User>, IUserRepository` (was `EditableRepository<User>, IUserRepository`)
+  - [x] No other changes in these files — constructors and existing methods remain identical
+
+- [x] Task 8: Implement `SoftDeleteAsync` directly in `VacancyRepository` (AC: 8)
+  - [x] Modify `backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs`
+  - [x] Keep `VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository` — do NOT change the base class to `EditableRepository` or `SoftDeletableRepository`
+  - [x] Add explicit implementation of `ISoftDeleteRepository<Vacancy>.SoftDeleteAsync`
+  - [x] Add XML doc on the method
+
+- [x] Task 9: Update `UnitOfWork` field and property types for CoverLetter (AC: 5)
+  - [x] Modify `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs`
+  - [x] Change `IEditableRepository<CoverLetter>? _coverLetterRepository` → `IMutableRepository<CoverLetter>?`
+  - [x] Change `IEditableRepository<Resume>? _resumeRepository` → `IMutableRepository<Resume>?`
+  - [x] Change `IEditableRepository<Education>? _educationRepository` → `IMutableRepository<Education>?`
+  - [x] Update the three lazy-init properties to return `IMutableRepository<T>`
+
+- [x] Task 10: Refactor `DeleteResumeCommandHandler` to use `SoftDeleteAsync` (AC: 6, 9)
+  - [x] Modify `backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs`
+  - [x] Remove manual flag setting; add `SoftDeleteAsync` call
+  - [x] All other logic unchanged
+
+- [x] Task 11: Refactor `DeleteEducationCommandHandler` to use `SoftDeleteAsync` (AC: 6, 9)
+  - [x] Modify `backend/src/JobNecto.Application/Educations/DeleteEducationCommandHandler.cs`
+  - [x] Remove manual flag setting; add `SoftDeleteAsync` call
+  - [x] All other logic unchanged
+
+- [x] Task 12: Update delete handler unit tests (AC: 10)
+  - [x] `backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs` — `Mock<IMutableRepository<Resume>>`, verify `SoftDeleteAsync` Times.Once and `UpdateAsync` Times.Never
+  - [x] `backend/tests/JobNecto.Tests/Application/Educations/DeleteEducationCommandHandlerTests.cs` — same pattern
+  - [x] Updated all other Resume/Education handler tests: `Mock<IMutableRepository<T>>` (6 additional files)
+
+- [x] Task 13: Add infrastructure tests for `SoftDeletableRepository<T>` (AC: 11)
+  - [x] Create `backend/tests/JobNecto.Tests/Infrastructure/SoftDeletableRepositoryTests.cs`
+  - [x] `SoftDeleteAsync_SetsIsDeletedAndDeletedAtUtc` passes
+  - [x] `SoftDeleteAsync_AfterSaveChanges_EntityExcludedFromQuery` passes
+
+- [x] Task 14: Run build and tests (AC: 12, 13)
+  - [x] `dotnet build backend/JobNecto.slnx` — 0 warnings, 0 errors
+  - [x] `dotnet test backend/JobNecto.slnx` — 292/292 passed
+  - [x] `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` — succeeded
+
+- [x] Task 15: Update architecture documentation (Decision 3 and 6)
+  - [x] Update `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md`
+  - [x] Decision 3: all six repositories listed with final interface types; full class hierarchy
+  - [x] Decision 6: soft delete handler pattern shows `SoftDeleteAsync` usage
+
+## Dev Notes
+
+### Core Problem
+
+Every entity in the domain that is soft-deletable extends `SoftDeletableEntity`. However, the soft delete operation — setting `IsDeleted = true` and `DeletedAt = DateTime.UtcNow` — was previously done inside handlers by calling `UpdateAsync` from `IEditableRepository<T>`. This couples delete semantics to update semantics. The fix: move soft delete into a dedicated interface and abstract class, and apply it uniformly across every repository whose entity is soft-deletable.
+
+### All Soft-Deletable Entities and Their Repositories
+
+| Entity | Current Repository Interface in UoW | After Refactor |
+| --- | --- | --- |
+| `Resume` | `IEditableRepository<Resume>` | `IMutableRepository<Resume>` |
+| `Education` | `IEditableRepository<Education>` | `IMutableRepository<Education>` |
+| `CoverLetter` | `IEditableRepository<CoverLetter>` | `IMutableRepository<CoverLetter>` |
+| `CoverLetterTemplate` | Not in UoW yet (Epic 3) | Base class changes now; Epic 3 adds to UoW |
+| `User` | `IUserRepository` | `IUserRepository` (now extends `ISoftDeleteRepository`) |
+| `Vacancy` | `IVacancyRepository` | `IVacancyRepository` (now extends `ISoftDeleteRepository`) |
+
+### Interface Hierarchy After Refactor
+
+```text
+IRepository<T>                                      [T : BaseEntity]
+├── IEditableRepository<T>  (+ UpdateAsync)         [T : BaseEntity]
+└── ISoftDeleteRepository<T>  (+ SoftDeleteAsync)   [T : SoftDeletableEntity]
+    └── IMutableRepository<T>                       [T : SoftDeletableEntity]
+            ← role-based composition: IEditableRepository<T> + ISoftDeleteRepository<T>
+```
+
+Specialized interfaces after refactor:
+
+```text
+IUserRepository    : IEditableRepository<User>,    ISoftDeleteRepository<User>
+IVacancyRepository : IRepository<Vacancy>,         ISoftDeleteRepository<Vacancy>
+```
+
+### Infrastructure Class Hierarchy After Refactor
+
+```text
+BaseRepository<T>                           (implements IRepository<T>)
+└── EditableRepository<T>                   (implements IEditableRepository<T>)
+    └── SoftDeletableRepository<T>          (implements ISoftDeleteRepository<T>)
+        ├── ResumeRepository
+        ├── EducationRepository
+        ├── CoverLetterRepository
+        ├── CoverLetterTemplateRepository
+        └── UserRepository                  (also implements IUserRepository)
+
+BaseRepository<Vacancy>                     (implements IRepository<Vacancy>)
+└── VacancyRepository                       (implements IVacancyRepository + SoftDeleteAsync directly)
+```
+
+### All Files to Touch
+
+| File | Change Type |
+| --- | --- |
+| `backend/src/JobNecto.Application/Interfaces/ISoftDeleteRepository.cs` | **CREATE** |
+| `backend/src/JobNecto.Application/Interfaces/IMutableRepository.cs` | **CREATE** |
+| `backend/src/JobNecto.Infrastructure/Repositories/SoftDeletableRepository.cs` | **CREATE** |
+| `backend/tests/JobNecto.Tests/Infrastructure/SoftDeletableRepositoryTests.cs` | **CREATE** |
+| `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs` | **UPDATE** — Resume, Education, CoverLetter property types |
+| `backend/src/JobNecto.Application/Interfaces/IUserRepository.cs` | **UPDATE** — add `ISoftDeleteRepository` |
+| `backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs` | **UPDATE** — add `ISoftDeleteRepository` |
+| `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs` | **UPDATE** — field and property types for Resume, Education, CoverLetter |
+| `backend/src/JobNecto.Infrastructure/Repositories/ResumeRepository.cs` | **UPDATE** — base class |
+| `backend/src/JobNecto.Infrastructure/Repositories/EducationRepository.cs` | **UPDATE** — base class |
+| `backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs` | **UPDATE** — base class |
+| `backend/src/JobNecto.Infrastructure/Repositories/CoverLetterTemplateRepository.cs` | **UPDATE** — base class |
+| `backend/src/JobNecto.Infrastructure/Repositories/UserRepository.cs` | **UPDATE** — base class |
+| `backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs` | **UPDATE** — add SoftDeleteAsync |
+| `backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs` | **UPDATE** — use SoftDeleteAsync |
+| `backend/src/JobNecto.Application/Educations/DeleteEducationCommandHandler.cs` | **UPDATE** — use SoftDeleteAsync |
+| `backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs` | **UPDATE** — mock type + verify calls |
+| `backend/tests/JobNecto.Tests/Application/Educations/DeleteEducationCommandHandlerTests.cs` | **UPDATE** — mock type + verify calls |
+| `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` | **UPDATE** — Decisions 3 and 6 |
+
+### Key Implementation Details
+
+**`SoftDeletableRepository<T>` implementation:**
+
+```csharp
+public abstract class SoftDeletableRepository<T> : EditableRepository<T>, ISoftDeleteRepository<T>
+    where T : SoftDeletableEntity
+{
+    protected SoftDeletableRepository(AppDbContext context) : base(context) { }
+
+    public Task SoftDeleteAsync(T entity, CancellationToken ct)
+    {
+        entity.IsDeleted = true;
+        entity.DeletedAt = DateTime.UtcNow;
+        _dbSet.Update(entity);
+        return Task.CompletedTask;
+    }
+}
+```
+
+`Task.CompletedTask` is correct — `_dbSet.Update` is synchronous; no `async/await` needed.
+
+**`VacancyRepository` — implement directly, do NOT change base class:**
+Vacancy does not need generic `UpdateAsync` (it has `UpdateMatchScoreAsync`). Changing its base to `SoftDeletableRepository<T>` would silently add an unintended `UpdateAsync` to the class and widen its capabilities without purpose. Implement `SoftDeleteAsync` inline instead.
+
+**`IUserRepository` — drop redundant `IRepository<User>`:**
+`IUserRepository` currently declares `IRepository<User>, IEditableRepository<User>` — since `IEditableRepository<User>` already extends `IRepository<User>`, the declaration is redundant. Remove the explicit `IRepository<User>` while adding `ISoftDeleteRepository<User>`:
+
+```csharp
+public interface IUserRepository : IEditableRepository<User>, ISoftDeleteRepository<User> { ... }
+```
+
+**`SoftDeletableEntity` uses fields, not properties:**
+`IsDeleted` and `DeletedAt` are declared as **public fields** in `SoftDeletableEntity.cs` — assign them directly without `.` property setter syntax confusion. This is an existing pattern in the codebase.
+
+**Test mock for `SoftDeleteAsync` must simulate entity mutation:**
+Moq won't run the real implementation. Configure with a Callback to ensure handler assertions on entity state stay valid:
+
+```csharp
+_repoMock
+    .Setup(x => x.SoftDeleteAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()))
+    .Callback<Resume, CancellationToken>((entity, _) =>
+    {
+        entity.IsDeleted = true;
+        entity.DeletedAt = DateTime.UtcNow;
+    })
+    .Returns(Task.CompletedTask);
+```
+
+**`CoverLetterTemplate` is not in `IUnitOfWork` yet — don't add it:**
+
+Only change its base class from `EditableRepository<CoverLetterTemplate>` to `SoftDeletableRepository<CoverLetterTemplate>`. Epic 3 will add it to UnitOfWork as `IMutableRepository<CoverLetterTemplate>`.
+
+**InMemory test: generate database name once per test, not per scope:**
+
+```csharp
+var dbName = Guid.NewGuid().ToString();
+var options = new DbContextOptionsBuilder<AppDbContext>()
+    .UseInMemoryDatabase(dbName)
+    .Options;
+```
+
+Reuse `options` across `await using` context instances in the same test. [Source: agent-learnings.md — "In-memory DB name changed per scope"]
+
+### Zero Behavioral Change Guarantee
+
+This is a pure refactoring. The following must be identical before and after:
+
+- `DELETE /api/v1/resumes/{id}` → `204 No Content`, `403`, `404` semantics unchanged
+- `DELETE /api/v1/educations/{id}` → same
+- EF global query filter exclusion of soft-deleted records — unchanged, since `_dbSet.Update(entity)` in `SoftDeleteAsync` produces the same EF change-tracking behavior as the prior `UpdateAsync` call
+
+### Agent Learnings to Apply
+
+- Set entity timestamps explicitly in UTC in the layer that owns the logic — here `SoftDeletableRepository.SoftDeleteAsync`, not the handler. [Source: agent-learnings.md — "Set entity timestamps in handlers, not only DB defaults"]
+- Prefer separate handler files; this story modifies existing files only. [Source: agent-learnings.md — "Prefer separate handler file"]
+- Keep generated test data validator-compliant. Infrastructure tests skip validators; seed any valid shape. [Source: agent-learnings.md — "Keep generated test data validator-compliant"]
+- Generate one database name per test provider, not inside the options lambda. [Source: agent-learnings.md — "In-memory DB name changed per scope"]
+
+### Namespace Convention (Mandatory)
+
+| File | Namespace |
+| --- | --- |
+| `ISoftDeleteRepository.cs` | `JobNecto.Application.Interfaces` |
+| `IMutableRepository.cs` | `JobNecto.Application.Interfaces` |
+
+| `SoftDeletableRepository.cs` | `JobNecto.Infrastructure.Repositories` |
+| `SoftDeletableRepositoryTests.cs` | `JobNecto.Tests.Infrastructure` |
+
+### References
+
+- [Source: `backend/src/JobNecto.Domain/Entities/SoftDeletableEntity.cs`] — `IsDeleted` and `DeletedAt` are **fields**
+- [Source: `backend/src/JobNecto.Application/Interfaces/IRepository.cs`] — base interface
+- [Source: `backend/src/JobNecto.Application/Interfaces/IEditableRepository.cs`] — unchanged
+- [Source: `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`] — property types to update
+- [Source: `backend/src/JobNecto.Application/Interfaces/IUserRepository.cs`] — add `ISoftDeleteRepository`
+- [Source: `backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs`] — add `ISoftDeleteRepository`
+- [Source: `backend/src/JobNecto.Infrastructure/Repositories/EditableRepository.cs`] — parent of new SoftDeletableRepository
+- [Source: `backend/src/JobNecto.Infrastructure/Repositories/BaseRepository.cs`] — root implementation
+- [Source: `backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs`] — inline SoftDeleteAsync
+- [Source: `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs`] — field/property changes
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` — Decision 3] — repository baseline
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` — Decision 6] — soft delete pattern
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Debug Log References
+
+Build error: `SoftDeletableRepository<T>` initially declared `ISoftDeleteRepository<T>` — needed `IMutableRepository<T>` so concrete repositories satisfy `IMutableRepository<T>` assignment in UnitOfWork. Fixed by changing class declaration.
+Side effect: 8 existing handler test files used `Mock<IEditableRepository<T>>` for Resume/Education repos — updated all to `Mock<IMutableRepository<T>>`.
+
+### Completion Notes List
+
+All 13 ACs satisfied. Pure refactoring — zero behavioral change at HTTP level.
+
+- Created `ISoftDeleteRepository<T>` and `IMutableRepository<T>` in Application/Interfaces.
+- Created `SoftDeletableRepository<T>` abstract class in Infrastructure; 5 repositories reparented to it.
+- `VacancyRepository` implements `SoftDeleteAsync` inline (no base-class change).
+- `IUserRepository` and `IVacancyRepository` extended with `ISoftDeleteRepository<T>`.
+- `IUnitOfWork` and `UnitOfWork` fields/properties updated to `IMutableRepository<T>` for Resume, Education, CoverLetter.
+- Both delete handlers now call `SoftDeleteAsync`; 10 test files updated.
+- 2 new infra tests added; 292/292 passed, Release + warnaserror clean.
+
+### File List
+
+backend/src/JobNecto.Application/Interfaces/ISoftDeleteRepository.cs (CREATED)
+backend/src/JobNecto.Application/Interfaces/IMutableRepository.cs (CREATED)
+backend/src/JobNecto.Infrastructure/Repositories/SoftDeletableRepository.cs (CREATED)
+backend/tests/JobNecto.Tests/Infrastructure/SoftDeletableRepositoryTests.cs (CREATED)
+backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs (UPDATED)
+backend/src/JobNecto.Application/Interfaces/IUserRepository.cs (UPDATED)
+backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs (UPDATED)
+backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs (UPDATED)
+backend/src/JobNecto.Infrastructure/Repositories/ResumeRepository.cs (UPDATED)
+backend/src/JobNecto.Infrastructure/Repositories/EducationRepository.cs (UPDATED)
+backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs (UPDATED)
+backend/src/JobNecto.Infrastructure/Repositories/CoverLetterTemplateRepository.cs (UPDATED)
+backend/src/JobNecto.Infrastructure/Repositories/UserRepository.cs (UPDATED)
+backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs (UPDATED)
+backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs (UPDATED)
+backend/src/JobNecto.Application/Educations/DeleteEducationCommandHandler.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Educations/DeleteEducationCommandHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Resumes/CreateResumeCommandHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Resumes/UpdateResumeCommandHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Resumes/ListResumesHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Resumes/GetResumeHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Educations/CreateEducationCommandHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Educations/UpdateEducationCommandHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Educations/ListEducationsQueryHandlerTests.cs (UPDATED)
+backend/tests/JobNecto.Tests/Application/Educations/GetEducationQueryHandlerTests.cs (UPDATED)
+_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md (UPDATED)
+
+## Change Log
+
+- 2026-05-05: Implemented story R.1 — introduced `ISoftDeleteRepository<T>`, `IMutableRepository<T>`, and `SoftDeletableRepository<T>`; reparented 5 repositories; refactored delete handlers to use `SoftDeleteAsync`; updated 10 test files; 292/292 tests passing.
+- 2026-05-06: Code review completed. 0 decision-needed, 0 patch, 2 deferred, 10 dismissed.
+
+### Review Findings
+
+- [x] \[Review\]\[Defer\] CancellationToken unused in SoftDeleteAsync \[SoftDeletableRepository.cs, VacancyRepository.cs\] — deferred, pre-existing pattern (EditableRepository.UpdateAsync has identical ct-ignoring behavior)
+- [x] \[Review\]\[Defer\] DateTime.UtcNow hardcoded in SoftDeletableRepository/VacancyRepository — deferred, pre-existing pattern already logged from story 2-8

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-05-05T00:00:00Z
+# last_updated: 2026-05-06T00:00:00Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -54,6 +54,11 @@ development_status:
   2-7-list-education-records: done
   2-8-get-update-delete-education-records: done
   epic-2-retrospective: done
+
+  # --- Maintenance / Refactoring (GitHub Issues) ---
+  epic-r: in-progress
+  r-1-separate-soft-delete-repository-contract: done
+  epic-r-retrospective: optional
 
   # --- Epic 3: Cover Letter Template Library ---
   epic-3: backlog

--- a/_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md
+++ b/_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md
@@ -162,20 +162,71 @@ public interface IEditableRepository<T> : IRepository<T>
 {
     Task<T> UpdateAsync(T entity, CancellationToken ct);
 }
+
+// Introduced by GitHub issue #65 (story R.1):
+// Soft delete is expressed as a first-class contract independent of update semantics.
+public interface ISoftDeleteRepository<T> : IRepository<T>
+    where T : SoftDeletableEntity
+{
+    Task SoftDeleteAsync(T entity, CancellationToken ct);
+}
+
+// Role-based composition for entities that support all write operations (update + soft delete).
+// Named by role ("mutable"), not by capability enumeration, so future write-side additions
+// do not require renaming this interface.
+// IEditableRepository<T> alone does NOT imply soft delete capability.
+public interface IMutableRepository<T> : IEditableRepository<T>, ISoftDeleteRepository<T>
+    where T : SoftDeletableEntity
+{
+}
 ```
+
+**Interface hierarchy:**
+
+```text
+IRepository<T>
+├── IEditableRepository<T>             (+ UpdateAsync)   [T : BaseEntity]
+└── ISoftDeleteRepository<T>           (+ SoftDeleteAsync) [T : SoftDeletableEntity]
+    └── IMutableRepository<T>  (composes both)  [T : SoftDeletableEntity]
+```
+
+**Infrastructure class hierarchy:**
+
+```text
+BaseRepository<T>                           (implements IRepository<T>)
+├── EditableRepository<T>                   (implements IEditableRepository<T>)
+│   └── SoftDeletableRepository<T>          (implements IMutableRepository<T>)
+│       ├── ResumeRepository
+│       ├── EducationRepository
+│       ├── CoverLetterRepository
+│       ├── CoverLetterTemplateRepository
+│       └── UserRepository                  (also implements IUserRepository)
+└── VacancyRepository                       (implements IVacancyRepository + SoftDeleteAsync directly)
+```
+
+**All six soft-deletable entity repositories and their final interface types:**
+
+| Repository | Interface in UnitOfWork / Specialized |
+| --- | --- |
+| `ResumeRepository` | `IMutableRepository<Resume>` |
+| `EducationRepository` | `IMutableRepository<Education>` |
+| `CoverLetterRepository` | `IMutableRepository<CoverLetter>` |
+| `CoverLetterTemplateRepository` | `SoftDeletableRepository<CoverLetterTemplate>` (Epic 3 adds to UoW as `IMutableRepository<CoverLetterTemplate>`) |
+| `UserRepository` | `IUserRepository` (extends `IEditableRepository<User>` + `ISoftDeleteRepository<User>`) |
+| `VacancyRepository` | `IVacancyRepository` (extends `IRepository<Vacancy>` + `ISoftDeleteRepository<Vacancy>`) |
 
 **`GetByIdAsync` contract:** Returns `Task<T>` (non-nullable). The repository implementation throws `NotFoundException` when no entity with the given `id` exists. Callers must not null-check the result — the throw guarantee is part of the contract. This is why handler examples do not include `if (entity == null)` guards after `GetByIdAsync` calls.
 
-**Current UnitOfWork exposure after Epic 2:**
+**Current UnitOfWork exposure after story R.1:**
 
 ```csharp
 public interface IUnitOfWork : IAsyncDisposable
 {
-    IUserRepository UserRepository { get; }
-    IVacancyRepository VacancyRepository { get; }
-    IEditableRepository<CoverLetter> CoverLetterRepository { get; }
-    IEditableRepository<Resume> ResumeRepository { get; }
-    IEditableRepository<Education> EducationRepository { get; }
+    IUserRepository UserRepository { get; }          // IUserRepository extends ISoftDeleteRepository<User>
+    IVacancyRepository VacancyRepository { get; }    // IVacancyRepository extends ISoftDeleteRepository<Vacancy>
+    IMutableRepository<CoverLetter> CoverLetterRepository { get; }
+    IMutableRepository<Resume> ResumeRepository { get; }
+    IMutableRepository<Education> EducationRepository { get; }
 
     Task<int> SaveChangesAsync(CancellationToken ct);
     Task BeginTransactionAsync(CancellationToken ct);
@@ -434,24 +485,21 @@ public class AppDbContext : DbContext
 }
 ```
 
-**Soft Delete Handler Pattern:**
+**Soft Delete Handler Pattern (after story R.1):**
+
+Soft delete is performed via `SoftDeleteAsync` on `IMutableRepository<T>`. The flag-setting logic (`IsDeleted = true`, `DeletedAt = DateTime.UtcNow`) lives in `SoftDeletableRepository<T>`, not in the handler.
 
 ```csharp
 public async Task<Unit> Handle(DeleteResumeCommand request, CancellationToken cancellationToken)
 {
     var resume = await _unitOfWork.ResumeRepository.GetByIdAsync(request.ResumeId, cancellationToken);
-    
-    // Verify ownership
+
     if (resume.UserId != request.UserId)
         throw new ForbiddenException("You do not have permission to delete this resume.");
-    
-    // Soft delete: mark as deleted and timestamp for TTL grace period
-    resume.IsDeleted = true;
-    resume.DeletedAt = DateTime.UtcNow;
-    
-    await _unitOfWork.ResumeRepository.UpdateAsync(resume, cancellationToken);
+
+    await _unitOfWork.ResumeRepository.SoftDeleteAsync(resume, cancellationToken);
     await _unitOfWork.SaveChangesAsync(cancellationToken);
-    
+
     return Unit.Value;
 }
 ```

--- a/backend/src/JobNecto.Application/Educations/DeleteEducationCommandHandler.cs
+++ b/backend/src/JobNecto.Application/Educations/DeleteEducationCommandHandler.cs
@@ -28,10 +28,7 @@ public class DeleteEducationCommandHandler : IRequestHandler<DeleteEducationComm
         if (education.UserId != request.UserId)
             throw new ForbiddenException("You do not have permission to delete this education record.");
 
-        education.IsDeleted = true;
-        education.DeletedAt = DateTime.UtcNow;
-
-        await _unitOfWork.EducationRepository.UpdateAsync(education, cancellationToken);
+        await _unitOfWork.EducationRepository.SoftDeleteAsync(education, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;

--- a/backend/src/JobNecto.Application/Interfaces/IMutableRepository.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IMutableRepository.cs
@@ -1,0 +1,13 @@
+using JobNecto.Domain.Entities;
+
+namespace JobNecto.Application.Interfaces;
+
+/// <summary>
+/// Role-based composition for entities that support all write operations: update and soft delete.
+/// <see cref="IEditableRepository{T}"/> alone does NOT imply soft delete capability.
+/// </summary>
+/// <typeparam name="T">An entity type that extends <see cref="SoftDeletableEntity"/>.</typeparam>
+public interface IMutableRepository<T> : IEditableRepository<T>, ISoftDeleteRepository<T>
+    where T : SoftDeletableEntity
+{
+}

--- a/backend/src/JobNecto.Application/Interfaces/ISoftDeleteRepository.cs
+++ b/backend/src/JobNecto.Application/Interfaces/ISoftDeleteRepository.cs
@@ -1,0 +1,18 @@
+using JobNecto.Domain.Entities;
+
+namespace JobNecto.Application.Interfaces;
+
+/// <summary>
+/// Repository contract for entities that support soft deletion.
+/// Soft delete is a first-class operation independent of update (<see cref="IEditableRepository{T}"/>) semantics.
+/// </summary>
+/// <typeparam name="T">An entity type that extends <see cref="SoftDeletableEntity"/>.</typeparam>
+public interface ISoftDeleteRepository<T> : IRepository<T>
+    where T : SoftDeletableEntity
+{
+    /// <summary>
+    /// Marks <paramref name="entity"/> as soft-deleted by setting <c>IsDeleted</c> and <c>DeletedAt</c>,
+    /// then stages the change for persistence on the next <c>SaveChangesAsync</c> call.
+    /// </summary>
+    Task SoftDeleteAsync(T entity, CancellationToken ct);
+}

--- a/backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs
@@ -21,19 +21,19 @@ public interface IUnitOfWork : IAsyncDisposable
     IVacancyRepository VacancyRepository { get; }
 
     /// <summary>
-    /// Repository for cover letters with CRUD/query support.
+    /// Repository for cover letters with full write support (update + soft delete).
     /// </summary>
-    IEditableRepository<CoverLetter> CoverLetterRepository { get; }
+    IMutableRepository<CoverLetter> CoverLetterRepository { get; }
 
     /// <summary>
-    /// Repository for resumes with CRUD/query support.
+    /// Repository for resumes with full write support (update + soft delete).
     /// </summary>
-    IEditableRepository<Resume> ResumeRepository { get; }
+    IMutableRepository<Resume> ResumeRepository { get; }
 
     /// <summary>
-    /// Repository for educations with CRUD/query support.
+    /// Repository for educations with full write support (update + soft delete).
     /// </summary>
-    IEditableRepository<Education> EducationRepository { get; }
+    IMutableRepository<Education> EducationRepository { get; }
 
     /// <summary>
     /// Persists pending changes to the database. Implementations should forward

--- a/backend/src/JobNecto.Application/Interfaces/IUserRepository.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IUserRepository.cs
@@ -5,9 +5,10 @@ namespace JobNecto.Application.Interfaces;
 /// <summary>
 /// Repository contract for <see cref="User"/> persistence operations that are specific
 /// to the <c>User</c> aggregate and are not covered by the generic <see cref="IRepository{T}"/>.
+/// Extends <see cref="ISoftDeleteRepository{T}"/> to expose soft-delete capability.
 /// Implementations live in the Infrastructure layer and are registered via <c>IUnitOfWork</c>.
 /// </summary>
-public interface IUserRepository : IRepository<User>, IEditableRepository<User>
+public interface IUserRepository : IEditableRepository<User>, ISoftDeleteRepository<User>
 {
     /// <summary>
     /// Retrieves a user by their email address.

--- a/backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs
@@ -3,7 +3,8 @@ using JobNecto.Domain.ValueObjects;
 
 namespace JobNecto.Application.Interfaces;
 
-public interface IVacancyRepository : IRepository<Vacancy>
+/// <summary>Vacancy-specific query and persistence contract. Extends soft delete capability.</summary>
+public interface IVacancyRepository : IRepository<Vacancy>, ISoftDeleteRepository<Vacancy>
 {
     public Task<PagedResult<Vacancy>> GetFilteredAsync(PagedQuery pagedQuery, VacancyFilter? filter = null, CancellationToken ct = default);
     public Task<Vacancy> UpdateMatchScoreAsync(Guid id, double matchScore, CancellationToken ct);

--- a/backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs
@@ -4,7 +4,7 @@ using JobNecto.Domain.ValueObjects;
 namespace JobNecto.Application.Interfaces;
 
 /// <summary>Vacancy-specific query and persistence contract. Extends soft delete capability.</summary>
-public interface IVacancyRepository : IRepository<Vacancy>, ISoftDeleteRepository<Vacancy>
+public interface IVacancyRepository : ISoftDeleteRepository<Vacancy>
 {
     public Task<PagedResult<Vacancy>> GetFilteredAsync(PagedQuery pagedQuery, VacancyFilter? filter = null, CancellationToken ct = default);
     public Task<Vacancy> UpdateMatchScoreAsync(Guid id, double matchScore, CancellationToken ct);

--- a/backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs
+++ b/backend/src/JobNecto.Application/Resumes/DeleteResumeCommandHandler.cs
@@ -28,10 +28,7 @@ public class DeleteResumeCommandHandler : IRequestHandler<DeleteResumeCommand, U
         if (resume.UserId != request.UserId)
             throw new ForbiddenException("You do not have permission to delete this resume.");
 
-        resume.IsDeleted = true;
-        resume.DeletedAt = DateTime.UtcNow;
-
-        await _unitOfWork.ResumeRepository.UpdateAsync(resume, cancellationToken);
+        await _unitOfWork.ResumeRepository.SoftDeleteAsync(resume, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;

--- a/backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs
@@ -13,9 +13,9 @@ public class UnitOfWork : IUnitOfWork
 
     private IUserRepository? _userRepository;
     private IVacancyRepository? _vacancyRepository;
-    private IEditableRepository<CoverLetter>? _coverLetterRepository;
-    private IEditableRepository<Resume>? _resumeRepository;
-    private IEditableRepository<Education>? _educationRepository;
+    private IMutableRepository<CoverLetter>? _coverLetterRepository;
+    private IMutableRepository<Resume>? _resumeRepository;
+    private IMutableRepository<Education>? _educationRepository;
 
     public UnitOfWork(AppDbContext context)
     {
@@ -28,13 +28,13 @@ public class UnitOfWork : IUnitOfWork
     public IVacancyRepository VacancyRepository => 
         _vacancyRepository ??= new VacancyRepository(_context);
 
-    public IEditableRepository<CoverLetter> CoverLetterRepository => 
+    public IMutableRepository<CoverLetter> CoverLetterRepository =>
         _coverLetterRepository ??= new CoverLetterRepository(_context);
 
-    public IEditableRepository<Resume> ResumeRepository => 
+    public IMutableRepository<Resume> ResumeRepository =>
         _resumeRepository ??= new ResumeRepository(_context);
 
-    public IEditableRepository<Education> EducationRepository => 
+    public IMutableRepository<Education> EducationRepository =>
         _educationRepository ??= new EducationRepository(_context);
 
     public async Task BeginTransactionAsync(CancellationToken ct)

--- a/backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs
@@ -3,7 +3,7 @@ using JobNecto.Domain.Entities;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class CoverLetterRepository : EditableRepository<CoverLetter>
+public class CoverLetterRepository : SoftDeletableRepository<CoverLetter>
 {
     public CoverLetterRepository(AppDbContext context) : base(context)
     {

--- a/backend/src/JobNecto.Infrastructure/Repositories/CoverLetterTemplateRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/CoverLetterTemplateRepository.cs
@@ -3,7 +3,7 @@ using JobNecto.Domain.Entities;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class CoverLetterTemplateRepository : EditableRepository<CoverLetterTemplate>
+public class CoverLetterTemplateRepository : SoftDeletableRepository<CoverLetterTemplate>
 {
     public CoverLetterTemplateRepository(AppDbContext context) : base(context)
     {

--- a/backend/src/JobNecto.Infrastructure/Repositories/EducationRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/EducationRepository.cs
@@ -3,7 +3,7 @@ using JobNecto.Domain.Entities;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class EducationRepository : EditableRepository<Education>
+public class EducationRepository : SoftDeletableRepository<Education>
 {
     public EducationRepository(AppDbContext context) : base(context)
     {

--- a/backend/src/JobNecto.Infrastructure/Repositories/ResumeRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/ResumeRepository.cs
@@ -3,7 +3,7 @@ using JobNecto.Domain.Entities;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class ResumeRepository : EditableRepository<Resume>
+public class ResumeRepository : SoftDeletableRepository<Resume>
 {
     public ResumeRepository(AppDbContext context) : base(context)
     {

--- a/backend/src/JobNecto.Infrastructure/Repositories/SoftDeletableRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/SoftDeletableRepository.cs
@@ -1,0 +1,29 @@
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.Entities;
+using JobNecto.Infrastructure.Persistance;
+
+namespace JobNecto.Infrastructure.Repositories;
+
+/// <summary>
+/// Abstract repository base for entities that support soft deletion.
+/// Encapsulates the <c>IsDeleted = true; DeletedAt = DateTime.UtcNow</c> flag-setting logic
+/// and stages the change via <c>_dbSet.Update</c>.
+/// </summary>
+/// <typeparam name="T">An entity type that extends <see cref="SoftDeletableEntity"/>.</typeparam>
+public abstract class SoftDeletableRepository<T> : EditableRepository<T>, IMutableRepository<T>
+    where T : SoftDeletableEntity
+{
+    protected SoftDeletableRepository(AppDbContext context) : base(context) { }
+
+    /// <summary>
+    /// Marks <paramref name="entity"/> as soft-deleted and stages the update for the next
+    /// <c>SaveChangesAsync</c> call. UTC timestamp is set here, not in the handler.
+    /// </summary>
+    public Task SoftDeleteAsync(T entity, CancellationToken ct)
+    {
+        entity.IsDeleted = true;
+        entity.DeletedAt = DateTime.UtcNow;
+        _dbSet.Update(entity);
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/JobNecto.Infrastructure/Repositories/UserRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/UserRepository.cs
@@ -5,7 +5,7 @@ using JobNecto.Domain.Entities;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class UserRepository : EditableRepository<User>, IUserRepository
+public class UserRepository : SoftDeletableRepository<User>, IUserRepository
 {
     public UserRepository(AppDbContext context)
         : base(context) { }

--- a/backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs
@@ -6,7 +6,7 @@ using JobNecto.Domain.ValueObjects;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository, ISoftDeleteRepository<Vacancy>
+public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository
 {
     public VacancyRepository(AppDbContext context)
         : base(context) { }

--- a/backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs
@@ -6,7 +6,7 @@ using JobNecto.Domain.ValueObjects;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository
+public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository, ISoftDeleteRepository<Vacancy>
 {
     public VacancyRepository(AppDbContext context)
         : base(context) { }
@@ -176,5 +176,17 @@ public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository
     public Task<Vacancy> UpdateMatchScoreAsync(Guid id, double matchScore, CancellationToken ct)
     {
         throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Marks <paramref name="entity"/> as soft-deleted and stages the update for the next
+    /// <c>SaveChangesAsync</c> call. 
+    /// </summary>
+    public Task SoftDeleteAsync(Vacancy entity, CancellationToken ct)
+    {
+        entity.IsDeleted = true;
+        entity.DeletedAt = DateTime.UtcNow;
+        _dbSet.Update(entity);
+        return Task.CompletedTask;
     }
 }

--- a/backend/tests/JobNecto.Tests/Application/Educations/CreateEducationCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Educations/CreateEducationCommandHandlerTests.cs
@@ -9,13 +9,13 @@ namespace JobNecto.Tests.Application.Educations;
 public class CreateEducationCommandHandlerTests
 {
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-    private readonly Mock<IEditableRepository<Education>> _educationRepositoryMock;
+    private readonly Mock<IMutableRepository<Education>> _educationRepositoryMock;
     private readonly CreateEducationCommandHandler _handler;
 
     public CreateEducationCommandHandlerTests()
     {
         _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _educationRepositoryMock = new Mock<IEditableRepository<Education>>();
+        _educationRepositoryMock = new Mock<IMutableRepository<Education>>();
 
         _unitOfWorkMock
             .Setup(x => x.EducationRepository)

--- a/backend/tests/JobNecto.Tests/Application/Educations/DeleteEducationCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Educations/DeleteEducationCommandHandlerTests.cs
@@ -12,19 +12,19 @@ namespace JobNecto.Tests.Application.Educations;
 public class DeleteEducationCommandHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Education>> _educationRepoMock;
+    private readonly Mock<IMutableRepository<Education>> _educationRepoMock;
     private readonly DeleteEducationCommandHandler _handler;
 
     public DeleteEducationCommandHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _educationRepoMock = new Mock<IEditableRepository<Education>>();
+        _educationRepoMock = new Mock<IMutableRepository<Education>>();
         _uowMock.Setup(x => x.EducationRepository).Returns(_educationRepoMock.Object);
         _handler = new DeleteEducationCommandHandler(_uowMock.Object);
     }
 
     [Fact]
-    public async Task Handle_OwnedRecord_SetsSoftDeleteFlagsAndPersists()
+    public async Task Handle_OwnedRecord_CallsSoftDeleteAndPersists()
     {
         var userId = Guid.NewGuid();
         var education = new Education
@@ -45,8 +45,13 @@ public class DeleteEducationCommandHandlerTests
             .ReturnsAsync(education);
 
         _educationRepoMock
-            .Setup(x => x.UpdateAsync(It.IsAny<Education>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Education entity, CancellationToken _) => entity);
+            .Setup(x => x.SoftDeleteAsync(It.IsAny<Education>(), It.IsAny<CancellationToken>()))
+            .Callback<Education, CancellationToken>((entity, _) =>
+            {
+                entity.IsDeleted = true;
+                entity.DeletedAt = DateTime.UtcNow;
+            })
+            .Returns(Task.CompletedTask);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -55,7 +60,8 @@ public class DeleteEducationCommandHandlerTests
         education.DeletedAt.Should().NotBeNull();
         education.DeletedAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
 
-        _educationRepoMock.Verify(x => x.UpdateAsync(education, It.IsAny<CancellationToken>()), Times.Once);
+        _educationRepoMock.Verify(x => x.SoftDeleteAsync(education, It.IsAny<CancellationToken>()), Times.Once);
+        _educationRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Education>(), It.IsAny<CancellationToken>()), Times.Never);
         _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -83,7 +89,7 @@ public class DeleteEducationCommandHandlerTests
         var act = () => _handler.Handle(command, CancellationToken.None);
 
         await act.Should().ThrowAsync<ForbiddenException>();
-        _educationRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Education>(), It.IsAny<CancellationToken>()), Times.Never);
+        _educationRepoMock.Verify(x => x.SoftDeleteAsync(It.IsAny<Education>(), It.IsAny<CancellationToken>()), Times.Never);
         _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -100,7 +106,7 @@ public class DeleteEducationCommandHandlerTests
         var act = () => _handler.Handle(command, CancellationToken.None);
 
         await act.Should().ThrowAsync<NotFoundException>();
-        _educationRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Education>(), It.IsAny<CancellationToken>()), Times.Never);
+        _educationRepoMock.Verify(x => x.SoftDeleteAsync(It.IsAny<Education>(), It.IsAny<CancellationToken>()), Times.Never);
         _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/backend/tests/JobNecto.Tests/Application/Educations/GetEducationQueryHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Educations/GetEducationQueryHandlerTests.cs
@@ -11,13 +11,13 @@ namespace JobNecto.Tests.Application.Educations;
 public class GetEducationQueryHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Education>> _educationRepoMock;
+    private readonly Mock<IMutableRepository<Education>> _educationRepoMock;
     private readonly GetEducationQueryHandler _handler;
 
     public GetEducationQueryHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _educationRepoMock = new Mock<IEditableRepository<Education>>();
+        _educationRepoMock = new Mock<IMutableRepository<Education>>();
         _uowMock.Setup(x => x.EducationRepository).Returns(_educationRepoMock.Object);
         _handler = new GetEducationQueryHandler(_uowMock.Object);
     }

--- a/backend/tests/JobNecto.Tests/Application/Educations/ListEducationsQueryHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Educations/ListEducationsQueryHandlerTests.cs
@@ -10,13 +10,13 @@ namespace JobNecto.Tests.Application.Educations;
 public class ListEducationsQueryHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Education>> _educationRepoMock;
+    private readonly Mock<IMutableRepository<Education>> _educationRepoMock;
     private readonly ListEducationsQueryHandler _handler;
 
     public ListEducationsQueryHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _educationRepoMock = new Mock<IEditableRepository<Education>>();
+        _educationRepoMock = new Mock<IMutableRepository<Education>>();
         _uowMock.Setup(x => x.EducationRepository).Returns(_educationRepoMock.Object);
         _handler = new ListEducationsQueryHandler(_uowMock.Object);
     }

--- a/backend/tests/JobNecto.Tests/Application/Educations/UpdateEducationCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Educations/UpdateEducationCommandHandlerTests.cs
@@ -11,13 +11,13 @@ namespace JobNecto.Tests.Application.Educations;
 public class UpdateEducationCommandHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Education>> _educationRepoMock;
+    private readonly Mock<IMutableRepository<Education>> _educationRepoMock;
     private readonly UpdateEducationCommandHandler _handler;
 
     public UpdateEducationCommandHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _educationRepoMock = new Mock<IEditableRepository<Education>>();
+        _educationRepoMock = new Mock<IMutableRepository<Education>>();
         _uowMock.Setup(x => x.EducationRepository).Returns(_educationRepoMock.Object);
         _handler = new UpdateEducationCommandHandler(_uowMock.Object);
     }

--- a/backend/tests/JobNecto.Tests/Application/Resumes/CreateResumeCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/CreateResumeCommandHandlerTests.cs
@@ -9,13 +9,13 @@ namespace JobNecto.Tests.Application.Resumes;
 public class CreateResumeCommandHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Resume>> _resumeRepoMock;
+    private readonly Mock<IMutableRepository<Resume>> _resumeRepoMock;
     private readonly CreateResumeCommandHandler _handler;
 
     public CreateResumeCommandHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _resumeRepoMock = new Mock<IEditableRepository<Resume>>();
+        _resumeRepoMock = new Mock<IMutableRepository<Resume>>();
         _uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object);
         _handler = new CreateResumeCommandHandler(_uowMock.Object);
     }

--- a/backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/DeleteResumeCommandHandlerTests.cs
@@ -11,19 +11,19 @@ namespace JobNecto.Tests.Application.Resumes;
 public class DeleteResumeCommandHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Resume>> _resumeRepoMock;
+    private readonly Mock<IMutableRepository<Resume>> _resumeRepoMock;
     private readonly DeleteResumeCommandHandler _handler;
 
     public DeleteResumeCommandHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _resumeRepoMock = new Mock<IEditableRepository<Resume>>();
+        _resumeRepoMock = new Mock<IMutableRepository<Resume>>();
         _uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object);
         _handler = new DeleteResumeCommandHandler(_uowMock.Object);
     }
 
     [Fact]
-    public async Task Handle_OwnedResume_SetsSoftDeleteFlagsAndPersists()
+    public async Task Handle_OwnedResume_CallsSoftDeleteAndPersists()
     {
         var userId = Guid.NewGuid();
         var resume = new Resume
@@ -47,8 +47,13 @@ public class DeleteResumeCommandHandlerTests
             .ReturnsAsync(resume);
 
         _resumeRepoMock
-            .Setup(x => x.UpdateAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Resume entity, CancellationToken _) => entity);
+            .Setup(x => x.SoftDeleteAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()))
+            .Callback<Resume, CancellationToken>((entity, _) =>
+            {
+                entity.IsDeleted = true;
+                entity.DeletedAt = DateTime.UtcNow;
+            })
+            .Returns(Task.CompletedTask);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
@@ -57,7 +62,8 @@ public class DeleteResumeCommandHandlerTests
         resume.DeletedAt.Should().NotBeNull();
         resume.DeletedAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
 
-        _resumeRepoMock.Verify(x => x.UpdateAsync(resume, It.IsAny<CancellationToken>()), Times.Once);
+        _resumeRepoMock.Verify(x => x.SoftDeleteAsync(resume, It.IsAny<CancellationToken>()), Times.Once);
+        _resumeRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()), Times.Never);
         _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -79,7 +85,7 @@ public class DeleteResumeCommandHandlerTests
         var act = () => _handler.Handle(command, CancellationToken.None);
 
         await act.Should().ThrowAsync<NotFoundException>();
-        _resumeRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()), Times.Never);
+        _resumeRepoMock.Verify(x => x.SoftDeleteAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()), Times.Never);
         _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -110,7 +116,7 @@ public class DeleteResumeCommandHandlerTests
         var act = () => _handler.Handle(command, CancellationToken.None);
 
         await act.Should().ThrowAsync<ForbiddenException>();
-        _resumeRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()), Times.Never);
+        _resumeRepoMock.Verify(x => x.SoftDeleteAsync(It.IsAny<Resume>(), It.IsAny<CancellationToken>()), Times.Never);
         _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/backend/tests/JobNecto.Tests/Application/Resumes/GetResumeHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/GetResumeHandlerTests.cs
@@ -10,13 +10,13 @@ namespace JobNecto.Tests.Application.Resumes;
 public class GetResumeHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Resume>> _resumeRepoMock;
+    private readonly Mock<IMutableRepository<Resume>> _resumeRepoMock;
     private readonly GetResumeQueryHandler _handler;
 
     public GetResumeHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _resumeRepoMock = new Mock<IEditableRepository<Resume>>();
+        _resumeRepoMock = new Mock<IMutableRepository<Resume>>();
         _uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object);
         _handler = new GetResumeQueryHandler(_uowMock.Object);
     }

--- a/backend/tests/JobNecto.Tests/Application/Resumes/ListResumesHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/ListResumesHandlerTests.cs
@@ -10,13 +10,13 @@ namespace JobNecto.Tests.Application.Resumes;
 public class ListResumesHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Resume>> _resumeRepoMock;
+    private readonly Mock<IMutableRepository<Resume>> _resumeRepoMock;
     private readonly ListResumesQueryHandler _handler;
 
     public ListResumesHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _resumeRepoMock = new Mock<IEditableRepository<Resume>>();
+        _resumeRepoMock = new Mock<IMutableRepository<Resume>>();
         _uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object);
         _handler = new ListResumesQueryHandler(_uowMock.Object);
     }

--- a/backend/tests/JobNecto.Tests/Application/Resumes/UpdateResumeCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/UpdateResumeCommandHandlerTests.cs
@@ -11,13 +11,13 @@ namespace JobNecto.Tests.Application.Resumes;
 public class UpdateResumeCommandHandlerTests
 {
     private readonly Mock<IUnitOfWork> _uowMock;
-    private readonly Mock<IEditableRepository<Resume>> _resumeRepoMock;
+    private readonly Mock<IMutableRepository<Resume>> _resumeRepoMock;
     private readonly UpdateResumeCommandHandler _handler;
 
     public UpdateResumeCommandHandlerTests()
     {
         _uowMock = new Mock<IUnitOfWork>();
-        _resumeRepoMock = new Mock<IEditableRepository<Resume>>();
+        _resumeRepoMock = new Mock<IMutableRepository<Resume>>();
         _uowMock.Setup(x => x.ResumeRepository).Returns(_resumeRepoMock.Object);
         _handler = new UpdateResumeCommandHandler(_uowMock.Object);
     }

--- a/backend/tests/JobNecto.Tests/Infrastructure/SoftDeletableRepositoryTests.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/SoftDeletableRepositoryTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using JobNecto.Infrastructure.Persistance;
+using JobNecto.Infrastructure.Repositories;
+using JobNecto.Domain.Entities;
+
+namespace JobNecto.Tests.Infrastructure;
+
+public class SoftDeletableRepositoryTests
+{
+    private static DbContextOptions<AppDbContext> CreateOptions()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        return new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+    }
+
+    [Fact]
+    public async Task SoftDeleteAsync_SetsIsDeletedAndDeletedAtUtc()
+    {
+        var options = CreateOptions();
+        var resume = new Resume
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Title = "Test Resume",
+            Skills = ["C#"],
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        await using (var context = new AppDbContext(options))
+        {
+            await context.Resumes.AddAsync(resume);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = new AppDbContext(options))
+        {
+            var repo = new ResumeRepository(context);
+            var entity = await repo.GetByIdAsync(resume.Id, CancellationToken.None);
+            await repo.SoftDeleteAsync(entity, CancellationToken.None);
+
+            entity.IsDeleted.Should().BeTrue();
+            entity.DeletedAt.Should().NotBeNull();
+            entity.DeletedAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        }
+    }
+
+    [Fact]
+    public async Task SoftDeleteAsync_AfterSaveChanges_EntityExcludedFromQuery()
+    {
+        var options = CreateOptions();
+        var resume = new Resume
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Title = "Test Resume",
+            Skills = ["C#"],
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        await using (var context = new AppDbContext(options))
+        {
+            await context.Resumes.AddAsync(resume);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = new AppDbContext(options))
+        {
+            var repo = new ResumeRepository(context);
+            var entity = await repo.GetByIdAsync(resume.Id, CancellationToken.None);
+            await repo.SoftDeleteAsync(entity, CancellationToken.None);
+            await context.SaveChangesAsync();
+        }
+
+        await using (var context = new AppDbContext(options))
+        {
+            var results = await context.Resumes.ToListAsync();
+            results.Should().NotContain(r => r.Id == resume.Id);
+        }
+    }
+}

--- a/docs/FRONTEND_IMPLEMENTATION_GUIDE.md
+++ b/docs/FRONTEND_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,726 @@
+# Jobnecto Frontend Implementation Guide
+
+## 1. Purpose and Audience
+
+This document is the implementation handoff for:
+
+- Frontend developers building the Jobnecto client application.
+- Product and UX designers defining interaction and visual behavior.
+- QA engineers validating UX, contract fidelity, and accessibility.
+
+Scope in this version:
+
+- Fully aligned with currently implemented backend endpoints:
+  - `POST /api/v1/users`
+  - `POST /api/v1/users/token/refresh`
+  - `GET /api/v1/users/me`
+  - `PATCH /api/v1/users/me`
+  - `POST /api/v1/users/me/avatar`
+  - `PUT /api/v1/users/me/avatar`
+  - `DELETE /api/v1/users/me/avatar`
+  - `POST /api/v1/resumes`
+  - `GET /api/v1/resumes`
+  - `GET /api/v1/resumes/{id}`
+  - `PATCH /api/v1/resumes/{id}`
+  - `DELETE /api/v1/resumes/{id}`
+  - `POST /api/v1/educations`
+  - `GET /api/v1/educations`
+  - `GET /api/v1/educations/{id}`
+  - `PATCH /api/v1/educations/{id}`
+  - `DELETE /api/v1/educations/{id}`
+
+Out-of-scope but planned (design stubs only): vacancies, cover letter templates, and cover letters.
+
+## 2. Frontend UI Architecture
+
+### 2.1 Application Layers
+
+Use a feature-sliced architecture:
+
+- `app`: app bootstrap, providers, router, global error boundaries.
+- `processes`: auth lifecycle, token refresh orchestration.
+- `pages`: route-level UI composition.
+- `widgets`: composed blocks (profile card, resume table, education timeline).
+- `features`: business actions (create resume, update profile, upload avatar).
+- `entities`: shared domain models (UserProfile, Resume, Education).
+- `shared`: UI kit, utilities, API client, schema validators, constants.
+
+### 2.2 Folder Blueprint
+
+```text
+src/
+  app/
+    providers/
+    router/
+  processes/
+    auth/
+  pages/
+    auth-sign-up/
+    dashboard/
+    profile/
+    resumes/
+    resume-detail/
+    educations/
+    education-detail/
+    settings/
+  widgets/
+    top-nav/
+    profile-summary/
+    cursor-pagination/
+  features/
+    user/
+      update-profile/
+      avatar-upload/
+    resume/
+      create-resume/
+      update-resume/
+      delete-resume/
+    education/
+      create-education/
+      update-education/
+      delete-education/
+  entities/
+    user/
+    resume/
+    education/
+  shared/
+    api/
+      client.ts
+      problem-details.ts
+      endpoints/
+    ui/
+    lib/
+    config/
+```
+
+### 2.3 State Model
+
+- Server state: query/mutation cache (recommended: TanStack Query).
+- Client state: minimal ephemeral UI state (drawer open, active tab, filter chips).
+- Form state: dedicated schema-driven form state (recommended: React Hook Form + Zod/Yup).
+- Auth state:
+  - Primary auth transport is HTTP-only cookie.
+  - Refresh endpoint may return `accessToken` in body only when bearer transport is used.
+  - Browser-first implementation should treat cookie transport as canonical.
+
+### 2.4 Routing
+
+Recommended routes:
+
+- `/sign-up`
+- `/dashboard`
+- `/profile`
+- `/resumes`
+- `/resumes/:id`
+- `/educations`
+- `/educations/:id`
+- `/settings`
+
+Guarded routes:
+
+- All except `/sign-up` should require authenticated session.
+
+## 3. Design System Tokens
+
+Define tokens in a single source (JSON or TS), then export to CSS variables.
+
+### 3.1 Color Tokens
+
+```json
+{
+  "color": {
+    "bg": {
+      "canvas": "#F7F9FC",
+      "surface": "#FFFFFF",
+      "elevated": "#F1F5FA"
+    },
+    "text": {
+      "primary": "#0F172A",
+      "secondary": "#334155",
+      "muted": "#64748B",
+      "inverse": "#FFFFFF"
+    },
+    "brand": {
+      "primary": "#0A66C2",
+      "primaryHover": "#004182",
+      "accent": "#14B8A6"
+    },
+    "status": {
+      "success": "#15803D",
+      "warning": "#D97706",
+      "danger": "#B91C1C",
+      "info": "#0369A1"
+    },
+    "border": {
+      "default": "#D0D9E5",
+      "strong": "#94A3B8",
+      "focus": "#0A66C2"
+    }
+  }
+}
+```
+
+### 3.2 Typography Tokens
+
+```json
+{
+  "font": {
+    "family": {
+      "sans": "Manrope, Segoe UI, sans-serif",
+      "mono": "IBM Plex Mono, Consolas, monospace"
+    },
+    "size": {
+      "xs": 12,
+      "sm": 14,
+      "md": 16,
+      "lg": 20,
+      "xl": 28,
+      "xxl": 36
+    },
+    "lineHeight": {
+      "tight": 1.2,
+      "base": 1.5,
+      "relaxed": 1.7
+    },
+    "weight": {
+      "regular": 400,
+      "medium": 500,
+      "semibold": 600,
+      "bold": 700
+    }
+  }
+}
+```
+
+### 3.3 Spacing, Radius, Shadow, Z-Index
+
+```json
+{
+  "space": { "1": 4, "2": 8, "3": 12, "4": 16, "5": 20, "6": 24, "8": 32, "10": 40, "12": 48 },
+  "radius": { "sm": 6, "md": 10, "lg": 14, "pill": 999 },
+  "shadow": {
+    "sm": "0 1px 2px rgba(15, 23, 42, 0.06)",
+    "md": "0 6px 18px rgba(15, 23, 42, 0.08)",
+    "lg": "0 12px 32px rgba(15, 23, 42, 0.12)"
+  },
+  "z": { "base": 1, "dropdown": 1000, "sticky": 1100, "modal": 1200, "toast": 1300 }
+}
+```
+
+### 3.4 Component Token Mapping
+
+- Buttons:
+  - Primary: `brand.primary` + `text.inverse`
+  - Secondary: `bg.surface` + `text.primary` + `border.default`
+  - Danger: `status.danger`
+- Inputs:
+  - Border default: `border.default`
+  - Focus ring: `border.focus`
+  - Error border: `status.danger`
+- Alerts:
+  - Success, warning, error, info each mapped to status palette.
+
+## 4. Page-by-Page UX Behavior
+
+## 4.1 Sign Up Page (`/sign-up`)
+
+Purpose: register account and establish authenticated session.
+
+Primary flow:
+
+1. User fills sign-up form.
+2. Submit to `POST /api/v1/users`.
+3. On 201, backend sets auth cookie and returns user payload.
+4. Frontend routes to `/dashboard` and hydrates profile via `GET /api/v1/users/me`.
+
+Required UI states:
+
+- Idle
+- Submitting
+- Field validation errors
+- Conflict error (email/login already used)
+- Server error
+
+## 4.2 Dashboard Page (`/dashboard`)
+
+Purpose: high-level orientation.
+
+Blocks:
+
+- Profile completion card (from user profile fields).
+- Resume count and quick links.
+- Education count and quick links.
+- Upcoming section placeholders for vacancies and cover letters.
+
+Behavior:
+
+- Parallel fetch for profile, resumes first page, educations first page.
+- Partial failure tolerance: one widget failing must not break others.
+
+## 4.3 Profile Page (`/profile`)
+
+Purpose: view and update current user profile and avatar.
+
+Actions:
+
+- Load current profile (`GET /api/v1/users/me`).
+- Partial updates (`PATCH /api/v1/users/me`).
+- Avatar upload/update (`POST` or `PUT /api/v1/users/me/avatar`).
+- Avatar delete (`DELETE /api/v1/users/me/avatar`).
+
+Behavior rules:
+
+- Save button enabled only when dirty and valid.
+- Optimistic preview allowed for avatar, but commit only after server 200.
+- On successful update, revalidate profile query.
+
+## 4.4 Resumes List Page (`/resumes`)
+
+Purpose: create, browse, paginate, and delete resumes.
+
+Actions:
+
+- Create resume (`POST /api/v1/resumes`).
+- Cursor list (`GET /api/v1/resumes?pageSize=&lastSeenId=&lastSeenUpdatedAt=`).
+- Delete resume (`DELETE /api/v1/resumes/{id}`).
+
+Behavior rules:
+
+- Cursor-based pagination only (not offset page index).
+- Show load-more pattern, not page numbers.
+- After delete, remove row immediately and refresh cursor metadata.
+
+## 4.5 Resume Detail/Edit Page (`/resumes/:id`)
+
+Actions:
+
+- Fetch detail (`GET /api/v1/resumes/{id}`).
+- Patch update (`PATCH /api/v1/resumes/{id}`).
+
+Behavior rules:
+
+- If 404, show not-found state with back-to-list CTA.
+- Prevent submit when no fields changed.
+- Submit only changed fields where possible.
+
+## 4.6 Educations List Page (`/educations`)
+
+Purpose: create, browse, paginate, and delete education records.
+
+Actions:
+
+- Create (`POST /api/v1/educations`).
+- Cursor list (`GET /api/v1/educations`).
+- Delete (`DELETE /api/v1/educations/{id}`).
+
+Behavior mirrors resumes list.
+
+## 4.7 Education Detail/Edit Page (`/educations/:id`)
+
+Actions:
+
+- Fetch detail (`GET /api/v1/educations/{id}`).
+- Patch update (`PATCH /api/v1/educations/{id}`).
+
+Behavior mirrors resume detail/edit, with education-specific validation.
+
+## 4.8 Settings Page (`/settings`)
+
+Purpose:
+
+- Session controls and support diagnostics.
+- Trigger refresh token call if needed (`POST /api/v1/users/token/refresh`).
+
+## 5. Component Contracts
+
+Use strongly typed props and explicit events for all reusable components.
+
+## 5.1 Core Form Components
+
+### `TextField`
+
+Props:
+
+- `name: string`
+- `label: string`
+- `value: string`
+- `onChange: (value: string) => void`
+- `onBlur?: () => void`
+- `required?: boolean`
+- `maxLength?: number`
+- `error?: string`
+- `hint?: string`
+- `autoComplete?: string`
+
+### `SelectField<T>`
+
+Props:
+
+- `name: string`
+- `label: string`
+- `value: T | null`
+- `options: Array<{ label: string; value: T }>`
+- `onChange: (value: T) => void`
+- `placeholder?: string`
+- `error?: string`
+
+### `TagInput`
+
+For skills, projects, certifications, excluded words.
+
+Props:
+
+- `values: string[]`
+- `onChange: (values: string[]) => void`
+- `maxItemLength?: number`
+- `maxItems?: number`
+- `allowDuplicates?: boolean`
+- `error?: string`
+
+## 5.2 Domain Components
+
+### `ProfileForm`
+
+Input model:
+
+- `loginName?: string`
+- `email?: string`
+- `phone?: string`
+- `location?: string`
+- `about?: string`
+- `avatar?: string`
+
+Events:
+
+- `onSubmit(payload: UpdateCurrentUserPayload)`
+- `onCancel()`
+
+### `AvatarUploader`
+
+Props:
+
+- `currentAvatar?: string`
+- `maxBytes: number` (must be 5 MB)
+- `acceptedMimeTypes: string[]` (jpeg, jpg, png, webp, gif)
+
+Events:
+
+- `onUpload(file: File)`
+- `onDelete()`
+
+### `ResumeForm`
+
+Input model (create/update compatible):
+
+- `title?: string`
+- `salary?: number`
+- `currency?: Currency`
+- `skills?: string[]`
+- `workLocationType?: WorkLocationType`
+- `experience?: Experience`
+- `projects?: string[]`
+- `certifications?: string[]`
+- `languages?: Array<{ language: Language; level: LanguageLevel }>`
+- `locations?: Location[]`
+- `excludedWords?: string[]`
+
+### `EducationForm`
+
+Input model:
+
+- `title?: string`
+- `specialization?: string`
+- `degree?: Degree`
+
+## 6. API Integration Mapping
+
+Base URL:
+
+- `http://localhost:5000/api/v1` in development unless overridden.
+
+Auth transport:
+
+- Browser clients rely on server-managed HTTP-only cookie.
+- Always send credentials in fetch/XHR where required.
+
+## 6.1 Endpoints by Feature
+
+| Feature | Endpoint | Method | Success | Notes |
+| --- | --- | --- | --- | --- |
+| Sign up | `/users` | POST | 201 | Sets auth cookie; Location points to `/api/v1/users/me` |
+| Get profile | `/users/me` | GET | 200 | Requires auth |
+| Update profile | `/users/me` | PATCH | 200 | Partial update |
+| Upload avatar | `/users/me/avatar` | POST | 200 | multipart/form-data |
+| Replace avatar | `/users/me/avatar` | PUT | 200 | multipart/form-data |
+| Delete avatar | `/users/me/avatar` | DELETE | 200 | Returns updated profile |
+| Refresh token | `/users/token/refresh` | POST | 200 | Body token only for bearer transport |
+| Create resume | `/resumes` | POST | 201 | Returns created resume |
+| List resumes | `/resumes` | GET | 200 | Cursor pagination |
+| Resume detail | `/resumes/{id}` | GET | 200 | 404 if not found or not owned |
+| Update resume | `/resumes/{id}` | PATCH | 200 | Partial update |
+| Delete resume | `/resumes/{id}` | DELETE | 204 | Soft delete |
+| Create education | `/educations` | POST | 201 | Returns created education |
+| List educations | `/educations` | GET | 200 | Cursor pagination |
+| Education detail | `/educations/{id}` | GET | 200 | 404 if not found or not owned |
+| Update education | `/educations/{id}` | PATCH | 200 | Partial update |
+| Delete education | `/educations/{id}` | DELETE | 204 | Soft delete |
+
+## 6.2 Problem Details Error Shape
+
+Backend uses RFC 7807 Problem Details (`application/problem+json`).
+
+Expected fields:
+
+- `status`
+- `title`
+- `detail`
+- `instance`
+- `traceId` in `extensions`
+- `errors` map for validation failures (400)
+
+Frontend contract:
+
+- Normalize all non-2xx responses into a single `ApiError` model.
+- Surface `errors[field]` messages inline for forms.
+- Surface generic banner for non-validation failures.
+
+## 6.3 Cursor Pagination Contract
+
+Response fields:
+
+- `items`
+- `totalCount`
+- `lastSeenId`
+- `lastSeenUpdatedAt`
+- `pageSize`
+- `hasNext`
+- `totalPages` (derived server-side from totalCount and pageSize)
+
+Query rules:
+
+- `pageSize < 1` defaults to 20 on server.
+- `pageSize > 100` is capped to 100 on server.
+- Send both `lastSeenId` and `lastSeenUpdatedAt` from previous response for next-page continuity.
+
+## 7. Form Validation Rules (Client Mirror)
+
+Client-side validation must mirror backend to reduce failed submissions.
+
+## 7.1 User Sign-Up
+
+- `loginName`: required, 3-50 chars, regex `^[A-Za-z0-9_]+$`
+- `email`: required, valid email, max 50
+- `password`: required, min 8, max 50
+- `phone`: optional, max 20, E.164 regex `^\+[1-9]\d{1,14}$`
+- `location`: optional, max 50, must be valid `Location` enum value
+- `about`: optional, max 5000
+
+## 7.2 Update Profile
+
+- All fields optional, but if provided must pass constraints above.
+- `avatar` string field (if sent via patch): max 2048, must be https URL or storage key pattern `^[A-Za-z0-9_./-]+$`.
+
+## 7.3 Avatar Upload
+
+- File required.
+- File size <= 5 MB.
+- Allowed MIME: `image/jpeg`, `image/jpg`, `image/png`, `image/webp`, `image/gif`.
+- Client should pre-check MIME and size before upload.
+
+## 7.4 Create/Update Resume
+
+- `title`: optional, max 500
+- `skills`: optional array; if provided each item non-empty, max 30 chars
+- `workLocationType`: optional, must match enum (`OnSite`, `Remote`, `Hybrid`)
+- `currency`: optional, valid enum
+- `experience`: optional, valid enum (`LessThanOneYear`, `OneToThreeYears`, `ThreeToFiveYears`, `MoreThanFiveYears`)
+- `salary`: optional, must be >= 0
+- Update request must include at least one updatable field.
+
+## 7.5 Create/Update Education
+
+Create:
+
+- `title`: required, non-whitespace, max 100
+- `specialization`: required, non-whitespace, max 100
+- `degree`: required, enum (`Bachelor`, `Master`, `PhD`, `PostDoc`, `Other`)
+
+Update:
+
+- At least one of `title`, `specialization`, `degree` required.
+- If provided, title and specialization must be non-empty and within length limit.
+- Degree, if provided, must be valid enum.
+
+## 8. Loading, Error, and Empty State Specifications
+
+## 8.1 Loading States
+
+- Page-level skeleton for initial route load.
+- Section-level skeleton for widgets fetched independently.
+- Inline submit spinners on action buttons.
+- Preserve layout dimensions to avoid cumulative layout shift.
+
+## 8.2 Error States
+
+- 400 validation:
+  - Inline field errors + summary banner.
+- 401 unauthorized:
+  - Redirect to sign-up or auth recovery flow.
+  - Preserve intended destination for post-auth return.
+- 403 forbidden:
+  - Show permission screen with explanation and recovery CTA.
+- 404 not found:
+  - In detail pages, show entity-not-found empty state and back link.
+- 409 conflict:
+  - For sign-up/profile unique collisions, show explicit action guidance.
+- 500:
+  - Show generic recoverable error with retry.
+
+## 8.3 Empty States
+
+- Resumes list empty:
+  - Headline: "No resumes yet"
+  - CTA: "Create first resume"
+- Educations list empty:
+  - Headline: "No education records yet"
+  - CTA: "Add education"
+- Dashboard empty summary:
+  - Show onboarding checklist with direct links.
+
+## 9. Accessibility Requirements
+
+Must satisfy WCAG 2.2 AA baseline.
+
+Mandatory requirements:
+
+- Semantic structure:
+  - One `h1` per page, logical heading order.
+- Keyboard:
+  - Full tab/shift+tab navigation, visible focus ring, no keyboard traps.
+- Form accessibility:
+  - Inputs tied to labels via `for`/`id`.
+  - Errors tied with `aria-describedby`.
+- Dynamic updates:
+  - Toasts and form errors announced via `aria-live` regions.
+- Color contrast:
+  - Body text >= 4.5:1, large text >= 3:1.
+- Hit targets:
+  - Interactive target size >= 24x24 px.
+- File upload:
+  - Dropzone and button flow both keyboard accessible.
+- Reduced motion:
+  - Honor `prefers-reduced-motion` for all non-essential animation.
+
+## 10. Responsive Breakpoints and Layout Rules
+
+Breakpoint tokens:
+
+- `xs`: 0-479
+- `sm`: 480-767
+- `md`: 768-1023
+- `lg`: 1024-1439
+- `xl`: 1440+
+
+Layout behavior:
+
+- `xs/sm`:
+  - Single-column pages.
+  - Bottom-sheet or full-screen modal for create/edit forms.
+- `md`:
+  - Two-column details where useful (form + live preview).
+- `lg/xl`:
+  - Primary content with optional contextual side panel.
+
+Tables/lists:
+
+- On `xs/sm`, card list layout instead of dense table.
+- Preserve action affordances with sticky action bar when editing.
+
+## 11. Motion Guidelines
+
+Use motion to communicate state changes, not decoration.
+
+Motion tokens:
+
+- Duration:
+  - Fast: 120ms
+  - Standard: 180ms
+  - Emphasis: 260ms
+- Easing:
+  - Standard: `cubic-bezier(0.2, 0, 0, 1)`
+  - Exit: `cubic-bezier(0.4, 0, 1, 1)`
+
+Patterns:
+
+- Page transitions:
+  - Fade + slight y-translation (4px), max 180ms.
+- List updates:
+  - Add item highlight pulse (single cycle).
+  - Remove item collapse animation, max 180ms.
+- Validation errors:
+  - Do not shake fields; use color/focus and helper text.
+- Loading:
+  - Skeleton shimmer optional; disable when reduced motion is enabled.
+
+## 12. Enum Sources for Frontend Select Controls
+
+To avoid drift, generate frontend enum options from backend OpenAPI or shared schema.
+
+Current backend enum values:
+
+- `WorkLocationType`: `OnSite`, `Remote`, `Hybrid`
+- `Experience`: `LessThanOneYear`, `OneToThreeYears`, `ThreeToFiveYears`, `MoreThanFiveYears`
+- `Degree`: `Bachelor`, `Master`, `PhD`, `PostDoc`, `Other`
+- `Currency`: `USD`, `EUR`, `GBP`, `CAD`, `AUD`, `CHF`, `JPY`, `CNY`, `INR`, `RUB`, `UAH`, `PLN`, `SEK`, `NOK`, `DKK`, `NZD`, `MXN`, `BRL`
+- `Location`: use the full backend enum set; do not hardcode partial list.
+- `Language`: use backend enum list from domain contract.
+- `LanguageLevel`: `Beginner`, `Intermediate`, `Advanced`, `Native`
+
+## 13. Developer Handoff Acceptance Checklist
+
+Definition of done for frontend implementation handoff:
+
+### 13.1 Architecture and Code Quality
+
+- [ ] Feature-sliced structure implemented.
+- [ ] Shared API client handles credentials and Problem Details parsing.
+- [ ] Typed models defined for user, resume, education, and pagination envelopes.
+- [ ] No duplicated validation logic across forms.
+
+### 13.2 Contract Fidelity
+
+- [ ] Every implemented backend endpoint has matching frontend service function.
+- [ ] Request/response typing matches server contracts.
+- [ ] Cursor pagination behavior verified end-to-end.
+- [ ] 400/401/403/404/409/500 states handled and visually tested.
+
+### 13.3 UX and Accessibility
+
+- [ ] All required loading/error/empty states implemented per page.
+- [ ] Keyboard-only flow validated for critical journeys.
+- [ ] Form errors are screen-reader announced.
+- [ ] Color contrast and focus visibility pass AA checks.
+
+### 13.4 Responsive and Motion
+
+- [ ] Layout verified at xs, sm, md, lg, xl breakpoints.
+- [ ] Edit/create flows are fully usable on mobile.
+- [ ] Motion tokens applied consistently and reduced-motion respected.
+
+### 13.5 QA and Release Readiness
+
+- [ ] E2E tests cover sign-up, profile update, avatar upload, resume CRUD, education CRUD.
+- [ ] API error mocking includes validation and conflict examples.
+- [ ] Cross-browser smoke tests pass (Chromium, Firefox, WebKit minimum).
+- [ ] Final review completed by frontend developer and designer together.
+
+## 14. Implementation Notes for Next Backend Phases
+
+When vacancies and cover-letter APIs are merged, extend this guide by adding:
+
+- Vacancies list/detail/filter page contracts.
+- Cover letter templates CRUD UX.
+- Cover letter generation flow (manual first, LLM-assisted later).
+- Job application orchestration UI states.
+
+Keep this document as the canonical frontend handoff artifact for Jobnecto client-side development.


### PR DESCRIPTION
- Introduce ISoftDeleteRepository<T> interface for soft delete capability
- Introduce IMutableRepository<T> interface as composition of IEditableRepository<T> and ISoftDeleteRepository<T>
- Create SoftDeletableRepository<T> abstract class encapsulating soft delete logic
- Update ResumeRepository, EducationRepository, CoverLetterRepository, CoverLetterTemplateRepository, and UserRepository to inherit from SoftDeletableRepository<T>
- Implement ISoftDeleteRepository<Vacancy> directly in VacancyRepository
- Update IUnitOfWork and UnitOfWork to expose IMutableRepository<T> for soft-deletable entities
- Refactor DeleteResumeCommandHandler and DeleteEducationCommandHandler to use SoftDeleteAsync
- Update all affected unit tests to mock IMutableRepository<T> and verify SoftDeleteAsync calls
- Add SoftDeletableRepositoryTests for infrastructure validation
- Update core architectural decisions documentation
- Update sprint status and deferred work artifacts
- Add frontend implementation guide document

Closes #65