### PR TITLE
feat(cover-letter-templates): POST /api/v1/cover-letter-templates (story 3.1)

### DIFF
--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,16 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-05-08 - Isolate Docker bind mount issues before retry loops
+
+**Trigger:** User correction
+**Context:** Archon container setup repeatedly appeared stuck while trying to recreate the container with port mapping and persistence.
+**Wrong action:** I retried multi-step run/remove commands repeatedly before isolating whether the bind mount itself was the blocker.
+**Root cause:** I optimized for repeating the intended final command instead of minimizing variables; on Windows Docker Desktop, bind mounts can stall container lifecycle operations when file sharing/mount resolution is problematic.
+**Correct behavior:** First run the container without a bind mount to validate baseline startup, then add port and volume flags incrementally to identify the exact failing option.
+**Pattern / trigger:** Container commands hang with objects stuck in `Created`, while daemon health commands still work and simple containers run normally.
+**Generalize?** Yes
+
 ### 2026-05-05 - Set entity timestamps in handlers, not only DB defaults
 
 **Trigger:** Test failure

--- a/_bmad-output/implementation-artifacts/3-1-create-cover-letter-template.md
+++ b/_bmad-output/implementation-artifacts/3-1-create-cover-letter-template.md
@@ -1,0 +1,381 @@
+# Story 3.1: Create Cover Letter Template
+
+Status: done
+
+## Story
+
+As a job seeker,
+I want to create a named cover letter template with reusable content,
+so that I can quickly apply it to future job applications.
+
+## Acceptance Criteria
+
+1. `POST /api/v1/cover-letter-templates` requires a valid JWT token. Unauthenticated requests return `401 Unauthorized`.
+2. Given a valid JWT token and `POST /api/v1/cover-letter-templates` with `name` and `content` (50-10,000 chars), returns `201 Created` with the full template object and `Location` header set to `/api/v1/cover-letter-templates/{id}`.
+3. Given `content` fewer than 50 characters, returns `400 Bad Request` with a field-level error on `content`.
+4. Given `content` more than 10,000 characters, returns `400 Bad Request` with a field-level error on `content`.
+5. Given `name` already used by this user (across non-deleted templates), returns `409 Conflict` from database-backed per-user uniqueness enforcement.
+6. Given the same `name` used by another user, returns `201 Created` (uniqueness is per-user, not global).
+
+## Tasks / Subtasks
+
+- [x] Task 1: Expose CoverLetterTemplateRepository in UnitOfWork (prerequisite for all handlers)
+  - [x] Add `IMutableRepository<CoverLetterTemplate> CoverLetterTemplateRepository { get; }` to `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`
+  - [x] Add backing field `IMutableRepository<CoverLetterTemplate>? _coverLetterTemplateRepository` and lazy property to `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs`
+
+- [x] Task 2: Add per-user name uniqueness DB constraint (AC: 5, 6)
+  - [x] Add filtered unique index to `CoverLetterTemplateConfiguration`:
+    ```csharp
+    builder.HasIndex(t => new { t.UserId, t.Name })
+        .IsUnique()
+        .HasFilter("\"IsDeleted\" = false");
+    ```
+  - [x] Generate EF migration: `dotnet ef migrations add AddCoverLetterTemplateUniqueNamePerUser --project backend/src/JobNecto.Infrastructure --startup-project backend/src/JobNecto.API`
+
+- [x] Task 3: Define application create contract (AC: 2, 3, 4)
+  - [x] Create `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommand.cs` with command (`UserId` `[JsonIgnore]`, `Name`, `Content`) and `CoverLetterTemplateResult` DTO (`Id`, `UserId`, `Name`, `Content`, `CreatedAt`, `UpdatedAt`)
+  - [x] Create `backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs` with `ToEntity(this CreateCoverLetterTemplateCommand)` and `ToCoverLetterTemplateResult(this CoverLetterTemplate)` extension methods
+  - [x] Create `backend/src/JobNecto.Application/CoverLetterTemplates/Validators/CreateCoverLetterTemplateCommandValidator.cs` with rules:
+    - `Name`: `NotEmpty()` + `MaximumLength(100)` (rejects null, empty, whitespace)
+    - `Content`: `NotEmpty()` + `MinimumLength(50)` + `MaximumLength(10000)`
+    - `UserId`: `NotEmpty()`
+
+- [x] Task 4: Implement Application handler (AC: 2, 5)
+  - [x] Create `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandler.cs`
+  - [x] Map command to entity, set `CreatedAt = UpdatedAt = DateTime.UtcNow` explicitly in handler
+  - [x] Persist via `_unitOfWork.CoverLetterTemplateRepository.CreateAsync(entity, ct)` then `SaveChangesAsync(ct)`
+  - [x] Return mapped `CoverLetterTemplateResult`
+
+- [x] Task 5: Expose authenticated HTTP endpoint (AC: 1, 2, 3, 4, 5)
+  - [x] Create `backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs` with `[ApiController]`, `[Route("api/v1/cover-letter-templates")]`, `[Authorize]`
+  - [x] Add `POST` action accepting `CreateCoverLetterTemplateCommand` (POST only — list/detail in later stories)
+  - [x] Extract `UserId` via `HttpContext.GetCurrentUserId()` and return `Unauthorized()` if parse fails
+  - [x] Return `Created($"/api/v1/cover-letter-templates/{result.Id}", result)` on success
+  - [x] Add `[ProducesResponseType]` for 201, 400, 401, 409
+
+- [x] Task 6: Add comprehensive tests and verification gates (AC: 1-6)
+  - [x] Create `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandValidatorTests.cs`:
+    - Valid payload passes
+    - Null/empty `name` fails with error on `Name`
+    - Whitespace-only `name` fails with error on `Name`
+    - `content` < 50 chars fails with error on `Content`
+    - `content` > 10,000 chars fails with error on `Content`
+    - Empty `content` fails with error on `Content`
+  - [x] Create `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandlerTests.cs`:
+    - Valid create persists exactly once and returns mapped result with non-default timestamps
+  - [x] Create `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs`:
+    - No token → `401`
+    - Valid request → `201` with correct `Location` header and response payload
+    - `content` < 50 chars → `400` with field-level error on `content`
+    - `content` > 10,000 chars → `400` with field-level error on `content`
+  - [x] Create `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs` (Postgres-backed factory, optional skip pattern matching UsersControllerConcurrencyTests):
+    - Duplicate `name` (same user) → `409`
+    - Same `name`, different users → both return `201`
+    - **Concurrent duplicate `name`** (same user, parallel `Task.WhenAll`) → at least one returns `409`
+  - [x] Run targeted tests: `dotnet test backend/JobNecto.slnx --filter "FullyQualifiedName~CoverLetterTemplates"`
+  - [x] Run full suite: `dotnet test backend/JobNecto.slnx`
+  - [x] Run CI parity: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` then `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror`
+
+## Dev Notes
+
+### Entity State — What Already Exists
+
+`CoverLetterTemplate` entity at `backend/src/JobNecto.Domain/Entities/CoverLetterTemplate.cs`:
+```csharp
+public class CoverLetterTemplate : SoftDeletableEntity
+{
+    public Guid UserId;          // PUBLIC FIELD, not auto-property
+    public required string Name; // PUBLIC FIELD, not auto-property
+    public required string Content; // PUBLIC FIELD, not auto-property
+}
+```
+- **CRITICAL:** `UserId`, `Name`, and `Content` are public **fields**, not properties. Set them with object initializer syntax. EF Core maps fields correctly via `CoverLetterTemplateConfiguration`.
+- `Id`, `CreatedAt`, `UpdatedAt`, `IsDeleted`, `DeletedAt` are on base classes and are properties.
+
+`CoverLetterTemplateConfiguration` at `backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterTemplateConfiguration.cs`:
+- Table `CoverLetterTemplates` configured, cascade delete from User, soft-delete fields configured.
+- **Missing:** the unique filtered index on `(UserId, Name)` — this story must add it.
+
+`CoverLetterTemplateRepository` at `backend/src/JobNecto.Infrastructure/Repositories/CoverLetterTemplateRepository.cs`:
+- Inherits `SoftDeletableRepository<CoverLetterTemplate>` which implements `IMutableRepository<CoverLetterTemplate>`.
+- **Not yet exposed in `IUnitOfWork`** — this story adds it.
+
+`AppDbContext`:
+- `DbSet<CoverLetterTemplate> CoverLetterTemplates` is already registered.
+- Global soft-delete query filter for `CoverLetterTemplate` is already configured.
+
+No application-layer files exist for `CoverLetterTemplates` yet. All Application + API files are new in this story.
+
+### IUnitOfWork Update
+
+Add to interface after the `EducationRepository` property:
+```csharp
+/// <summary>
+/// Repository for cover letter templates with full write support (update + soft delete).
+/// </summary>
+IMutableRepository<CoverLetterTemplate> CoverLetterTemplateRepository { get; }
+```
+
+Add to `UnitOfWork.cs`:
+```csharp
+private IMutableRepository<CoverLetterTemplate>? _coverLetterTemplateRepository;
+
+public IMutableRepository<CoverLetterTemplate> CoverLetterTemplateRepository =>
+    _coverLetterTemplateRepository ??= new CoverLetterTemplateRepository(_context);
+```
+
+### Unique Index in EF Core (filtered, per-user, active records only)
+
+Add to `CoverLetterTemplateConfiguration.Configure(...)`:
+```csharp
+builder.HasIndex(t => new { t.UserId, t.Name })
+    .IsUnique()
+    .HasFilter("\"IsDeleted\" = false");
+```
+
+The filter ensures soft-deleted templates do not block re-use of their names. The snapshot currently only has `b.HasIndex("UserId")` — the migration adds the filtered unique composite index.
+
+### 409 Conflict — No Pre-check Required
+
+Do **not** add a pre-check query before `CreateAsync`. The DB unique constraint is the authoritative guard:
+
+- `GlobalExceptionHandler.IsUniqueConstraintViolation()` detects `PostgresException.SqlState == UniqueViolation` (Npgsql `PostgresErrorCodes.UniqueViolation`)
+- Falls back to string matching `"duplicate key"` / `"unique constraint"` for non-Postgres providers (used in integration tests via `InMemory` + `UNIQUE constraint failed`)
+- Response: `{ "title": "Conflict", "status": 409, "detail": "A unique constraint was violated." }`
+
+This approach handles concurrent race conditions without an explicit pre-check. It satisfies NFR13 and the Epic 3 readiness constraint.
+
+### Handler Pattern
+
+Follow `CreateEducationCommandHandler` exactly:
+```csharp
+public async Task<CoverLetterTemplateResult> Handle(
+    CreateCoverLetterTemplateCommand request, CancellationToken cancellationToken)
+{
+    var template = request.ToEntity();
+    var now = DateTime.UtcNow;
+    template.CreatedAt = now;
+    template.UpdatedAt = now;
+
+    await _unitOfWork.CoverLetterTemplateRepository.CreateAsync(template, cancellationToken);
+    await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+    return template.ToCoverLetterTemplateResult();
+}
+```
+
+**Why set timestamps in handler:** DB defaults (`Now()`) are not applied by EF InMemory provider. Tests that assert non-default timestamps fail if handler does not set them. (Lesson 2026-05-05)
+
+### Controller Pattern
+
+Follow `EducationsController.Create` exactly:
+```csharp
+[HttpPost]
+[ProducesResponseType(typeof(CoverLetterTemplateResult), StatusCodes.Status201Created)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(StatusCodes.Status409Conflict)]
+public async Task<ActionResult<CoverLetterTemplateResult>> Create(
+    CreateCoverLetterTemplateCommand command,
+    CancellationToken cancellationToken)
+{
+    var userIdValue = HttpContext.GetCurrentUserId();
+    if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+        return Unauthorized();
+
+    command.UserId = userId;
+
+    var result = await _mediator.Send(command, cancellationToken);
+    return Created($"/api/v1/cover-letter-templates/{result.Id}", result);
+}
+```
+
+`GetCurrentUserId()` is in `backend/src/JobNecto.API/Infrastructure/AuthContext.cs`. It checks `ClaimTypes.NameIdentifier`, `"sub"`, and `"userId"` claims in order.
+
+### Validator Rules
+
+```csharp
+public class CreateCoverLetterTemplateCommandValidator
+    : AbstractValidator<CreateCoverLetterTemplateCommand>
+{
+    public CreateCoverLetterTemplateCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Content).NotEmpty().MinimumLength(50).MaximumLength(10000);
+    }
+}
+```
+
+**Name validation decisions (Epic 2 validator audit lesson):**
+- Null, empty string, and whitespace-only all rejected via `NotEmpty()`
+- No minimum length specified in AC; `NotEmpty()` alone is sufficient
+- Max length 100 follows the pattern used by `Education.Title` and `Education.Specialization`
+
+### Test Patterns
+
+Copy auth cookie setup from `EducationsApiTests` verbatim:
+```csharp
+private static async Task<string> CreateUserAndGetCookieAsync(HttpClient client, ...)
+{
+    var response = await client.PostAsJsonAsync("/api/v1/users", command);
+    var authCookie = response.Headers.GetValues("Set-Cookie")
+        .Select(x => x.Split(';', ...).FirstOrDefault(y => y.StartsWith("auth-token=", ...)))
+        .First(x => !string.IsNullOrWhiteSpace(x));
+    return authCookie!;
+}
+```
+
+Forward cookie via:
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/cover-letter-templates")
+{
+    Content = JsonContent.Create(payload)
+};
+request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+```
+
+**Test data constraints (lesson 2026-04-25):**
+- `name`: any string ≤ 100 chars, `NotEmpty()` satisfied
+- `content`: must be 50-10,000 chars for valid payloads; use exactly 49 chars for the under-limit test and exactly 10,001 chars for the over-limit test
+- `LoginName` in user setup: alphanumeric + underscore only (`^[a-zA-Z0-9_]+$`), max 20 chars total (prefix + 8-char GUID suffix = 12+8 = 20 — keep prefix ≤ 12 chars)
+
+**Concurrent 409 test pattern:**
+```csharp
+[Fact]
+public async Task Create_ConcurrentDuplicateName_AtLeastOneReturns409()
+{
+    await using var factory = new JobNectoApiFactory();
+    var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+    var authCookie = await CreateUserAndGetCookieAsync(client);
+
+    var task1 = PostTemplateAsync(client, authCookie, "Same Name", ValidContent());
+    var task2 = PostTemplateAsync(client, authCookie, "Same Name", ValidContent());
+    var results = await Task.WhenAll(task1, task2);
+
+    results.Should().Contain(r => r.StatusCode == HttpStatusCode.Conflict);
+}
+```
+
+### File Structure Requirements
+
+| File | Action |
+|------|--------|
+| `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs` | UPDATE — add `CoverLetterTemplateRepository` |
+| `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs` | UPDATE — add backing field + property |
+| `backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterTemplateConfiguration.cs` | UPDATE — add unique filtered index |
+| `backend/src/JobNecto.Infrastructure/Migrations/<timestamp>_AddCoverLetterTemplateUniqueNamePerUser.cs` | NEW — EF migration |
+| `backend/src/JobNecto.Infrastructure/Migrations/AppDbContextModelSnapshot.cs` | UPDATE — by EF migration tooling |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommand.cs` | NEW |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandler.cs` | NEW |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs` | NEW |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/Validators/CreateCoverLetterTemplateCommandValidator.cs` | NEW |
+| `backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs` | NEW |
+| `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandValidatorTests.cs` | NEW |
+| `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandlerTests.cs` | NEW |
+| `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs` | NEW |
+| `_bmad-output/implementation-artifacts/3-1-create-cover-letter-template.md` | THIS FILE |
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | UPDATE — status to ready-for-dev |
+
+Do **not** modify Resume, Education, or any other existing entity handlers or repositories.
+
+### Namespace Conventions
+
+Namespaces must match folder structure:
+- `JobNecto.Application.CoverLetterTemplates`
+- `JobNecto.Application.CoverLetterTemplates.Mappers`
+- `JobNecto.Application.CoverLetterTemplates.Validators`
+- `JobNecto.API.Controllers`
+- `JobNecto.Tests.API.CoverLetterTemplates`
+- `JobNecto.Tests.Application.CoverLetterTemplates`
+
+### Previous Story Intelligence
+
+- **Set timestamps in handler** (`CreatedAt = UpdatedAt = DateTime.UtcNow`) — EF InMemory does not execute SQL defaults; tests that assert non-default timestamps will fail otherwise (lesson 2026-05-05)
+- **Separate handler file** — `CreateCoverLetterTemplateCommand.cs` and `CreateCoverLetterTemplateCommandHandler.cs` are separate files (lesson 2026-04-28)
+- **Test data must be validator-compliant** — `content` must be 50-10,000 chars for setup data; `LoginName` must match `^[a-zA-Z0-9_]+$` with length ≤ 20 (lesson 2026-04-25)
+- **Do not null-check after `GetByIdAsync`** — repository throws `NotFoundException` on miss (relevant to later stories 3.3, 3.4, 3.5)
+- **Concurrent tests required by NFR13** — any uniqueness rule surfaced as 409 must have at least one concurrent create/update integration test
+
+### References
+
+- [Epic 3 source](_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md) — Story 3.1 ACs and readiness constraints
+- [Core architectural decisions](_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md) — MediatR, validation, repository patterns
+- [Epic 2 architecture revision](_bmad-output/planning-artifacts/architecture/epic-2-architecture-revision-2026-05-05.md) — Epic 3 guardrails and accepted patterns
+- [Pattern: EducationsController](backend/src/JobNecto.API/Controllers/EducationsController.cs)
+- [Pattern: CreateEducationCommandHandler](backend/src/JobNecto.Application/Educations/CreateEducationCommandHandler.cs)
+- [Pattern: EducationsApiTests](backend/tests/JobNecto.Tests/API/Educations/EducationsApiTests.cs)
+- [Pattern: GlobalExceptionHandler](backend/src/JobNecto.API/Infrastructure/ExceptionHandling/GlobalExceptionHandler.cs) — 409 via DB constraint
+
+## Dev Agent Record
+
+### Implementation Plan
+
+Followed the task sequence exactly as written.
+
+- Task 1: Added `IMutableRepository<CoverLetterTemplate> CoverLetterTemplateRepository` to `IUnitOfWork` and `UnitOfWork` lazy backing field — mirrors Education pattern.
+- Task 2: Added `HasIndex(t => new { t.UserId, t.Name }).IsUnique().HasFilter("\"IsDeleted\" = false")` to `CoverLetterTemplateConfiguration` and generated migration `AddCoverLetterTemplateUniqueNamePerUser`.
+- Task 3: Created `CreateCoverLetterTemplateCommand` + `CoverLetterTemplateResult`, `CoverLetterTemplateMappers` (`ToEntity`, `ToCoverLetterTemplateResult`), and `CreateCoverLetterTemplateCommandValidator` — all follow Education pattern exactly.
+- Task 4: Created `CreateCoverLetterTemplateCommandHandler` — sets `CreatedAt = UpdatedAt = DateTime.UtcNow` explicitly (per lesson 2026-05-05), persists via `CoverLetterTemplateRepository.CreateAsync` + `SaveChangesAsync`.
+- Task 5: Created `CoverLetterTemplatesController` with `[Authorize]`, POST-only, returns `Created(...)` with Location header — mirrors `EducationsController.Create`.
+- Task 6: Created 3 test files totaling 16 new tests. Uniqueness/409 tests use a Postgres-backed factory (`CoverLetterTemplatesPostgresFactory`) with graceful skip when Postgres is unavailable — same pattern as `UsersControllerConcurrencyTests`. EF Core InMemory does not enforce unique constraints, hence the split.
+
+### Completion Notes
+
+All 6 tasks complete. 308/308 tests pass. CI parity: 0 warnings, 0 errors.
+
+AC coverage:
+- AC1: `[Authorize]` on controller + 401 integration test ✅
+- AC2: `POST /api/v1/cover-letter-templates` returns 201 + Location + full payload ✅
+- AC3: content < 50 chars → 400 (validator + integration test) ✅
+- AC4: content > 10,000 chars → 400 (validator + integration test) ✅
+- AC5: duplicate name same user → 409 via DB unique constraint (Postgres factory test, skips without Postgres) ✅
+- AC6: same name different users → 201 both (Postgres factory test, skips without Postgres) ✅
+
+### Debug Log
+
+No blockers encountered. EF Core InMemory uniqueness limitation resolved by introducing `CoverLetterTemplatesPostgresFactory` (matching existing project pattern from `UsersControllerConcurrencyTests`).
+
+## File List
+
+- `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs` — updated: added `CoverLetterTemplateRepository`
+- `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs` — updated: added backing field + lazy property
+- `backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterTemplateConfiguration.cs` — updated: added filtered unique index
+- `backend/src/JobNecto.Infrastructure/Migrations/<timestamp>_AddCoverLetterTemplateUniqueNamePerUser.cs` — new: EF migration
+- `backend/src/JobNecto.Infrastructure/Migrations/AppDbContextModelSnapshot.cs` — updated: by EF migration tooling
+- `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommand.cs` — new
+- `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandler.cs` — new
+- `backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs` — new
+- `backend/src/JobNecto.Application/CoverLetterTemplates/Validators/CreateCoverLetterTemplateCommandValidator.cs` — new
+- `backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs` — new
+- `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandValidatorTests.cs` — new
+- `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandlerTests.cs` — new
+- `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs` — new (InMemory: auth + validation tests)
+- `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs` — new (Postgres: uniqueness + concurrency tests)
+- `_bmad-output/implementation-artifacts/3-1-create-cover-letter-template.md` — this file
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — updated: status to review
+
+## Change Log
+
+- 2026-05-07: Implemented story 3.1 — POST /api/v1/cover-letter-templates endpoint with JWT auth, FluentValidation (content 50–10,000 chars, name unique per user), DB-backed 409 Conflict via filtered unique index, 16 tests added (308 total, 0 failures).
+
+## Story Completion Status
+
+- Ultimate context engine analysis completed - comprehensive developer guide created.
+
+## Review Findings
+
+- [x] [Review][Decision] Case-sensitive name uniqueness — dismissed: case-sensitive uniqueness is intentional per owner decision 2026-05-07.
+- [x] [Review][Patch] Missing DB-level HasMaxLength(100) on Name — fixed: added `.HasMaxLength(100)` to `CoverLetterTemplateConfiguration.cs` + generated migration `AddCoverLetterTemplateNameMaxLength`. [`CoverLetterTemplateConfiguration.cs`]
+- [x] [Review][Patch] Missing test for Name exceeding 100 characters — fixed: added `Validate_NameMoreThan100Chars_Fails`. [`CreateCoverLetterTemplateCommandValidatorTests.cs`]
+- [x] [Review][Patch] Concurrent duplicate test assertion too weak — fixed: asserts exactly 1×201 and 1×409. [`CoverLetterTemplatesUniquenessApiTests.cs`]
+- [x] [Review][Patch] Location header test does not validate GUID suffix — fixed: parses and validates GUID segment. [`CoverLetterTemplatesApiTests.cs:92`]
+- [x] [Review][Patch] Handler test missing CreatedAt == UpdatedAt equality assertion — fixed: added `result.CreatedAt.Should().Be(result.UpdatedAt)`. [`CreateCoverLetterTemplateCommandHandlerTests.cs`]
+- [x] [Review][Defer] Unit handler test missing result.Id != Guid.Empty assertion [`CreateCoverLetterTemplateCommandHandlerTests.cs`] — deferred, integration test covers ID generation via NotBeEmpty assertion
+- [x] [Review][Defer] C# clock vs DB clock for timestamps [`CreateCoverLetterTemplateCommandHandler.cs:28-30`] — deferred, by design: documented EF InMemory lesson (2026-05-05); app-layer assignment required for in-memory test compatibility
+- [x] [Review][Defer] TryInitializeSchemaAsync not thread-safe [`CoverLetterTemplatesUniquenessApiTests.cs:128`] — deferred, latent: only one fixture class currently uses this factory
+- [x] [Review][Defer] ConfigureWebHost/TryInitializeSchemaAsync ordering fragility [`CoverLetterTemplatesUniquenessApiTests.cs:162`] — deferred, WebApplicationFactory lazy-builds host on first CreateClient(); current test pattern is safe
+- [x] [Review][Defer] Exception swallowing in Postgres factory [`CoverLetterTemplatesUniquenessApiTests.cs:154-158`] — deferred, intentional skip behaviour for CI environments without Postgres
+- [x] [Review][Defer] DI bypass for repository in UnitOfWork [`UnitOfWork.cs:41`] — deferred, pre-existing pattern throughout all repositories
+- [x] [Review][Defer] Hard-coded Location URI string in controller [`CoverLetterTemplatesController.cs:50`] — deferred, pre-existing established pattern per EducationsController
+- [x] [Review][Defer] GetCurrentUserId() returns 401 vs 403 for malformed claim [`CoverLetterTemplatesController.cs:44`] — deferred, matches existing pattern in EducationsController

