### PR TITLE
feat: implement Story 3.4 cover letter template PATCH update flow

### DIFF
--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,16 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-05-10 - Align endpoint method with latest user contract
+
+**Trigger:** User correction
+**Context:** Story 3.4 planning artifacts for cover letter template update endpoint method.
+**Wrong action:** I generated/kept `PUT /api/v1/cover-letter-templates/{id}` in story source artifacts.
+**Root cause:** I over-relied on previously documented wording and did not treat the user's latest method preference as the immediate source of truth.
+**Correct behavior:** When the user corrects an endpoint method, update all related source-of-truth artifacts in the same pass (epic story, requirements inventory, and generated implementation story file) to keep contracts consistent.
+**Pattern / trigger:** User explicitly changes API method semantics (e.g., "change PUT to PATCH") after artifacts were generated.
+**Generalize?** No
+
 ### 2026-05-09 - Run mandatory post-merge docs workflow immediately
 
 **Trigger:** User correction

--- a/_bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md
+++ b/_bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md
@@ -202,7 +202,7 @@ so that I can refine my reusable material over time.
 ## Story Completion Status
 
 - Story context drafted and validated against current architecture and test patterns.
-- Sprint status updated to `ready-for-dev`.
+- Sprint status updated to `review`.
 - Completion note: comprehensive developer guide prepared for direct `dev-story` execution.
 
 ## Dev Agent Record

