### PR TITLE
docs: run post-merge workflow for Story 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ curl -i http://localhost:5000/
   - Returns a cursor-paginated list of cover letter templates for the authenticated user (`pageSize`, `lastSeenId`, `lastSeenUpdatedAt`). Supports optional case-insensitive name search via `?search=`. Each item includes a `contentPreview` (first 200 characters) instead of full content. Soft-deleted templates are excluded.
 - `GET /api/v1/cover-letter-templates/{id}`
   - Returns full detail for an owned template, including full `content`; returns `404 Not Found` for missing, soft-deleted, or cross-user templates.
+- `PATCH /api/v1/cover-letter-templates/{id}`
+  - Updates template `name` and/or `content` for an owned template; returns `200 OK`, `400` for invalid payloads, `403` for cross-user access, `404` for missing or soft-deleted records, and `409` for per-user name uniqueness conflicts.
 
 ### CORS
 

--- a/_bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md
+++ b/_bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md
@@ -1,6 +1,6 @@
 # Story 3.4: Update Cover Letter Template
 
-Status: review
+Status: done
 
 ## Story
 
@@ -202,7 +202,7 @@ so that I can refine my reusable material over time.
 ## Story Completion Status
 
 - Story context drafted and validated against current architecture and test patterns.
-- Sprint status updated to `review`.
+- Sprint status updated to `done`.
 - Completion note: comprehensive developer guide prepared for direct `dev-story` execution.
 
 ## Dev Agent Record

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-05-10T00:30:00Z
+# last_updated: 2026-05-09T22:42:46Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -65,7 +65,7 @@ development_status:
   3-1-create-cover-letter-template: done
   3-2-list-cover-letter-templates: done
   3-3-get-cover-letter-template-detail: done
-  3-4-update-cover-letter-template: review
+  3-4-update-cover-letter-template: done
   3-5-delete-cover-letter-template: backlog
   epic-3-retrospective: optional
 

--- a/_bmad-output/planning-artifacts/architecture/index.md
+++ b/_bmad-output/planning-artifacts/architecture/index.md
@@ -4,7 +4,7 @@
 
 The architecture document is organized into the following shards:
 
-1. **[Post-Merge Implementation Status (2026-04-30)](post-merge-implementation-status-2026-04-30.md)** - Current state of Phase B implementation; which stories are merged and what infrastructure is in place
+1. **[Post-Merge Implementation Status (2026-05-10)](post-merge-implementation-status-2026-04-30.md)** - Current state of Phase B implementation; which stories are merged and what infrastructure is in place
 2. **[Epic 2 Architecture Revision (2026-05-05)](epic-2-architecture-revision-2026-05-05.md)** - Audit of architecture docs after Epic 2; confirms implemented baseline, stale assumptions, and Epic 3 guardrails
 3. **[Project Context Analysis](project-context-analysis.md)** - Requirements overview, technical constraints, and cross-cutting concerns (ownership, soft deletes, validation, filtering, async, migrations, OpenAPI)
 4. **[Core Architectural Decisions](core-architectural-decisions.md)** - Detailed architectural decisions: MediatR request/handler structure, validation strategy, repository pattern, error handling, soft deletes, ownership model, concurrency control

--- a/_bmad-output/planning-artifacts/architecture/post-merge-implementation-status-2026-04-30.md
+++ b/_bmad-output/planning-artifacts/architecture/post-merge-implementation-status-2026-04-30.md
@@ -1,12 +1,13 @@
-# Post-Merge Implementation Status (2026-05-05)
+# Post-Merge Implementation Status (2026-05-10)
 
-- Stories `1-5-password-hashing-token-policy-hardening`, `2-1-create-resume`, `2-2-list-resumes`, `2-3-get-resume-detail`, `2-4-update-resume`, `2-5-delete-resume`, `2-6-create-education-record`, `2-7-list-education-records`, and `2-8-get-update-delete-education-records` are merged and active on `master`.
+- Stories `1-5-password-hashing-token-policy-hardening`, `2-1-create-resume`, `2-2-list-resumes`, `2-3-get-resume-detail`, `2-4-update-resume`, `2-5-delete-resume`, `2-6-create-education-record`, `2-7-list-education-records`, `2-8-get-update-delete-education-records`, `3-1-create-cover-letter-template`, `3-2-list-cover-letter-templates`, `3-3-get-cover-letter-template-detail`, and `3-4-update-cover-letter-template` are merged and active on `master`.
 - `Program.cs` now wires infrastructure (`AddInfrastructure`), JWT authentication, CORS, and global exception handling in the HTTP pipeline.
 - Security baseline is implemented with `IPasswordHasher` (`Pbkdf2PasswordHasher`) and authenticated token refresh (`POST /api/v1/users/token/refresh`).
 - The application now has complete resume and education vertical slices: `POST`, `GET` list, `GET {id}`, `PATCH {id}`, and `DELETE {id}` endpoints for `/api/v1/resumes` and `/api/v1/educations`, with MediatR command/query handling, FluentValidation, ownership checks, soft-delete behavior, and mapper-based DTO-to-entity conversion.