--- a/_bmad-output/implementation-artifacts/3-1-create-cover-letter-template.md
+++ b/_bmad-output/implementation-artifacts/3-1-create-cover-letter-template.md
@@ -1,6 +1,6 @@
 # Story 3.1: Create Cover Letter Template
 
-Status: done
+Status: review-complete
 
 ## Story
 
@@ -379,3 +379,10 @@ No blockers encountered. EF Core InMemory uniqueness limitation resolved by intr
 - [x] [Review][Defer] DI bypass for repository in UnitOfWork [`UnitOfWork.cs:41`] — deferred, pre-existing pattern throughout all repositories
 - [x] [Review][Defer] Hard-coded Location URI string in controller [`CoverLetterTemplatesController.cs:50`] — deferred, pre-existing established pattern per EducationsController
 - [x] [Review][Defer] GetCurrentUserId() returns 401 vs 403 for malformed claim [`CoverLetterTemplatesController.cs:44`] — deferred, matches existing pattern in EducationsController
+
+## Additional Code Review (2026-05-08)
+
+- [x] [Review][Patch] Thread-safety in `TryInitializeSchemaAsync` — fixed: added `SemaphoreSlim _initLock` with double-check pattern in `TryInitializeSchemaAsync`. [`CoverLetterTemplatesUniquenessApiTests.cs:128-145`]
+- [x] [Review][Patch] Missing test for content at exactly 10,000 characters — fixed: added `Validate_ContentExactly10000Chars_Passes()` test. [`CreateCoverLetterTemplateCommandValidatorTests.cs`]
+- [x] [Review][Patch] Exception swallowing in `CoverLetterTemplatesPostgresFactory` — fixed: log exception message to `_output` before returning false. [`CoverLetterTemplatesUniquenessApiTests.cs:154-160`]
+- [x] [Review][Defer] Connection string ordering fragility — `_scopedConnectionString` could be uninitialized if `CreateClient` called before `TryInitializeSchemaAsync`. Current test pattern is safe. [`CoverLetterTemplatesUniquenessApiTests.cs:162-169`]

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -47,3 +47,14 @@
 - **`DateTime.UtcNow` hardcoded** — No clock abstraction in `UpdateEducationCommandHandler` and `DeleteEducationCommandHandler` makes time-sensitive unit tests fragile. Deferred: pre-existing pattern across all handlers in the project.
 - **Non-atomic `UpdateAsync` + `SaveChangesAsync`** — A `SaveChangesAsync` failure leaves the EF change tracker in a dirty state; subsequent operations on the same scope could inadvertently persist partial changes. Deferred: pre-existing pattern across all handlers.
 - **`DeleteEducationCommandValidator` has no unit tests** — Validator is exercised implicitly through the pipeline; route `:guid` constraint prevents `Guid.Empty` from reaching it. Deferred: low-risk, consistent with project convention for simple validators.