--- a/_bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md
+++ b/_bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md
@@ -1,0 +1,248 @@
+# Story 3.4: Update Cover Letter Template
+
+Status: review
+
+## Story
+
+As a job seeker,
+I want to update a template's name or content,
+so that I can refine my reusable material over time.
+
+## Acceptance Criteria
+
+1. Given a valid JWT token and `PATCH /api/v1/cover-letter-templates/{id}` with new `name` and/or `content`, when the request is processed then `200 OK` is returned with the updated template and refreshed `updatedAt`.
+2. Given the new `name` is already taken by another non-deleted template of this user, when the request is processed then `409 Conflict` is returned from database-backed per-user uniqueness enforcement.
+3. Given the template belongs to another user, then `403 Forbidden` is returned.
+4. Given updated `content` violates 50-10000 char bounds, then `400 Bad Request` is returned with field-level validation error on `content`.
+5. Given the template does not exist or is soft-deleted, then `404 Not Found` is returned.
+6. Given neither `name` nor `content` is provided, then `400 Bad Request` is returned.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Implement Application update flow for cover letter templates (AC: 1, 2, 3, 4, 5, 6)
+  - [x] Add `backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommand.cs` implementing `IRequest<CoverLetterTemplateResult>`.
+  - [x] Include `[JsonIgnore]` route/auth-injected fields: `CoverLetterTemplateId` and `UserId`.
+  - [x] Include optional payload fields: `string? Name` and `string? Content` (partial update semantics per story AC wording "name and/or content").
+  - [x] Add `backend/src/JobNecto.Application/CoverLetterTemplates/Validators/UpdateCoverLetterTemplateCommandValidator.cs`:
+    - [x] Validate `CoverLetterTemplateId` and `UserId` are not empty.
+    - [x] Require at least one updatable field (`Name` or `Content`).
+    - [x] When `Name` is provided: reject empty/whitespace and enforce max length 100.
+    - [x] When `Content` is provided: enforce min 50 and max 10000.
+  - [x] Add `ApplyUpdates(this CoverLetterTemplate template, UpdateCoverLetterTemplateCommand command)` to `backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs`:
+    - [x] Update only provided fields.
+    - [x] Preserve `Id`, `UserId`, and `CreatedAt`.
+  - [x] Add `backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandler.cs`:
+    - [x] Load entity via `_unitOfWork.CoverLetterTemplateRepository.GetByIdAsync(...)`.
+    - [x] If ownership mismatches, throw `ForbiddenException("You do not have permission to update this cover letter template.")`.
+    - [x] Apply updates, set `UpdatedAt = DateTime.UtcNow`, call `UpdateAsync`, then `SaveChangesAsync`.
+    - [x] Return `template.ToCoverLetterTemplateResult()`.
+
+- [x] Task 2: Add authenticated PATCH endpoint (AC: 1, 2, 3, 4, 5, 6)
+  - [x] Update `backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs` with `[HttpPatch("{id:guid}")]` action.
+  - [x] Use strict auth guard pattern:
+    - [x] `var userIdValue = HttpContext.GetCurrentUserId();`
+    - [x] `if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId)) return Unauthorized();`
+  - [x] Inject route and auth fields into command: `command.CoverLetterTemplateId = id; command.UserId = userId;`.
+  - [x] Dispatch via `_mediator.Send(command, cancellationToken)` and return `Ok(result)`.
+  - [x] Add response metadata:
+    - [x] `200 OK` (`CoverLetterTemplateResult`)
+    - [x] `400 BadRequest`
+    - [x] `401 Unauthorized`
+    - [x] `403 Forbidden`
+    - [x] `404 NotFound`
+    - [x] `409 Conflict`
+
+- [x] Task 3: Add Application unit tests (AC: 1, 2, 3, 4, 5, 6)
+  - [x] Create `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandValidatorTests.cs`:
+    - [x] no updatable fields -> invalid
+    - [x] valid `Name` only -> valid
+    - [x] valid `Content` only -> valid
+    - [x] whitespace/too-long `Name` -> invalid
+    - [x] `Content` below 50 / above 10000 -> invalid
+  - [x] Create `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandlerTests.cs`:
+    - [x] owned template update returns updated result
+    - [x] `UpdatedAt` refreshed in UTC
+    - [x] cross-user template update throws `ForbiddenException`
+    - [x] non-existent/soft-deleted id propagates `NotFoundException`
+
+- [x] Task 4: Add API integration tests for PATCH endpoint (AC: 1, 2, 3, 4, 5, 6)
+  - [x] Update `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs`.
+  - [x] Add helper: `PatchTemplateAsync(HttpClient client, string authCookie, Guid id, object payload)`.
+  - [x] Add tests:
+    - [x] `Patch_WithoutToken_Returns401`
+    - [x] `Patch_OwnedTemplate_NameOnly_Returns200AndPreservesContent`
+    - [x] `Patch_OwnedTemplate_ContentOnly_Returns200AndPreservesName`
+    - [x] `Patch_AnotherUsersTemplate_Returns403`
+    - [x] `Patch_NonExistentId_Returns404`
+    - [x] `Patch_InvalidContentBounds_Returns400WithFieldError`
+    - [x] `Patch_EmptyBody_Returns400`
+
+- [x] Task 5: Extend PostgreSQL uniqueness tests for update collisions (AC: 2)
+  - [x] Update `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs`.
+  - [x] Add update uniqueness tests using `CoverLetterTemplatesPostgresFactory`:
+    - [x] rename to another existing non-deleted template name of same user -> `409 Conflict`
+    - [x] same name used by different user does not block update -> `200 OK`
+    - [x] concurrent rename collision test -> one success and at least one conflict
+
+- [x] Task 6: Verification gates
+  - [x] Run targeted tests:
+    - [x] `dotnet test backend/JobNecto.slnx --filter "FullyQualifiedName~CoverLetterTemplates"`
+  - [x] Run full tests:
+    - [x] `dotnet test backend/JobNecto.slnx`
+  - [x] Run CI parity:
+    - [x] `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`
+    - [x] `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror`
+
+## Dev Notes
+
+### Scope and behavior guardrails
+
+- This story adds update behavior only. Do not change create/list/detail semantics from stories 3.1-3.3.
+- Endpoint verb is `PATCH` for story contract alignment (`FR17` and Epic 3 story text), and payload supports updating `name` and/or `content`.
+- Keep ownership semantics explicit:
+  - Detail read cross-user -> `404` (already implemented in 3.3).
+  - Mutation cross-user -> `403` (required for 3.4).
+
+### Existing code baseline to extend
+
+- Controller currently has `POST`, list `GET`, and detail `GET` only:
+  - `backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs`
+- Existing create/list/detail handlers:
+  - `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandler.cs`
+  - `backend/src/JobNecto.Application/CoverLetterTemplates/ListCoverLetterTemplatesQueryHandler.cs`
+  - `backend/src/JobNecto.Application/CoverLetterTemplates/GetCoverLetterTemplateQueryHandler.cs`
+- Existing mapper and DTO to reuse:
+  - `backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs`
+  - `CoverLetterTemplateResult` in `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommand.cs`
+
+### Data, uniqueness, and error mapping
+
+- Database already enforces per-user template-name uniqueness on active records:
+  - `backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterTemplateConfiguration.cs`
+  - unique filtered index: `(UserId, Name)` with filter `"IsDeleted" = false`.
+- Rely on DB constraint for race-safe uniqueness and map unique violations to `409`:
+  - `backend/src/JobNecto.API/Infrastructure/ExceptionHandling/GlobalExceptionHandler.cs`
+- Do not add "pre-check only" uniqueness logic as the sole enforcement mechanism.
+
+### Ownership and not-found handling
+
+- `GetByIdAsync` repository contract is non-nullable and throws `NotFoundException` when missing/soft-deleted.
+- Handler must perform ownership check after load and throw `ForbiddenException` for cross-user update.
+- Global exception handler already maps:
+  - `ForbiddenException` -> `403`
+  - `NotFoundException` -> `404`
+  - unique-constraint `DbUpdateException` -> `409`
+
+### Validation specifics
+
+- `Name` when provided: not empty/whitespace, max 100.
+- `Content` when provided: min 50, max 10000.
+- Empty payload (`Name` and `Content` both null) must fail with `400`.
+- Keep validation style aligned with existing update validators in:
+  - `backend/src/JobNecto.Application/Educations/Validators/UpdateEducationCommandValidator.cs`
+  - `backend/src/JobNecto.Application/Resumes/Validators/UpdateResumeCommandValidator.cs`
+
+### Testing guidance
+
+- Reuse helpers in `CoverLetterTemplatesApiTests` (`CreateUserAndGetCookieHelperAsync`, `PostTemplateAsync`) and add a PATCH helper.
+- Keep test setup payloads validator-compliant (especially content length 50-10000).
+- For uniqueness update races, extend existing Postgres integration suite:
+  - `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs`
+- Preserve existing test architecture split:
+  - Application unit tests in `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates`
+  - API integration tests in `backend/tests/JobNecto.Tests/API/CoverLetterTemplates`
+
+### Project structure notes
+
+| File | Action |
+| ---- | ------ |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommand.cs` | NEW |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandler.cs` | NEW |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/Validators/UpdateCoverLetterTemplateCommandValidator.cs` | NEW |
+| `backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs` | UPDATE |
+| `backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs` | UPDATE |
+| `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandValidatorTests.cs` | NEW |
+| `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandlerTests.cs` | NEW |
+| `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs` | UPDATE |
+| `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs` | UPDATE |
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | UPDATE |
+
+### Namespace requirements
+
+- `JobNecto.Application.CoverLetterTemplates`
+- `JobNecto.Application.CoverLetterTemplates.Validators`
+- `JobNecto.Application.CoverLetterTemplates.Mappers`
+- `JobNecto.API.Controllers`
+- `JobNecto.Tests.Application.CoverLetterTemplates`
+- `JobNecto.Tests.API.CoverLetterTemplates`
+
+### Previous story intelligence
+
+- Story 3.2 established list/search patterns and API test helpers in `CoverLetterTemplatesApiTests` - extend instead of creating duplicate API test classes.
+- Story 3.3 established strict auth guard pattern and detail semantics (`404` for cross-user reads) - keep that unchanged while adding `403` for mutation.
+- Recent commits follow a stable vertical-slice sequence: controller + command/query handler + validators/mappers + tests + sprint/doc updates.
+
+### Latest technical information
+
+- No framework/library migration is required for this story.
+- Continue with current stack and constraints (`net10.0`, MediatR, FluentValidation, EF Core + Npgsql, global exception mapping).
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md` - Story 3.4]
+- [Source: `_bmad-output/planning-artifacts/epics/requirements-inventory.md` - FR17/FR28]
+- [Source: `_bmad-output/planning-artifacts/architecture/index.md`]
+- [Source: `_bmad-output/planning-artifacts/architecture/project-context-analysis.md`]
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md`]
+- [Source: `_bmad-output/planning-artifacts/architecture/epic-2-architecture-revision-2026-05-05.md`]
+- [Source: `backend/src/JobNecto.API/Infrastructure/ExceptionHandling/GlobalExceptionHandler.cs`]
+- [Source: `_bmad-output/implementation-artifacts/3-2-list-cover-letter-templates.md`]
+- [Source: `_bmad-output/implementation-artifacts/3-3-get-cover-letter-template-detail.md`]
+
+## Story Completion Status
+
+- Story context drafted and validated against current architecture and test patterns.
+- Sprint status updated to `ready-for-dev`.
+- Completion note: comprehensive developer guide prepared for direct `dev-story` execution.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.3-Codex
+
+### Debug Log References
+
+- Implemented `UpdateCoverLetterTemplateCommand`, validator, and handler with partial update semantics and ownership `403` enforcement.
+- Added `ApplyUpdates` mapper extension and authenticated `PATCH /api/v1/cover-letter-templates/{id}` endpoint with full response metadata.
+- Added new application tests and API integration tests for PATCH success/error paths and per-user uniqueness update collisions.
+- Executed verification gates successfully:
+  - `dotnet test backend/JobNecto.slnx --filter "FullyQualifiedName~CoverLetterTemplates"` (64 passed)
+  - `dotnet test backend/JobNecto.slnx` (356 passed)
+  - `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` (passed)
+  - `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror` (356 passed)
+
+### Completion Notes List
+
+- Completed Story 3.4 implementation for cover letter template update flow with `PATCH` endpoint and partial payload (`name` and/or `content`).
+- Implemented validation for required auth/route IDs, at-least-one-field rule, name bounds/whitespace checks, and content bounds (50-10000).
+- Added conflict-safe update behavior backed by database uniqueness constraints and global `409` mapping.
+- Added/updated tests across application and API layers, including PostgreSQL uniqueness collision scenarios for update operations.
+
+### File List
+
+- backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommand.cs
+- backend/src/JobNecto.Application/CoverLetterTemplates/Validators/UpdateCoverLetterTemplateCommandValidator.cs
+- backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandler.cs
+- backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs
+- backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs
+- backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandValidatorTests.cs
+- backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandlerTests.cs
+- backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs
+- backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
+- _bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+
+## Change Log
+
+- 2026-05-10: Implemented Story 3.4 update flow (`PATCH /api/v1/cover-letter-templates/{id}`), added validation/handler/mapper changes, expanded unit+integration+PostgreSQL uniqueness tests, and passed all verification gates.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-05-09T20:46:41Z
+# last_updated: 2026-05-10T00:30:00Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -65,7 +65,7 @@ development_status:
   3-1-create-cover-letter-template: done
   3-2-list-cover-letter-templates: done
   3-3-get-cover-letter-template-detail: done
-  3-4-update-cover-letter-template: backlog
+  3-4-update-cover-letter-template: review
   3-5-delete-cover-letter-template: backlog
   epic-3-retrospective: optional
 

--- a/_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md
+++ b/_bmad-output/planning-artifacts/epics/epic-3-cover-letter-template-library.md
@@ -86,7 +86,7 @@ So that I can refine my reusable material over time.
 
 **Acceptance Criteria:**
 
-**Given** a valid JWT token and `PUT /api/v1/cover-letter-templates/{id}` with new `name` and/or `content`
+**Given** a valid JWT token and `PATCH /api/v1/cover-letter-templates/{id}` with new `name` and/or `content`
 **When** the request is processed
 **Then** `200 OK` with updated template; `updatedAt` refreshed
 

--- a/_bmad-output/planning-artifacts/epics/requirements-inventory.md
+++ b/_bmad-output/planning-artifacts/epics/requirements-inventory.md
@@ -18,7 +18,7 @@ FR13: User can soft-delete an education record via `DELETE /api/v1/educations/{i
 FR14: User can create a cover letter template with `name` (unique per user) and `content` (50-10000 chars) via `POST /api/v1/cover-letter-templates`; returns `201 Created`.
 FR15: User can list their cover letter templates (paginated, searchable by `name`, ordered by `updatedAt desc`) via `GET /api/v1/cover-letter-templates`; returns `200 OK` with content preview (first 200 chars).
 FR16: User can retrieve a single cover letter template with full `content` via `GET /api/v1/cover-letter-templates/{id}`; returns `404` if not found.
-FR17: User can update a cover letter template's `name` or `content` via `PUT /api/v1/cover-letter-templates/{id}`; name uniqueness re-validated if changed; returns `200 OK`.
+FR17: User can update a cover letter template's `name` or `content` via `PATCH /api/v1/cover-letter-templates/{id}`; name uniqueness re-validated if changed; returns `200 OK`.
 FR18: User can soft-delete a cover letter template via `DELETE /api/v1/cover-letter-templates/{id}`; returns `204 No Content`.
 FR19: User can create a job-specific cover letter with `vacancyId` (required, must exist), `content` (50-10000 chars), and optional `templateId` via `POST /api/v1/cover-letters`; one letter per vacancy per user; returns `201 Created`.
 FR20: User can list their cover letters (paginated, ordered by `createdAt desc`) via `GET /api/v1/cover-letters`; includes `vacancyTitle` from linked vacancy; returns `200 OK`.

--- a/backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs
+++ b/backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs
@@ -120,4 +120,34 @@ public class CoverLetterTemplatesController : ControllerBase
         var result = await _mediator.Send(command, cancellationToken);
         return Created($"/api/v1/cover-letter-templates/{result.Id}", result);
     }