+- Cover letter template vertical slices now include `POST`, `GET` list, `GET {id}`, and `PATCH {id}` on `/api/v1/cover-letter-templates`; `DELETE` remains backlog for Story 3.5.
 - Token transport policy is explicit: browser flows rely on HTTP-only secure cookies; bearer clients can consume body tokens from refresh responses.
 - Architecture decisions around conflict handling are enforced in production code (`DbUpdateException` unique-constraint mapping to HTTP 409) and concurrency integration tests.
 - DB Command Timing: Added `DbCommandTimingInterceptor` to JobNecto.Infrastructure to monitor and log slow database queries (merged in story 2-4).
-- Epic 2 retrospective is complete and identifies the architecture as stable, with follow-up decisions needed for ownership-aware single-record reads, timestamp/clock policy, validator edge-case policy, and database-backed uniqueness for Epic 3 cover letter templates.
+- Epic 2 retrospective is complete and identifies the architecture as stable, with follow-up decisions needed for ownership-aware single-record reads and timestamp/clock policy. Epic 3 now enforces database-backed template-name uniqueness with concurrent collision coverage in tests.
 - Current verification caveat: the Epic 2 retrospective recorded local `dotnet test backend/JobNecto.slnx` and Release build attempts failing without useful diagnostics. Treat implementation logs as positive evidence, but diagnose local solution-runner behavior before relying on a fresh green gate.
 

--- a/_bmad-output/planning-artifacts/architecture/project-context-analysis.md
+++ b/_bmad-output/planning-artifacts/architecture/project-context-analysis.md
@@ -5,7 +5,7 @@
 **Functional Requirements (Phase B):**
 
 - 6 primary domain resources: User (Profile), Resume, Education, CoverLetterTemplate, CoverLetter, Vacancy
-- Epic 2 delivered complete Resume and Education CRUD endpoints. Epic 3 delivered CoverLetterTemplate create/list/detail endpoints; CoverLetterTemplate update/delete plus CoverLetter and Vacancy endpoint work remains scheduled for later epics.
+- Epic 2 delivered complete Resume and Education CRUD endpoints. Epic 3 delivered CoverLetterTemplate create/list/detail/update endpoints; CoverLetterTemplate delete plus CoverLetter and Vacancy endpoint work remains scheduled for later epics.
 - `GET /api/v1/users/me` returns only core user profile fields; related resources are fetched via dedicated resource routes
 - CRUD operations on user-owned resources (User, Resume, Education, Template, Letter)
 - Read-only operations on shared resources (Vacancy browsing and filtering)

--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -56,10 +56,10 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - **`Program.cs`** wires **`AddInfrastructure()`** and **`AddJwtAuthentication()`** in the API host. For tests, DB wiring/connection scope can be overridden by the test host.
 - When adding Redis/Quartz behavior, align with packages already referenced — avoid duplicate client/scheduler abstractions unless introducing a deliberate replacement.
 
-### Current implementation snapshot (2026-05-09)
+### Current implementation snapshot (2026-05-10)
 