+
+## Deferred from: code review of 3-1-create-cover-letter-template (2026-05-07)
+
+- **Unit handler test missing `result.Id != Guid.Empty` assertion** — `CreateCoverLetterTemplateCommandHandlerTests` does not assert the returned Id is populated; integration test covers this via `NotBeEmpty` assertion in `CoverLetterTemplatesApiTests`.
+- **C# clock vs DB clock for timestamps** — `CreateCoverLetterTemplateCommandHandler` sets `CreatedAt`/`UpdatedAt` via `DateTime.UtcNow` rather than letting EF use `HasDefaultValueSql`; by design for EF InMemory test compatibility (documented lesson 2026-05-05).
+- **`TryInitializeSchemaAsync` not thread-safe** — No synchronization guard; concurrent fixture initialization could race if a second test class uses `CoverLetterTemplatesPostgresFactory`. Latent — currently only one fixture class.
+- **`ConfigureWebHost`/`TryInitializeSchemaAsync` ordering fragility** — `_scopedConnectionString` is set by `TryInitializeSchemaAsync` which must be called before `CreateClient()`; relies on `WebApplicationFactory` lazy host construction. Safe with current test pattern.
+- **Exception swallowing in `CoverLetterTemplatesPostgresFactory`** — `catch { return false; }` and `catch { }` discard exceptions silently; CI skips without logging the failure cause. Intentional skip behaviour for environments without Postgres.
+- **DI bypass for repository in `UnitOfWork`** — `new CoverLetterTemplateRepository(_context)` bypasses the DI container; pre-existing pattern across all repositories in `UnitOfWork`.
+- **Hard-coded `Location` URI string in controller** — `Created($"/api/v1/cover-letter-templates/{result.Id}", result)` would silently break on route changes; pre-existing pattern per `EducationsController`.
+- **`GetCurrentUserId()` returns 401 vs 403 for malformed claim** — A valid but malformed JWT claim returns 401 rather than 403; matches existing pattern in `EducationsController`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-05-06T00:00:00Z
+# last_updated: 2026-05-07T21:00:00Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -61,8 +61,8 @@ development_status:
   epic-r-retrospective: optional
 
   # --- Epic 3: Cover Letter Template Library ---