+
+    /// <summary>
+    /// Updates one or more fields on an existing cover letter template owned by the current authenticated user.
+    /// </summary>
+    /// <param name="id">The cover letter template identifier.</param>
+    /// <param name="command">Partial update payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated cover letter template.</returns>
+    [HttpPatch("{id:guid}")]
+    [ProducesResponseType(typeof(CoverLetterTemplateResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<CoverLetterTemplateResult>> UpdateAsync(
+        [FromRoute] Guid id,
+        UpdateCoverLetterTemplateCommand command,
+        CancellationToken cancellationToken)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        command.CoverLetterTemplateId = id;
+        command.UserId = userId;
+
+        var result = await _mediator.Send(command, cancellationToken);
+        return Ok(result);
+    }
 }

--- a/backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs
+++ b/backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs
@@ -81,7 +81,7 @@ public class CoverLetterTemplatesController : ControllerBase
     [ProducesResponseType(typeof(CoverLetterTemplateResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<CoverLetterTemplateResult>> GetByIdAsync(
+    public async Task<ActionResult<CoverLetterTemplateResult>> GetAsync(
         Guid id,
         CancellationToken cancellationToken)
     {

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/Mappers/CoverLetterTemplateMappers.cs
@@ -26,6 +26,27 @@ public static class CoverLetterTemplateMappers
     }
 
     /// <summary>
+    /// Applies non-null fields from an update command onto an existing template entity.
+    /// Null fields are left unchanged (partial update semantics).
+    /// </summary>
+    /// <param name="template">Target entity to update.</param>
+    /// <param name="command">Update payload.</param>
+    public static void ApplyUpdates(this CoverLetterTemplate template, UpdateCoverLetterTemplateCommand command)
+    {
+        if (template == null)
+            throw new ArgumentNullException(nameof(template));
+
+        if (command == null)
+            throw new ArgumentNullException(nameof(command));
+
+        if (command.Name != null)
+            template.Name = command.Name;
+
+        if (command.Content != null)
+            template.Content = command.Content;
+    }
+
+    /// <summary>
     /// Maps a domain entity to the API response DTO.
     /// </summary>
     /// <param name="template">Persisted cover letter template entity.</param>

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommand.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommand.cs
@@ -1,0 +1,32 @@
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.CoverLetterTemplates;
+
+/// <summary>
+/// Command for updating one or more fields on an existing cover letter template.
+/// </summary>
+public class UpdateCoverLetterTemplateCommand : IRequest<CoverLetterTemplateResult>
+{
+    /// <summary>
+    /// Cover letter template identifier from route.
+    /// </summary>
+    [JsonIgnore]
+    public Guid CoverLetterTemplateId { get; set; }
+
+    /// <summary>
+    /// Authenticated user identifier from security context.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Updated template name. Null means no change.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Updated template content. Null means no change.
+    /// </summary>
+    public string? Content { get; set; }
+}

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandler.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandler.cs
@@ -1,0 +1,40 @@
+using JobNecto.Application.CoverLetterTemplates.Mappers;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using MediatR;
+
+namespace JobNecto.Application.CoverLetterTemplates;
+
+/// <summary>
+/// Handles cover letter template update requests.
+/// </summary>
+public class UpdateCoverLetterTemplateCommandHandler : IRequestHandler<UpdateCoverLetterTemplateCommand, CoverLetterTemplateResult>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateCoverLetterTemplateCommandHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public UpdateCoverLetterTemplateCommandHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<CoverLetterTemplateResult> Handle(UpdateCoverLetterTemplateCommand request, CancellationToken cancellationToken)
+    {
+        var template = await _unitOfWork.CoverLetterTemplateRepository.GetByIdAsync(request.CoverLetterTemplateId, cancellationToken);
+
+        if (template.UserId != request.UserId)
+            throw new ForbiddenException("You do not have permission to update this cover letter template.");
+
+        template.ApplyUpdates(request);
+        template.UpdatedAt = DateTime.UtcNow;
+
+        await _unitOfWork.CoverLetterTemplateRepository.UpdateAsync(template, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return template.ToCoverLetterTemplateResult();
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/Validators/UpdateCoverLetterTemplateCommandValidator.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/Validators/UpdateCoverLetterTemplateCommandValidator.cs
@@ -29,8 +29,6 @@ public class UpdateCoverLetterTemplateCommandValidator : AbstractValidator<Updat
 
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("name must not be empty when provided.")
-            .Must(value => value == null || !string.IsNullOrWhiteSpace(value))
-            .WithMessage("name must not be empty when provided.")
             .MaximumLength(100).WithMessage("name must be at most 100 characters long.")
             .When(x => x.Name != null);
 

--- a/backend/src/JobNecto.Application/CoverLetterTemplates/Validators/UpdateCoverLetterTemplateCommandValidator.cs
+++ b/backend/src/JobNecto.Application/CoverLetterTemplates/Validators/UpdateCoverLetterTemplateCommandValidator.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+
+namespace JobNecto.Application.CoverLetterTemplates.Validators;
+
+/// <summary>
+/// Validator for <see cref="UpdateCoverLetterTemplateCommand"/>.
+/// </summary>
+public class UpdateCoverLetterTemplateCommandValidator : AbstractValidator<UpdateCoverLetterTemplateCommand>
+{
+    /// <summary>
+    /// Initializes validation rules for cover letter template update requests.
+    /// </summary>
+    public UpdateCoverLetterTemplateCommandValidator()
+    {
+        RuleFor(x => x.CoverLetterTemplateId)
+            .NotEmpty().WithMessage("coverLetterTemplateId is required.");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("userId is required.");
+
+        RuleFor(x => x)
+            .Custom((command, context) =>
+            {
+                if (command.Name == null && command.Content == null)
+                {
+                    context.AddFailure(nameof(UpdateCoverLetterTemplateCommand.Name), "At least one updatable field must be provided.");
+                }
+            });
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("name must not be empty when provided.")
+            .Must(value => value == null || !string.IsNullOrWhiteSpace(value))
+            .WithMessage("name must not be empty when provided.")
+            .MaximumLength(100).WithMessage("name must be at most 100 characters long.")
+            .When(x => x.Name != null);
+
+        RuleFor(x => x.Content)
+            .MinimumLength(50).WithMessage("content must be at least 50 characters long.")
+            .MaximumLength(10000).WithMessage("content must be at most 10000 characters long.")
+            .When(x => x.Content != null);
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs
@@ -61,6 +61,20 @@ public class CoverLetterTemplatesApiTests
         return await client.SendAsync(request);
     }
 
+    internal static async Task<HttpResponseMessage> PatchTemplateAsync(
+        HttpClient client,
+        string authCookie,
+        Guid id,
+        object payload)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Patch, $"/api/v1/cover-letter-templates/{id}")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(request);
+    }
+
     [Fact]
     public async Task Create_WithoutToken_Returns401()
     {
@@ -417,6 +431,171 @@ public class CoverLetterTemplatesApiTests
         var response = await GetTemplateByIdAsync(client, cookieB, created!.Id);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // --- PATCH /api/v1/cover-letter-templates/{id} ---
+
+    [Fact]
+    public async Task Patch_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.PatchAsJsonAsync(
+            $"/api/v1/cover-letter-templates/{Guid.NewGuid()}",
+            new { name = "Updated Name" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Patch_OwnedTemplate_NameOnly_Returns200AndPreservesContent()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var createResponse = await PostTemplateAsync(client, authCookie, new
+        {
+            name = "Original Name",
+            content = new string('a', 70),
+        });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+
+        var response = await PatchTemplateAsync(client, authCookie, created!.Id, new
+        {
+            name = "Updated Name",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Updated Name");
+        result.Content.Should().Be(new string('a', 70));
+        result.UpdatedAt.Should().BeAfter(created.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task Patch_OwnedTemplate_ContentOnly_Returns200AndPreservesName()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var createResponse = await PostTemplateAsync(client, authCookie, new
+        {
+            name = "Original Name",
+            content = new string('a', 70),
+        });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+        var updatedContent = new string('b', 80);
+
+        var response = await PatchTemplateAsync(client, authCookie, created!.Id, new
+        {
+            content = updatedContent,
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Original Name");
+        result.Content.Should().Be(updatedContent);
+        result.UpdatedAt.Should().BeAfter(created.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task Patch_AnotherUsersTemplate_Returns403()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var cookieA = await CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_a_"));
+        var cookieB = await CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_b_"));
+
+        var createResponse = await PostTemplateAsync(client, cookieA, new
+        {
+            name = "Owner Template",
+            content = ValidContent(),
+        });
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+
+        var response = await PatchTemplateAsync(client, cookieB, created!.Id, new
+        {
+            name = "Attack",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Patch_NonExistentId_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var response = await PatchTemplateAsync(client, authCookie, Guid.NewGuid(), new
+        {
+            name = "Updated",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Patch_InvalidContentBounds_Returns400WithFieldError()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var createResponse = await PostTemplateAsync(client, authCookie, new
+        {
+            name = "Template",
+            content = ValidContent(),
+        });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+
+        var response = await PatchTemplateAsync(client, authCookie, created!.Id, new
+        {
+            content = new string('x', 49),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Content");
+    }
+
+    [Fact]
+    public async Task Patch_EmptyBody_Returns400()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var authCookie = await CreateUserAndGetCookieHelperAsync(client);
+
+        var createResponse = await PostTemplateAsync(client, authCookie, new
+        {
+            name = "Template",
+            content = ValidContent(),
+        });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<CoverLetterTemplateResultDto>(JsonOptions);
+
+        var response = await PatchTemplateAsync(client, authCookie, created!.Id, new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]

--- a/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
@@ -42,6 +42,14 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
             Password = "Password123!",
         };
 
+    private static Guid ExtractIdFromLocation(HttpResponseMessage response)
+    {
+        response.Headers.Location.Should().NotBeNull();
+        var idSegment = response.Headers.Location!.ToString().Split('/').Last();
+        Guid.TryParse(idSegment, out var id).Should().BeTrue("Location header must end with a valid GUID");
+        return id;
+    }
+
     [Fact]
     public async Task Create_DuplicateName_SameUser_Returns409()
     {
@@ -115,6 +123,113 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
 
         results.Count(r => r.StatusCode == HttpStatusCode.Created).Should().Be(1);
         results.Count(r => r.StatusCode == HttpStatusCode.Conflict).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Patch_RenameToExistingName_SameUser_Returns409()
+    {
+        if (!await _factory!.TryInitializeSchemaAsync())
+        {
+            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+            return;
+        }
+
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_same_"));
+
+        var first = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new
+        {
+            name = "First Name",
+            content = ValidContent(),
+        });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new
+        {
+            name = "Second Name",
+            content = ValidContent(),
+        });
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+        var secondId = ExtractIdFromLocation(second);
+
+        var patch = await CoverLetterTemplatesApiTests.PatchTemplateAsync(client, authCookie, secondId, new
+        {
+            name = "First Name",
+        });
+
+        patch.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Patch_SameNameUsedByAnotherUser_DoesNotBlockUpdate_Returns200()
+    {
+        if (!await _factory!.TryInitializeSchemaAsync())
+        {
+            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+            return;
+        }
+
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var cookieA = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_a_"));
+        var cookieB = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_b_"));
+
+        var userATemplate = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, cookieA, new
+        {
+            name = "UserA Original",
+            content = ValidContent(),
+        });
+        userATemplate.StatusCode.Should().Be(HttpStatusCode.Created);
+        var userATemplateId = ExtractIdFromLocation(userATemplate);
+
+        var userBTemplate = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, cookieB, new
+        {
+            name = "Shared Across Users",
+            content = ValidContent(),
+        });
+        userBTemplate.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var patch = await CoverLetterTemplatesApiTests.PatchTemplateAsync(client, cookieA, userATemplateId, new
+        {
+            name = "Shared Across Users",
+        });
+
+        patch.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Patch_ConcurrentRenameCollision_OneSuccessAndAtLeastOneConflict()
+    {
+        if (!await _factory!.TryInitializeSchemaAsync())
+        {
+            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+            return;
+        }
+
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_race_"));
+
+        var first = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new
+        {
+            name = "Race One",
+            content = ValidContent(),
+        });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+        var firstId = ExtractIdFromLocation(first);
+
+        var second = await CoverLetterTemplatesApiTests.PostTemplateAsync(client, authCookie, new
+        {
+            name = "Race Two",
+            content = ValidContent(),
+        });
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+        var secondId = ExtractIdFromLocation(second);
+
+        var patch1 = CoverLetterTemplatesApiTests.PatchTemplateAsync(client, authCookie, firstId, new { name = "Collision Name" });
+        var patch2 = CoverLetterTemplatesApiTests.PatchTemplateAsync(client, authCookie, secondId, new { name = "Collision Name" });
+        var responses = await Task.WhenAll(patch1, patch2);
+
+        responses.Count(x => x.StatusCode == HttpStatusCode.OK).Should().Be(1);
+        responses.Count(x => x.StatusCode == HttpStatusCode.Conflict).Should().BeGreaterThanOrEqualTo(1);
     }
 }
 

--- a/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/GetCoverLetterTemplateQueryHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/GetCoverLetterTemplateQueryHandlerTests.cs
@@ -23,6 +23,7 @@ public class GetCoverLetterTemplateQueryHandlerTests
 
     private static CoverLetterTemplate MakeTemplate(Guid userId) => new()
     {
+        Id = Guid.NewGuid(),
         UserId = userId,
         Name = "My Template",
         Content = new string('a', 50),

--- a/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandlerTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetterTemplates;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.Entities;
+using Moq;
+
+namespace JobNecto.Tests.Application.CoverLetterTemplates;
+
+public class UpdateCoverLetterTemplateCommandHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<IMutableRepository<CoverLetterTemplate>> _repositoryMock;
+    private readonly UpdateCoverLetterTemplateCommandHandler _handler;
+
+    public UpdateCoverLetterTemplateCommandHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _repositoryMock = new Mock<IMutableRepository<CoverLetterTemplate>>();
+        _uowMock.Setup(x => x.CoverLetterTemplateRepository).Returns(_repositoryMock.Object);
+        _handler = new UpdateCoverLetterTemplateCommandHandler(_uowMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_OwnedTemplatePartialUpdate_ReturnsUpdatedResult()
+    {
+        var userId = Guid.NewGuid();
+        var template = new CoverLetterTemplate
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Name = "Original Name",
+            Content = new string('a', 50),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1),
+        };
+
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = template.Id,
+            UserId = userId,
+            Name = "Updated Name",
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(template.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(template);
+
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<CoverLetterTemplate>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CoverLetterTemplate entity, CancellationToken _) => entity);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Id.Should().Be(template.Id);
+        result.UserId.Should().Be(userId);
+        result.Name.Should().Be("Updated Name");
+        result.Content.Should().Be(new string('a', 50));
+
+        _repositoryMock.Verify(x => x.UpdateAsync(template, It.IsAny<CancellationToken>()), Times.Once);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UpdatedAt_IsRefreshedWithUtcNow()
+    {
+        var userId = Guid.NewGuid();
+        var previousUpdatedAt = DateTime.UtcNow.AddMinutes(-5);
+
+        var template = new CoverLetterTemplate
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Name = "Template",
+            Content = new string('b', 50),
+            UpdatedAt = previousUpdatedAt,
+        };
+
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = template.Id,
+            UserId = userId,
+            Content = new string('c', 60),
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(template.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(template);
+
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<CoverLetterTemplate>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CoverLetterTemplate entity, CancellationToken _) => entity);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        template.UpdatedAt.Should().BeAfter(previousUpdatedAt);
+        template.UpdatedAt.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task Handle_CrossUserUpdate_ThrowsForbiddenException()
+    {
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+
+        var template = new CoverLetterTemplate
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            Name = "Owner Template",
+            Content = new string('d', 50),
+        };
+
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = template.Id,
+            UserId = attackerId,
+            Name = "Malicious Update",
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(template.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(template);
+
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<CoverLetterTemplate>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_PropagatesNotFoundException()
+    {
+        var templateId = Guid.NewGuid();
+
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = templateId,
+            UserId = Guid.NewGuid(),
+            Name = "Updated",
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(templateId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("CoverLetterTemplate", templateId));
+
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandValidatorTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetterTemplates;
+using JobNecto.Application.CoverLetterTemplates.Validators;
+
+namespace JobNecto.Tests.Application.CoverLetterTemplates;
+
+public class UpdateCoverLetterTemplateCommandValidatorTests
+{
+    private readonly UpdateCoverLetterTemplateCommandValidator _validator = new();
+
+    private static string ValidContent() => new string('a', 50);
+
+    [Fact]
+    public void Validate_NoUpdatableFieldsProvided_Fails()
+    {
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_ValidNameOnly_Passes()
+    {
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Name = "Updated Name",
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ValidContentOnly_Passes()
+    {
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = ValidContent(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("   ")]
+    [InlineData("")]
+    public void Validate_WhitespaceOrEmptyName_Fails(string name)
+    {
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Name = name,
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(UpdateCoverLetterTemplateCommand.Name));
+    }
+
+    [Fact]
+    public void Validate_TooLongName_Fails()
+    {
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Name = new string('x', 101),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(UpdateCoverLetterTemplateCommand.Name));
+    }
+
+    [Theory]
+    [InlineData(49)]
+    [InlineData(10001)]
+    public void Validate_ContentOutOfBounds_Fails(int length)
+    {
+        var command = new UpdateCoverLetterTemplateCommand
+        {
+            CoverLetterTemplateId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = new string('a', length),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == nameof(UpdateCoverLetterTemplateCommand.Content));
+    }
+}


### PR DESCRIPTION
## Summary
- implement Story 3.4 update flow for cover letter templates via `PATCH /api/v1/cover-letter-templates/{id}`
- add `UpdateCoverLetterTemplateCommand`, validator, handler, and mapper partial-update support (`name` and/or `content`)
- enforce ownership semantics (`403` for cross-user mutation), not-found propagation (`404`), and DB-backed uniqueness conflict handling (`409`)
- extend API tests for PATCH success/error scenarios and PostgreSQL uniqueness collision cases
- add Story 3.4 implementation artifact and update planning/sprint docs (FR17 + epic endpoint method updated to PATCH, sprint status moved to review)

## Validation
- `dotnet test backend/JobNecto.slnx --filter "FullyQualifiedName~CoverLetterTemplates"`
- `dotnet test backend/JobNecto.slnx`
- `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`
- `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror`

## Notes
- branch: `feat/story-3-4-cover-letter-template-patch`
- commit: `e076a9d`