-- Merged stories: `1-1` (global exception handling), `1-2` (create user account), `1-3` (retrieve current user profile), `1-4` (update user profile), `1-5` (password hashing + token policy hardening), `2-1` (create resume), `2-2` (list resumes), `2-3` (get resume detail), `2-4` (update resume), `2-5` (delete resume), `2-6` (create education record), `2-7` (list education records), `2-8` (get, update, and delete education records), `r-1` (separate soft-delete repository contract), `3-1` (create cover letter template), `3-2` (list cover letter templates), `3-3` (get cover letter template detail).
-- Active HTTP endpoints: `POST /api/v1/users`, `POST /api/v1/users/token/refresh`, `GET /api/v1/users/me`, `PATCH /api/v1/users/me`, `POST|PATCH|DELETE /api/v1/users/me/avatar`, `POST /api/v1/resumes`, `GET /api/v1/resumes`, `GET /api/v1/resumes/{id}`, `PATCH /api/v1/resumes/{id}`, `DELETE /api/v1/resumes/{id}`, `POST /api/v1/educations`, `GET /api/v1/educations`, `GET /api/v1/educations/{id}`, `PATCH /api/v1/educations/{id}`, `DELETE /api/v1/educations/{id}`, `POST /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates/{id}`.
+- Merged stories: `1-1` (global exception handling), `1-2` (create user account), `1-3` (retrieve current user profile), `1-4` (update user profile), `1-5` (password hashing + token policy hardening), `2-1` (create resume), `2-2` (list resumes), `2-3` (get resume detail), `2-4` (update resume), `2-5` (delete resume), `2-6` (create education record), `2-7` (list education records), `2-8` (get, update, and delete education records), `r-1` (separate soft-delete repository contract), `3-1` (create cover letter template), `3-2` (list cover letter templates), `3-3` (get cover letter template detail), `3-4` (update cover letter template).
+- Active HTTP endpoints: `POST /api/v1/users`, `POST /api/v1/users/token/refresh`, `GET /api/v1/users/me`, `PATCH /api/v1/users/me`, `POST|PATCH|DELETE /api/v1/users/me/avatar`, `POST /api/v1/resumes`, `GET /api/v1/resumes`, `GET /api/v1/resumes/{id}`, `PATCH /api/v1/resumes/{id}`, `DELETE /api/v1/resumes/{id}`, `POST /api/v1/educations`, `GET /api/v1/educations`, `GET /api/v1/educations/{id}`, `PATCH /api/v1/educations/{id}`, `DELETE /api/v1/educations/{id}`, `POST /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates/{id}`, `PATCH /api/v1/cover-letter-templates/{id}`.
 - Password storage uses PBKDF2 (`Pbkdf2PasswordHasher`) behind `IPasswordHasher`.
 - Auth transport policy: browser flows rely on HTTP-only cookie transport; bearer clients can use response-body token on refresh.
 - Education records support degree types: `bachelor`, `master`, `phd`, `postdoc`, `other`.
@@ -110,6 +110,6 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - Keep this file **lean** and agent-focused; prefer **`AGENTS.md`** for long-form contributor docs if content overlaps.
 - Refresh when **TargetFramework**, CI, or layer boundaries change; remove rules that become universally obvious.
 
-_Last updated: 2026-05-09_
+_Last updated: 2026-05-10_
 
 ---

--- a/docs/JOBNECTO_BACKEND_ROADMAP.md
+++ b/docs/JOBNECTO_BACKEND_ROADMAP.md
@@ -9,10 +9,10 @@
 - **Filter and paginate** vacancies (`VacancyFilter`, `PagedQuery`, `PagedResult`); support **matching** via `Vacancy.MatchScore` (and optional future persisted analysis if the team adds it).
 - **LLM** integration via `JobNecto.Infrastructure.LLM`, `LlmProvider` enum, and `LlmProviderConfig`.
 
-## Implementation snapshot (2026-05-09)
+## Implementation snapshot (2026-05-10)
 
-- Stories `1-1` (global exception handling), `1-2` (create user account), `1-3` (retrieve current user profile), `1-4` (update user profile + avatar management), `1-5` (password hashing and token policy hardening), `2-1` (create resume), `2-2` (list resumes), `2-3` (get resume detail), `2-4` (update resume), `2-5` (soft-delete resume), `2-6` (create education record), `2-7` (list education records), `2-8` (get/update/delete education records), `r-1` (separate soft-delete repository contract), `3-1` (create cover letter template), `3-2` (list cover letter templates), and `3-3` (get cover letter template detail) are merged to `master`.
-- Authentication baseline is live: `POST /api/v1/users` creates users; `POST /api/v1/users/token/refresh` renews JWTs; `GET /api/v1/users/me` returns the core profile (id, loginName, email, phone, location, about, avatar, timestamps). Story 1.4 adds `PATCH /api/v1/users/me` for partial profile updates and avatar endpoints (`POST|PUT|DELETE /api/v1/users/me/avatar`). Resume create/list/detail/update/delete and education create/list/detail/update/delete endpoints are merged. Epic 3 currently includes cover letter template create/list/detail (`POST /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates/{id}`) with per-user ownership and soft-delete semantics.
+- Stories `1-1` (global exception handling), `1-2` (create user account), `1-3` (retrieve current user profile), `1-4` (update user profile + avatar management), `1-5` (password hashing and token policy hardening), `2-1` (create resume), `2-2` (list resumes), `2-3` (get resume detail), `2-4` (update resume), `2-5` (soft-delete resume), `2-6` (create education record), `2-7` (list education records), `2-8` (get/update/delete education records), `r-1` (separate soft-delete repository contract), `3-1` (create cover letter template), `3-2` (list cover letter templates), `3-3` (get cover letter template detail), and `3-4` (update cover letter template) are merged to `master`.
+- Authentication baseline is live: `POST /api/v1/users` creates users; `POST /api/v1/users/token/refresh` renews JWTs; `GET /api/v1/users/me` returns the core profile (id, loginName, email, phone, location, about, avatar, timestamps). Story 1.4 adds `PATCH /api/v1/users/me` for partial profile updates and avatar endpoints (`POST|PUT|DELETE /api/v1/users/me/avatar`). Resume create/list/detail/update/delete and education create/list/detail/update/delete endpoints are merged. Epic 3 currently includes cover letter template create/list/detail/update (`POST /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates`, `GET /api/v1/cover-letter-templates/{id}`, `PATCH /api/v1/cover-letter-templates/{id}`) with per-user ownership and soft-delete semantics.
 - Password persistence uses PBKDF2 (`pbkdf2-sha256`) via `IPasswordHasher` and `Pbkdf2PasswordHasher`, with test coverage for malformed hash formats.
 - CI and PR review automation are active on merge and PR events (`CI` + `PR review (LLM via OpenRouter)`).
 - Repository layer supports UserId-scoped filtering and cursor-based pagination (BaseRepository); ownership filtering is enforced for all user-scoped resources.