-  epic-3: backlog
-  3-1-create-cover-letter-template: backlog
+  epic-3: in-progress
+  3-1-create-cover-letter-template: done
   3-2-list-cover-letter-templates: backlog
   3-3-get-cover-letter-template-detail: backlog
   3-4-update-cover-letter-template: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-05-07T21:00:00Z
+# last_updated: 2026-05-08T00:00:00Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system

--- a/backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs
+++ b/backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs
@@ -1,0 +1,52 @@
+using JobNecto.API.Infrastructure;
+using JobNecto.Application.CoverLetterTemplates;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JobNecto.API.Controllers;
+
+/// <summary>
+/// Controller for managing cover letter templates.
+/// </summary>
+[ApiController]
+[Route("api/v1/cover-letter-templates")]
+[Authorize]
+public class CoverLetterTemplatesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CoverLetterTemplatesController"/> class.
+    /// </summary>
+    /// <param name="mediator">MediatR dispatcher.</param>
+    public CoverLetterTemplatesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Creates a new cover letter template for the current authenticated user.
+    /// </summary>
+    /// <param name="command">Cover letter template creation payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created cover letter template.</returns>
+    [HttpPost]
+    [ProducesResponseType(typeof(CoverLetterTemplateResult), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<CoverLetterTemplateResult>> Create(
+        CreateCoverLetterTemplateCommand command,
+        CancellationToken cancellationToken)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        command.UserId = userId;
+
+        var result = await _mediator.Send(command, cancellationToken);
+        return Created($"/api/v1/cover-letter-templates/{result.Id}", result);
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommand.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommand.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.CoverLetterTemplates;
+
+/// <summary>
+/// Command for creating a new cover letter template for the authenticated user.
+/// </summary>
+public class CreateCoverLetterTemplateCommand : IRequest<CoverLetterTemplateResult>
+{
+    /// <summary>
+    /// Authenticated user identifier injected by the API layer.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Template name, must be unique per user across non-deleted templates.
+    /// </summary>
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Cover letter content body (50–10,000 characters).
+    /// </summary>
+    public string Content { get; set; } = null!;
+}
+
+/// <summary>
+/// Response payload for a created or retrieved cover letter template.
+/// </summary>
+public class CoverLetterTemplateResult
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public string Name { get; set; } = null!;
+    public string Content { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandler.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandler.cs
@@ -1,0 +1,37 @@
+using JobNecto.Application.CoverLetterTemplates.Mappers;
+using JobNecto.Application.Interfaces;
+using MediatR;
+
+namespace JobNecto.Application.CoverLetterTemplates;
+
+/// <summary>
+/// Handles creation of cover letter templates for the current user.
+/// </summary>
+public class CreateCoverLetterTemplateCommandHandler : IRequestHandler<CreateCoverLetterTemplateCommand, CoverLetterTemplateResult>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateCoverLetterTemplateCommandHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public CreateCoverLetterTemplateCommandHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<CoverLetterTemplateResult> Handle(
+        CreateCoverLetterTemplateCommand request, CancellationToken cancellationToken)
+    {
+        var template = request.ToEntity();
+        var now = DateTime.UtcNow;
+        template.CreatedAt = now;
+        template.UpdatedAt = now;
+
+        await _unitOfWork.CoverLetterTemplateRepository.CreateAsync(template, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return template.ToCoverLetterTemplateResult();
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs
@@ -1,0 +1,48 @@
+using JobNecto.Domain.Entities;
+
+namespace JobNecto.Application.CoverLetterTemplates.Mappers;
+
+/// <summary>
+/// Mapping extensions for the cover letter template create flow.
+/// </summary>
+public static class CoverLetterTemplateMappers
+{
+    /// <summary>
+    /// Maps a create command into a domain entity.
+    /// </summary>
+    /// <param name="command">Incoming command payload.</param>
+    /// <returns>Mapped cover letter template entity.</returns>
+    public static CoverLetterTemplate ToEntity(this CreateCoverLetterTemplateCommand command)
+    {
+        if (command == null)
+            throw new ArgumentNullException(nameof(command));
+
+        return new CoverLetterTemplate
+        {
+            UserId = command.UserId,
+            Name = command.Name,
+            Content = command.Content,
+        };
+    }
+
+    /// <summary>
+    /// Maps a domain entity to the API response DTO.
+    /// </summary>
+    /// <param name="template">Persisted cover letter template entity.</param>
+    /// <returns>API-facing cover letter template result.</returns>
+    public static CoverLetterTemplateResult ToCoverLetterTemplateResult(this CoverLetterTemplate template)
+    {
+        if (template == null)
+            throw new ArgumentNullException(nameof(template));
+
+        return new CoverLetterTemplateResult
+        {
+            Id = template.Id,
+            UserId = template.UserId,
+            Name = template.Name,
+            Content = template.Content,
+            CreatedAt = template.CreatedAt,
+            UpdatedAt = template.UpdatedAt,
+        };
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/Validators/CreateCoverLetterTemplateCommandValidator.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/Validators/CreateCoverLetterTemplateCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace JobNecto.Application.CoverLetterTemplates.Validators;
+
+/// <summary>
+/// Validator for <see cref="CreateCoverLetterTemplateCommand"/>.
+/// </summary>
+public class CreateCoverLetterTemplateCommandValidator : AbstractValidator<CreateCoverLetterTemplateCommand>
+{
+    /// <summary>
+    /// Initializes validation rules for cover letter template creation requests.
+    /// </summary>
+    public CreateCoverLetterTemplateCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Content).NotEmpty().MinimumLength(50).MaximumLength(10000);
+    }
+}

--- a/backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs
@@ -36,6 +36,11 @@ public interface IUnitOfWork : IAsyncDisposable
     IMutableRepository<Education> EducationRepository { get; }
 
     /// <summary>
+    /// Repository for cover letter templates with full write support (update + soft delete).
+    /// </summary>
+    IMutableRepository<CoverLetterTemplate> CoverLetterTemplateRepository { get; }
+
+    /// <summary>
     /// Persists pending changes to the database. Implementations should forward
     /// the provided <paramref name="ct"/> to the underlying DbContext save call.
     /// </summary>

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260507201350_AddCoverLetterTemplateUniqueNamePerUser.Designer.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260507201350_AddCoverLetterTemplateUniqueNamePerUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JobNecto.Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JobNecto.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507201350_AddCoverLetterTemplateUniqueNamePerUser")]
+    partial class AddCoverLetterTemplateUniqueNamePerUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -105,8 +108,7 @@ namespace JobNecto.Infrastructure.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAt")
                         .ValueGeneratedOnAddOrUpdate()

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260507201350_AddCoverLetterTemplateUniqueNamePerUser.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260507201350_AddCoverLetterTemplateUniqueNamePerUser.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobNecto.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCoverLetterTemplateUniqueNamePerUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CoverLetterTemplates_UserId",
+                table: "CoverLetterTemplates");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CoverLetterTemplates_UserId_Name",
+                table: "CoverLetterTemplates",
+                columns: new[] { "UserId", "Name" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CoverLetterTemplates_UserId_Name",
+                table: "CoverLetterTemplates");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CoverLetterTemplates_UserId",
+                table: "CoverLetterTemplates",
+                column: "UserId");
+        }
+    }
+}

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260507205303_AddCoverLetterTemplateNameMaxLength.Designer.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260507205303_AddCoverLetterTemplateNameMaxLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JobNecto.Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JobNecto.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507205303_AddCoverLetterTemplateNameMaxLength")]
+    partial class AddCoverLetterTemplateNameMaxLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260507205303_AddCoverLetterTemplateNameMaxLength.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260507205303_AddCoverLetterTemplateNameMaxLength.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobNecto.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCoverLetterTemplateNameMaxLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CoverLetterTemplates",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CoverLetterTemplates",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+        }
+    }
+}

--- a/backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterTemplateConfiguration.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterTemplateConfiguration.cs
@@ -12,7 +12,7 @@ public class CoverLetterTemplateConfiguration : IEntityTypeConfiguration<CoverLe
 
         builder.HasKey(clt => clt.Id);
 
-        builder.Property(clt => clt.Name).IsRequired();
+        builder.Property(clt => clt.Name).IsRequired().HasMaxLength(100);
 
         builder.Property(clt => clt.Content).IsRequired();
 
@@ -32,5 +32,9 @@ public class CoverLetterTemplateConfiguration : IEntityTypeConfiguration<CoverLe
             .WithMany()
             .HasForeignKey(clt => clt.UserId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(t => new { t.UserId, t.Name })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
     }
 }

--- a/backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs
@@ -16,6 +16,7 @@ public class UnitOfWork : IUnitOfWork
     private IMutableRepository<CoverLetter>? _coverLetterRepository;
     private IMutableRepository<Resume>? _resumeRepository;
     private IMutableRepository<Education>? _educationRepository;
+    private IMutableRepository<CoverLetterTemplate>? _coverLetterTemplateRepository;
 
     public UnitOfWork(AppDbContext context)
     {
@@ -36,6 +37,9 @@ public class UnitOfWork : IUnitOfWork
 
     public IMutableRepository<Education> EducationRepository =>
         _educationRepository ??= new EducationRepository(_context);
+
+    public IMutableRepository<CoverLetterTemplate> CoverLetterTemplateRepository =>
+        _coverLetterTemplateRepository ??= new CoverLetterTemplateRepository(_context);
 
     public async Task BeginTransactionAsync(CancellationToken ct)
     {

--- a/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using JobNecto.Application.CoverLetterTemplates;
+using JobNecto.Application.Users;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace JobNecto.Tests.API.CoverLetterTemplates;
+
+public class CoverLetterTemplatesApiTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static string ValidContent() => new string('a', 50);
+
+    private static CreateUserCommand NewUserCommand(string prefix = "clt_user") =>
+        new()
+        {
+            LoginName = prefix + Guid.NewGuid().ToString("N")[..8],
+            Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+            Password = "Password123!",
+        };
+
+    internal static async Task<string> CreateUserAndGetCookieHelperAsync(
+        HttpClient client,
+        CreateUserCommand? command = null)
+    {
+        command ??= NewUserCommand();
+
+        var response = await client.PostAsJsonAsync("/api/v1/users", command);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var authCookie = response
+            .Headers.GetValues("Set-Cookie")
+            .Select(x =>
+                x.Split(';', StringSplitOptions.TrimEntries)
+                    .FirstOrDefault(y =>
+                        y.StartsWith("auth-token=", StringComparison.OrdinalIgnoreCase)))
+            .First(x => !string.IsNullOrWhiteSpace(x));
+
+        authCookie.Should().NotBeNullOrWhiteSpace();
+        return authCookie!;
+    }
+
+    internal static async Task<HttpResponseMessage> PostTemplateAsync(
+        HttpClient client,
+        string authCookie,
+        object payload)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/cover-letter-templates")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(request);
+    }
+
+    [Fact]
+    public async Task Create_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/v1/cover-letter-templates",
+            new CreateCoverLetterTemplateCommand { Name = "Test", Content = ValidContent() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Create_ValidPayload_Returns201WithLocationAndPayload()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var response = await PostTemplateAsync(client, authCookie, new
+        {
+            name = "My Cover Letter",
+            content = ValidContent(),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+        var locationStr = response.Headers.Location.ToString();
+        locationStr.Should().StartWith("/api/v1/cover-letter-templates/");
+        var idSegment = locationStr.Split('/').Last();
+        Guid.TryParse(idSegment, out _).Should().BeTrue("Location header must end with a valid GUID");
+
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Id.Should().NotBeEmpty();
+        result.Name.Should().Be("My Cover Letter");
+        result.Content.Should().Be(ValidContent());
+        result.CreatedAt.Should().NotBe(default(DateTime));
+        result.UpdatedAt.Should().NotBe(default(DateTime));
+    }
+
+    [Fact]
+    public async Task Create_ContentLessThan50Chars_Returns400WithFieldLevelError()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var response = await PostTemplateAsync(client, authCookie, new
+        {
+            name = "My Template",
+            content = new string('a', 49),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Content");
+    }
+
+    [Fact]
+    public async Task Create_ContentMoreThan10000Chars_Returns400WithFieldLevelError()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var response = await PostTemplateAsync(client, authCookie, new
+        {
+            name = "My Template",
+            content = new string('a', 10001),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Content");
+    }
+
+    internal class CoverLetterTemplateResultDto
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public string Name { get; set; } = null!;
+        public string Content { get; set; } = null!;
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
@@ -10,17 +10,26 @@ using Xunit.Abstractions;
 
 namespace JobNecto.Tests.API.CoverLetterTemplates;
 
-public class CoverLetterTemplatesUniquenessApiTests : IClassFixture<CoverLetterTemplatesPostgresFactory>
+public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
 {
-    private readonly CoverLetterTemplatesPostgresFactory _factory;
     private readonly ITestOutputHelper _output;
+    private CoverLetterTemplatesPostgresFactory? _factory;
 
-    public CoverLetterTemplatesUniquenessApiTests(
-        CoverLetterTemplatesPostgresFactory factory,
-        ITestOutputHelper output)
+    public CoverLetterTemplatesUniquenessApiTests(ITestOutputHelper output)
     {
-        _factory = factory;
         _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _factory = new CoverLetterTemplatesPostgresFactory(_output);
+        await Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
     }
 
     private static string ValidContent() => new string('a', 50);
@@ -42,7 +51,7 @@ public class CoverLetterTemplatesUniquenessApiTests : IClassFixture<CoverLetterT
             return;
         }
 
-        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand());
 
         var first = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new
@@ -69,7 +78,7 @@ public class CoverLetterTemplatesUniquenessApiTests : IClassFixture<CoverLetterT
             return;
         }
 
-        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var cookieA = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_a_"));
         var cookieB = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_b_"));
 
@@ -97,7 +106,7 @@ public class CoverLetterTemplatesUniquenessApiTests : IClassFixture<CoverLetterT
             return;
         }
 
-        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand());
 
         var task1 = CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new { name = "Same Name", content = ValidContent() });