@@ -102,6 +102,7 @@ Use a **version prefix** (e.g. `/api/v1/...`) and add auth where noted below.
 | POST | `/api/v1/cover-letter-templates` | Create a cover letter template for the authenticated user (name unique per user, content 50–10,000 chars); returns `201 Created` with `Location` header. |
 | GET | `/api/v1/cover-letter-templates` | Return a cursor-paginated template library for the authenticated user; supports case-insensitive `search` and returns `contentPreview` only. |
 | GET | `/api/v1/cover-letter-templates/{id}` | Return full detail for an owned template, including `content`; return `404` for missing, soft-deleted, or cross-user records. |
+| PATCH | `/api/v1/cover-letter-templates/{id}` | Update name/content on an owned template; return `403` for cross-user access, `404` for missing/soft-deleted records, and `409` for uniqueness conflicts. |
 
 ## Tech stack
 
@@ -135,7 +136,7 @@ Use a **version prefix** (e.g. `/api/v1/...`) and add auth where noted below.
 6. [done] API versioning and first endpoints (controllers under `/api/v1`).
 7. [done] **Users** CRUD with validation (create endpoint implemented; profile update and avatar management implemented in Story 1.4).
 8. [backlog] **Vacancies** list + CRUD.
-9. [in-progress] **Resumes**, **educations**, **cover letters** CRUD and relationships via user-scoped routes only (no cross-user list endpoints). Resume and education CRUD are merged; cover letter template create/list/detail are merged; template update/delete and cover letter CRUD remain in backlog.
+9. [in-progress] **Resumes**, **educations**, **cover letters** CRUD and relationships via user-scoped routes only (no cross-user list endpoints). Resume and education CRUD are merged; cover letter template create/list/detail/update are merged; template delete and cover letter CRUD remain in backlog.
 
 ### Phase C — Security
 
@@ -157,4 +158,4 @@ Use a **version prefix** (e.g. `/api/v1/...`) and add auth where noted below.
 ## Tracking
 
 Work is broken into small GitHub issues **#16–#37** (foundation through hardening).
-Stories **1-4 update user profile and avatar management**, **2-1 create resume**, **2-2 list resumes**, **2-4 update resume**, and **2-8 get/update/delete education records** merged on **2026-04-25**, **2026-04-27**, **2026-04-28**, **2026-04-30**, and **2026-05-05** respectively.
+Stories **1-4 update user profile and avatar management**, **2-1 create resume**, **2-2 list resumes**, **2-4 update resume**, **2-8 get/update/delete education records**, and **3-4 update cover letter template** merged on **2026-04-25**, **2026-04-27**, **2026-04-28**, **2026-04-30**, **2026-05-05**, and **2026-05-09** respectively.


### PR DESCRIPTION
## Summary
- execute mandatory post-merge documentation workflow after PR #72 merge
- mark Story 3.4 as `done` in sprint tracking and implementation artifact status
- update roadmap/project context/README to include merged Story 3.4 and `PATCH /api/v1/cover-letter-templates/{id}` in implemented API snapshots
- refresh architecture status shards to reflect current Epic 3 implementation state (create/list/detail/update merged, delete pending)

## Updated files
- `docs/JOBNECTO_BACKEND_ROADMAP.md`
- `README.md`
- `_bmad-output/implementation-artifacts/sprint-status.yaml`
- `_bmad-output/implementation-artifacts/3-4-update-cover-letter-template.md`
- `_bmad-output/project-context.md`
- `_bmad-output/planning-artifacts/architecture/index.md`
- `_bmad-output/planning-artifacts/architecture/project-context-analysis.md`
- `_bmad-output/planning-artifacts/architecture/post-merge-implementation-status-2026-04-30.md`

## Notes
- Epic 3 remains `in-progress` because Story 3.5 is still `backlog`.
- Existing untracked draft file `_bmad-output/implementation-artifacts/3-5-delete-cover-letter-template.md` was intentionally not included.