@@ -118,9 +127,12 @@ public sealed class CoverLetterTemplatesPostgresFactory : WebApplicationFactory<
     private readonly string _schemaName;
     private string? _scopedConnectionString;
     private bool _schemaInitialized;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private readonly ITestOutputHelper? _output;
 
-    public CoverLetterTemplatesPostgresFactory()
+    public CoverLetterTemplatesPostgresFactory(ITestOutputHelper? output = null)
     {
+        _output = output;
         _baseConnectionString = Environment.GetEnvironmentVariable("JOBNECTO_TEST_POSTGRES")
             ?? DefaultConnectionString;
         _schemaName = "clt_uniqueness_" + Guid.NewGuid().ToString("N");
@@ -131,8 +143,12 @@ public sealed class CoverLetterTemplatesPostgresFactory : WebApplicationFactory<
         if (_schemaInitialized)
             return true;
 
+        await _initLock.WaitAsync(cancellationToken);
         try
         {
+            if (_schemaInitialized)
+                return true;
+
             await EnsureSchemaExistsAsync(cancellationToken);
 
             var builder = new NpgsqlConnectionStringBuilder(_baseConnectionString)
@@ -154,9 +170,14 @@ public sealed class CoverLetterTemplatesPostgresFactory : WebApplicationFactory<
             _schemaInitialized = true;
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            _output?.WriteLine($"Schema initialization failed: {ex.Message}");
             return false;
+        }
+        finally
+        {
+            _initLock.Release();
         }
     }
 
@@ -198,9 +219,9 @@ public sealed class CoverLetterTemplatesPostgresFactory : WebApplicationFactory<
             command.CommandText = $"DROP SCHEMA IF EXISTS \"{_schemaName}\" CASCADE;";
             await command.ExecuteNonQueryAsync();
         }
-        catch
+        catch (Exception ex)
         {
-            // Best-effort cleanup only.
+            _output?.WriteLine($"Schema cleanup failed: {ex.Message}");
         }
     }
 }

--- a/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using FluentAssertions;
+using JobNecto.Application.Users;
+using JobNecto.Infrastructure.Persistance;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Xunit.Abstractions;
+
+namespace JobNecto.Tests.API.CoverLetterTemplates;
+
+public class CoverLetterTemplatesUniquenessApiTests : IClassFixture<CoverLetterTemplatesPostgresFactory>
+{
+    private readonly CoverLetterTemplatesPostgresFactory _factory;
+    private readonly ITestOutputHelper _output;
+
+    public CoverLetterTemplatesUniquenessApiTests(
+        CoverLetterTemplatesPostgresFactory factory,
+        ITestOutputHelper output)
+    {
+        _factory = factory;
+        _output = output;
+    }
+
+    private static string ValidContent() => new string('a', 50);
+
+    private static CreateUserCommand NewUserCommand(string prefix = "clt_u") =>
+        new()
+        {
+            LoginName = prefix + Guid.NewGuid().ToString("N")[..8],
+            Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+            Password = "Password123!",
+        };
+
+    [Fact]
+    public async Task Create_DuplicateName_SameUser_Returns409()
+    {
+        if (!await _factory.TryInitializeSchemaAsync())
+        {
+            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+            return;
+        }
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand());
+
+        var first = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new
+        {
+            name = "Duplicate Name",
+            content = ValidContent(),
+        });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new
+        {
+            name = "Duplicate Name",
+            content = ValidContent(),
+        });
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Create_SameName_DifferentUsers_Returns201BothTimes()
+    {
+        if (!await _factory.TryInitializeSchemaAsync())
+        {
+            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+            return;
+        }
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var cookieA = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_a_"));
+        var cookieB = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_b_"));
+
+        var responseA = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, cookieA, new
+        {
+            name = "Shared Name",
+            content = ValidContent(),
+        });
+        var responseB = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, cookieB, new
+        {
+            name = "Shared Name",
+            content = ValidContent(),
+        });
+
+        responseA.StatusCode.Should().Be(HttpStatusCode.Created);
+        responseB.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentDuplicateName_AtLeastOneReturns409()
+    {
+        if (!await _factory.TryInitializeSchemaAsync())
+        {
+            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+            return;
+        }
+
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand());
+
+        var task1 = CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new { name = "Same Name", content = ValidContent() });
+        var task2 = CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new { name = "Same Name", content = ValidContent() });
+        var results = await Task.WhenAll(task1, task2);
+
+        results.Count(r => r.StatusCode == HttpStatusCode.Created).Should().Be(1);
+        results.Count(r => r.StatusCode == HttpStatusCode.Conflict).Should().Be(1);
+    }
+}
+
+public sealed class CoverLetterTemplatesPostgresFactory : WebApplicationFactory<Program>
+{
+    private const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=JobNectoTest;Username=test;Password=test";
+
+    private readonly string _baseConnectionString;
+    private readonly string _schemaName;
+    private string? _scopedConnectionString;
+    private bool _schemaInitialized;
+
+    public CoverLetterTemplatesPostgresFactory()
+    {
+        _baseConnectionString = Environment.GetEnvironmentVariable("JOBNECTO_TEST_POSTGRES")
+            ?? DefaultConnectionString;
+        _schemaName = "clt_uniqueness_" + Guid.NewGuid().ToString("N");
+    }
+
+    public async Task<bool> TryInitializeSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        if (_schemaInitialized)
+            return true;
+
+        try
+        {
+            await EnsureSchemaExistsAsync(cancellationToken);
+
+            var builder = new NpgsqlConnectionStringBuilder(_baseConnectionString)
+            {
+                SearchPath = _schemaName
+            };
+
+            _scopedConnectionString = builder.ConnectionString;
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseNpgsql(
+                    _scopedConnectionString,
+                    npgsql => npgsql.MigrationsAssembly("JobNecto.Infrastructure"))
+                .Options;
+
+            await using var dbContext = new AppDbContext(options);
+            await dbContext.Database.MigrateAsync(cancellationToken);
+
+            _schemaInitialized = true;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Test");
+        builder.UseSetting(
+            "ConnectionStrings:Postgres",
+            _scopedConnectionString ?? _baseConnectionString);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await DropSchemaAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task EnsureSchemaExistsAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(_baseConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{_schemaName}\";";
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task DropSchemaAsync()
+    {
+        if (!_schemaInitialized)
+            return;
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(_baseConnectionString);
+            await connection.OpenAsync();
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"DROP SCHEMA IF EXISTS \"{_schemaName}\" CASCADE;";
+            await command.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandlerTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetterTemplates;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.Entities;
+using Moq;
+
+namespace JobNecto.Tests.Application.CoverLetterTemplates;
+
+public class CreateCoverLetterTemplateCommandHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IMutableRepository<CoverLetterTemplate>> _repositoryMock;
+    private readonly CreateCoverLetterTemplateCommandHandler _handler;
+
+    public CreateCoverLetterTemplateCommandHandlerTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _repositoryMock = new Mock<IMutableRepository<CoverLetterTemplate>>();
+
+        _unitOfWorkMock
+            .Setup(x => x.CoverLetterTemplateRepository)
+            .Returns(_repositoryMock.Object);
+
+        _handler = new CreateCoverLetterTemplateCommandHandler(_unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PersistsExactlyOnceAndReturnsResultWithNonDefaultTimestamps()
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = "My Cover Letter",
+            Content = new string('a', 50),
+        };
+
+        CoverLetterTemplate? capturedEntity = null;
+        _repositoryMock
+            .Setup(x => x.CreateAsync(It.IsAny<CoverLetterTemplate>(), It.IsAny<CancellationToken>()))
+            .Callback<CoverLetterTemplate, CancellationToken>((entity, _) => capturedEntity = entity)
+            .ReturnsAsync((CoverLetterTemplate entity, CancellationToken _) => entity);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.UserId.Should().Be(command.UserId);
+        result.Name.Should().Be(command.Name);
+        result.Content.Should().Be(command.Content);
+        result.CreatedAt.Should().NotBe(default(DateTime));
+        result.UpdatedAt.Should().NotBe(default(DateTime));
+        result.CreatedAt.Should().Be(result.UpdatedAt);
+
+        capturedEntity.Should().NotBeNull();
+        capturedEntity!.UserId.Should().Be(command.UserId);
+        capturedEntity.Name.Should().Be(command.Name);
+        capturedEntity.Content.Should().Be(command.Content);
+        capturedEntity.CreatedAt.Should().NotBe(default(DateTime));
+        capturedEntity.UpdatedAt.Should().NotBe(default(DateTime));
+
+        _repositoryMock.Verify(
+            x => x.CreateAsync(It.IsAny<CoverLetterTemplate>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _unitOfWorkMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandValidatorTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetterTemplates;
+using JobNecto.Application.CoverLetterTemplates.Validators;
+
+namespace JobNecto.Tests.Application.CoverLetterTemplates;
+
+public class CreateCoverLetterTemplateCommandValidatorTests
+{
+    private readonly CreateCoverLetterTemplateCommandValidator _validator = new();
+
+    private static string ValidContent() => new string('a', 50);
+
+    [Fact]
+    public void Validate_ValidPayload_Passes()
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = "My Template",
+            Content = ValidContent(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Validate_NullOrEmptyName_Fails(string? name)
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = name!,
+            Content = ValidContent(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Name");
+    }
+
+    [Fact]
+    public void Validate_WhitespaceOnlyName_Fails()
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = "   ",
+            Content = ValidContent(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Name");
+    }
+
+    [Fact]
+    public void Validate_ContentLessThan50Chars_Fails()
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = "My Template",
+            Content = new string('a', 49),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Fact]
+    public void Validate_ContentMoreThan10000Chars_Fails()
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = "My Template",
+            Content = new string('a', 10001),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Fact]
+    public void Validate_NameMoreThan100Chars_Fails()
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = new string('a', 101),
+            Content = ValidContent(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Name");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Validate_NullOrEmptyContent_Fails(string? content)
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = "My Template",
+            Content = content!,
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandValidatorTests.cs
@@ -124,4 +124,19 @@ public class CreateCoverLetterTemplateCommandValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(x => x.PropertyName == "Content");
     }
+
+    [Fact]
+    public void Validate_ContentExactly10000Chars_Passes()
+    {
+        var command = new CreateCoverLetterTemplateCommand
+        {
+            UserId = Guid.NewGuid(),
+            Name = "My Template",
+            Content = new string('a', 10000),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary

- Implements `POST /api/v1/cover-letter-templates` with JWT auth (`[Authorize]`), returning `201 Created` with `Location` header
- Adds per-user name uniqueness enforced by a filtered DB index (`IsDeleted = false`) with DB-backed 409 via `GlobalExceptionHandler`
- FluentValidation: `content` 50–10,000 chars, `name` non-empty + max 100 chars (enforced at both app and DB level)

## Changes

| Area | Files |
|------|-------|
| Application | `CreateCoverLetterTemplateCommand`, `CommandHandler`, `Mappers`, `Validator` |
| API | `CoverLetterTemplatesController` |
| Infrastructure | `IUnitOfWork` + `UnitOfWork` (expose repo), `CoverLetterTemplateConfiguration` (unique index + max length), 2 EF migrations |
| Tests | 17 new tests: validator (6), handler (1), API/InMemory (4), uniqueness/Postgres (3+factory) |

## Migrations

1. `AddCoverLetterTemplateUniqueNamePerUser` — filtered unique index on `(UserId, Name)` where `IsDeleted = false`
2. `AddCoverLetterTemplateNameMaxLength` — alters `Name` column from `text` to `character varying(100)`

## Test plan

- [ ] `dotnet test backend/JobNecto.slnx --filter "FullyQualifiedName~CoverLetterTemplates"` — 17/17 pass
- [ ] `dotnet test backend/JobNecto.slnx` — 309/309 pass
- [ ] Postgres uniqueness tests skip gracefully when DB unavailable (CI-safe)
- [ ] Review findings all resolved; 8 items deferred to `deferred-work.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)