### PR TITLE
feat(vacancies): Story 4.1 — Browse & filter vacancies with cursor pagination

### DIFF
--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,36 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-05-10 - Return structured ProblemDetails for all 400 responses, never plain strings
+
+**Trigger:** PR review comment (LLM reviewer, second pass)
+**Context:** Story 4.1 `VacanciesController` returned `BadRequest("plain string")` for cursor validation. Existing `UsersController` already uses `BadRequest(new ProblemDetails { Status, Title, Detail })`.
+**Wrong action:** I introduced a plain-string `BadRequest` without checking the project-wide error-shape convention first.
+**Root cause:** I focused on the validation logic itself and did not cross-check the response format against existing controllers before writing the return statement.
+**Correct behavior:** Before writing any `BadRequest` (or other error return) in a controller, check at least one existing controller for the established error-shape. In this project: `BadRequest(new ProblemDetails { Status = 400, Title = "Validation failed", Detail = "..." })`.
+**Pattern / trigger:** Any new controller action that returns a 4xx response — check the project's existing error shape first.
+**Generalize?** Yes
+
+### 2026-05-10 - Validate all free-form string inputs that map to a fixed set of values
+
+**Trigger:** PR review comment (LLM reviewer, second pass)
+**Context:** Story 4.1 `SortBy` is a free-form string in `FilterVacanciesQuery`. The repository's `NormalizeSortBy` silently coerces unknown values to `createdAt`. Clients sending typos get 200 OK with the wrong ordering and no feedback.
+**Wrong action:** I treated the silent-fallback in `NormalizeSortBy` as a design choice and did not add allowlist validation in the controller.
+**Root cause:** I conflated "the code works" with "the contract is correct". The repository-level normalization is a robustness measure, not a substitute for input validation at the API boundary.
+**Correct behavior:** Any string field that maps to a fixed set of values (sort modes, filter types, etc.) must be validated at the controller/handler boundary with an explicit allowlist and a 400 response for unknown values.
+**Pattern / trigger:** Request DTO has a `string? SortBy` (or equivalent) field; check for allowlist validation before accepting.
+**Generalize?** Yes
+
+### 2026-05-10 - After every fix cycle, immediately update agent-learnings.md
+
+**Trigger:** User correction (repeated, twice in same session)
+**Context:** After both fix rounds in story 4.1, I failed to update agent-learnings until explicitly asked.
+**Wrong action:** I treated the fix as complete once code and tests passed, skipping the mandatory self-improvement log update.
+**Root cause:** I do not treat agent-learnings as part of the definition of done for a fix cycle. I optimize for the visible output (green tests, pushed commit) and treat documentation as optional.
+**Correct behavior:** At the end of every session where I made a mistake that was caught by a reviewer or user, append an entry to `_bmad-output/agent-learnings.md` and commit it before closing the task — without being asked.
+**Pattern / trigger:** Any session where a code review, PR comment, or user correction caused me to change code. Update learnings as the final step.
+**Generalize?** Yes
+
 ### 2026-05-10 - Check JSON serialization config when reviewing request DTO field types
 
 **Trigger:** PR review comment (Copilot reviewer)

--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,16 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-05-10 - Honor single-route API strategy across all planning artifacts
+
+**Trigger:** User correction
+**Context:** Epic 4 planning/story artifacts for vacancy browsing and filtering routes.
+**Wrong action:** I created planning/story context with a separate simple browse route (`GET /api/v1/vacancies`) instead of using the single filter route strategy.
+**Root cause:** I over-followed the previous epic wording and did not validate that the latest user route decision should replace the split-route structure before generating artifacts.
+**Correct behavior:** When the user clarifies endpoint strategy, update all connected source-of-truth artifacts in one pass (epic story, generated story file, requirements mapping, and sprint plan) to the same contract.
+**Pattern / trigger:** User explicitly states one endpoint should serve both browse and filtered behavior (empty criteria = browse mode).
+**Generalize?** Yes
+
 ### 2026-05-10 - Align endpoint method with latest user contract
 
 **Trigger:** User correction

--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,26 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-05-10 - Check JSON serialization config when reviewing request DTO field types
+
+**Trigger:** PR review comment (Copilot reviewer)
+**Context:** Story 4.1 `FilterVacanciesQuery` used typed enum arrays (`Location[]`, `WorkTimeType[]`, `WorkLocationType[]`, `Currency[]`) in the request body. Without `JsonStringEnumConverter` registered globally, clients must send integer values instead of string names — an unusable API contract.
+**Wrong action:** I read the DTO fields, saw typed enum arrays, and accepted them at face value without checking whether the serializer was configured to handle string enum names.
+**Root cause:** I did not trace the full client-to-handler path: HTTP body → JSON deserialization → DTO field type → serializer config. I reviewed the domain logic but skipped the deserialization layer.
+**Correct behavior:** When reviewing or writing request DTOs with enum-typed fields, always check `Program.cs` / `AddControllers` options for `JsonStringEnumConverter`. If it is absent, either add it globally or use `string` fields with manual `Enum.TryParse` (consistent with the rest of the codebase).
+**Pattern / trigger:** Request DTO contains `SomeEnum[]` or `SomeEnum?` fields in an ASP.NET Core project; check serializer config before accepting the design.
+**Generalize?** Yes
+
+### 2026-05-10 - Validate partial-cursor states, not just missing-cursor states
+
+**Trigger:** PR review comment (Copilot reviewer and LLM reviewer)
+**Context:** Story 4.1 cursor pagination required both `lastSeenId` and `lastSeenUpdatedAt`. Sending only one field silently skipped the cursor entirely and re-returned the first page — a potential infinite loop for clients.
+**Wrong action:** I reviewed the cursor logic and correctly identified the sort-mode-change risk (finding #1), but I only considered "cursor present" vs "cursor absent". I never considered the degenerate case where exactly one cursor field is supplied.
+**Root cause:** I stayed within the happy path and the one-field-missing-but-other-present case did not surface as a distinct state to test.
+**Correct behavior:** For any pagination contract that requires a pair of cursor fields, explicitly validate the XOR state (exactly one provided) and return 400. Add tests for both asymmetric directions.
+**Pattern / trigger:** Cursor pagination with two correlated fields (`lastSeenId` + `lastSeenTimestamp`); always add XOR validation and tests.
+**Generalize?** Yes
+
 ### 2026-05-10 - Honor single-route API strategy across all planning artifacts
 
 **Trigger:** User correction

--- a/_bmad-output/implementation-artifacts/4-1-browse-vacancies-paginated-list.md
+++ b/_bmad-output/implementation-artifacts/4-1-browse-vacancies-paginated-list.md
@@ -1,0 +1,187 @@
+# Story 4.1: Browse Vacancies (Empty Filter Mode)
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a job seeker,
+I want to browse all available vacancies using the filter route with empty criteria,
+so that I can scan what is available without defining filters.
+
+## Acceptance Criteria
+
+1. Given a valid JWT token, when `POST /api/v1/vacancies/filter` is called with empty body `{}`, then `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`, returning only vacancies owned by the authenticated user, ordered by `createdAt desc` by default, `pageSize` defaulting to 20, and each item includes `id`, `title`, `company`, `workLocationType`, `location`, `salary`, `currency`, `createdAt`.
+2. Given `pageSize`, `lastSeenId`, `lastSeenUpdatedAt`, and optional `sortBy` are provided in the request body while filter criteria are empty, when the request is processed, then the correct cursor window is returned and `pageSize` is capped at 100.
+3. Given `sortBy` is `updatedAt` or `relevance`, when the request is processed, then ordering is `updatedAt desc` with deterministic tie-break by `id desc`.
+4. Given no vacancies exist in DB, when `POST /api/v1/vacancies/filter` is called with empty body `{}`, then `200 OK` with `{ totalCount: 0, hasNext: false, items: [] }`.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add unified vacancy filter query contract and browse response DTOs (AC: 1, 2, 3)
+  - [ ] Create `backend/src/JobNecto.Application/Vacancies/FilterVacanciesQuery.cs` implementing `IRequest<PagedResult<VacancyListItemResult>>`.
+  - [ ] Include pagination fields: `PageSize` (default 20), `LastSeenId`, `LastSeenUpdatedAt`.
+  - [ ] Include optional `SortBy` field (`createdAt` default, `updatedAt`, `relevance`).
+  - [ ] Include optional filter criteria fields (all nullable/optional) so empty body maps to browse mode.
+  - [ ] Add list DTO `VacancyListItemResult` containing at minimum: `Id`, `Title`, `Company`, `WorkLocationType`, `Location`, salary representation, `Currency`, `CreatedAt`.
+
+- [ ] Task 2: Add mapper and handler for empty-filter browse behavior (AC: 1, 2, 3)
+  - [ ] Create `backend/src/JobNecto.Application/Vacancies/Mappers/VacancyMappers.cs` for `Vacancy` -> `VacancyListItemResult`.
+  - [ ] Create `backend/src/JobNecto.Application/Vacancies/FilterVacanciesQueryHandler.cs`.
+  - [ ] In handler, cap page size with `request.PageSize < 1 ? 20 : Math.Min(request.PageSize, 100)`.
+  - [ ] Build `PagedQuery` and a nullable `VacancyFilter`; when criteria are empty, pass `null` to repository.
+  - [ ] Call `_unitOfWork.VacancyRepository.GetFilteredAsync(pagedQuery, filter, cancellationToken)`.
+  - [ ] Map to `PagedResult<VacancyListItemResult>` and preserve metadata (`TotalCount`, `HasNext`, `LastSeenId`, `LastSeenUpdatedAt`, `PageSize`).
+
+- [ ] Task 3: Add the single vacancy list/filter API route (AC: 1, 2, 3)
+  - [ ] Create `backend/src/JobNecto.API/Controllers/VacanciesController.cs` with `[ApiController]`, `[Route("api/v1/vacancies")]`, `[Authorize]`.
+  - [ ] Add `[HttpPost("filter")]` action accepting `FilterVacanciesQuery` body.
+  - [ ] Normalize `LastSeenUpdatedAt` using the same UTC normalization pattern used in existing list endpoints.
+  - [ ] Dispatch `FilterVacanciesQuery` through MediatR and return `Ok(result)`.
+  - [ ] Add response metadata attributes for `200`, `400`, and `401`.
+
+- [ ] Task 4: Align vacancy repository ordering with Story 4.1 browse contract (AC: 1, 2, 3)
+  - [ ] Support selectable sort mode in `backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs`: `createdAt desc` (default), `updatedAt desc` for `sortBy=updatedAt|relevance`, deterministic tiebreak by `Id desc`.
+  - [ ] Update cursor comparison logic to use timestamp that matches selected sorting mode.
+  - [ ] Ensure query remains scoped to authenticated user (`pagedQuery.UserId`).
+  - [ ] Keep `GetFilteredAsync` signature and filter logic reusable for Story 4.2 advanced criteria.
+
+- [ ] Task 5: Add tests for browse mode via filter route (AC: 1, 2, 3)
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/Vacancies/FilterVacanciesQueryHandlerTests.cs`.
+  - [ ] Add handler tests for default page size, page-size cap, cursor forwarding, and metadata preservation when criteria are empty.
+  - [ ] Create `backend/tests/JobNecto.Tests/API/Vacancies/VacanciesApiTests.cs`.
+  - [ ] Add API tests:
+    - [ ] `POST /api/v1/vacancies/filter` without token -> `401`.
+    - [ ] empty body `{}` with empty DB -> `200` with empty `items`, `totalCount = 0`, `hasNext = false`.
+    - [ ] empty body `{}` with seeded vacancies -> `200` with expected item shape and `createdAt desc` ordering for current user only.
+    - [ ] `sortBy = updatedAt` -> `200` with `updatedAt desc` ordering.
+    - [ ] `sortBy = relevance` -> `200` with `updatedAt desc` ordering (alias behavior).
+    - [ ] `pageSize` cap behavior when body sets value > 100.
+    - [ ] cursor paging with empty criteria returns next deterministic slice.
+  - [ ] Update `backend/tests/JobNecto.Tests/Infrastructure/VacancyRepositoryTests.cs` to cover both default `createdAt desc` ordering and `sortBy=updatedAt` mode.
+
+- [ ] Task 6: Verification gates
+  - [ ] Run targeted tests: `dotnet test backend/JobNecto.slnx --filter "FullyQualifiedName~Vacanc"`.
+  - [ ] Run full test suite: `dotnet test backend/JobNecto.slnx`.
+  - [ ] Run CI parity build: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`.
+  - [ ] Run CI parity tests: `dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror`.
+
+## Dev Notes
+
+### Vacancy Baseline (Already Implemented)
+
+- `IVacancyRepository` already exists with `GetFilteredAsync(PagedQuery, VacancyFilter?, CancellationToken)` and `UpdateMatchScoreAsync(...)`.
+- `VacancyRepository.GetFilteredAsync` already supports pagination + optional filter application.
+- `VacancyRepository` currently orders by `UpdatedAt desc`, then `Id desc`, then `MatchScore` tiebreak. Story 4.1 requires `createdAt desc` ordering for browse mode.
+- Global soft-delete filter for `Vacancy` is active in `AppDbContext` (`HasQueryFilter(v => !v.IsDeleted)`).
+- No API/application vacancy browse/filter endpoint exists yet (no `VacanciesController`, no vacancy query handler/DTO in Application layer).
+
+### Architectural Guardrails
+
+- Keep Clean Architecture boundaries:
+  - API layer: HTTP contract, auth, parameter normalization, MediatR dispatch.
+  - Application layer: query/handler and DTO mapping.
+  - Infrastructure layer: repository query behavior.
+- Use MediatR query pattern consistent with `ListResumesQuery` / `ListEducationsQuery` / `ListCoverLetterTemplatesQuery`.
+- Preserve existing `PagedResult<T>` response contract used across list endpoints.
+- Follow async + cancellation token propagation across controller -> mediator -> handler -> repository.
+
+### Critical Behavior Decisions for This Story
+
+- Story AC and FR24 require default ordering by `createdAt desc`, with optional `sortBy=updatedAt|relevance` for updated-time relevance view.
+- Cursor field name remains `lastSeenUpdatedAt` for compatibility, but the timestamp it carries depends on selected sort mode.
+- Keep cursor contract field names unchanged (`lastSeenUpdatedAt`) for API consistency across project, but ensure paging logic remains deterministic after ordering change.
+- Do not add a separate `GET /api/v1/vacancies` list route. Browse mode must use `POST /api/v1/vacancies/filter` with empty criteria.
+- Story 4.2 extends the same route by supplying non-empty filter criteria.
+
+### Existing Files To Read Before Implementation
+
+- `backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs`
+- `backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs`
+- `backend/src/JobNecto.Domain/Entities/Vacancy.cs`
+- `backend/src/JobNecto.Domain/ValueObjects/Pagination.cs`
+- `backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs`
+- `backend/src/JobNecto.API/Controllers/ResumesController.cs`
+- `backend/src/JobNecto.API/Controllers/EducationsController.cs`
+- `backend/src/JobNecto.Application/Resumes/ListResumesQuery.cs`
+- `backend/src/JobNecto.Application/Resumes/ListResumesHandler.cs`
+- `backend/src/JobNecto.Application/CoverLetterTemplates/ListCoverLetterTemplatesQueryHandler.cs`
+- `backend/tests/JobNecto.Tests/Infrastructure/VacancyRepositoryTests.cs`
+- `backend/tests/JobNecto.Tests/Infrastructure/VacancyTestData.cs`
+
+### Testing Notes
+
+- Existing `VacancyRepositoryTests` already exercise pagination/filter behavior and should be extended/updated instead of duplicated.
+- `VacancyTestData` provides seeded realistic fixtures and should be reused for both repository and API integration tests.
+- Keep response metadata assertions aligned with existing list endpoint tests in resume/education/template test suites.
+
+### Project Structure Notes
+
+- New Application files should live under `backend/src/JobNecto.Application/Vacancies/` and `.../Vacancies/Mappers/`.
+- New API controller should live under `backend/src/JobNecto.API/Controllers/`.
+- New tests should follow established split:
+  - Application tests: `backend/tests/JobNecto.Tests/Application/Vacancies/`
+  - API tests: `backend/tests/JobNecto.Tests/API/Vacancies/`
+  - Infrastructure tests: update existing `backend/tests/JobNecto.Tests/Infrastructure/VacancyRepositoryTests.cs`
+- Namespace must match folder structure exactly.
+
+### Git Intelligence Summary
+
+Recent merged work confirms this workflow sequence:
+
+1. Implement story slice in API/Application/Infrastructure.
+2. Add targeted tests + full suite verification.
+3. Sync implementation artifacts and sprint status docs.
+
+Most recent commits:
+
+- `ce7a3c4` docs(epic-3): finalize retrospective and close epic tracking
+- `c0fa357` docs(post-merge): sync story 3.5 workflow docs
+- `c51a8e3` story 3.5 implementation merge
+
+### Latest Technical Information
+
+- Current project stack is pinned around .NET 10 + EF Core 10 + MediatR 14 + FluentValidation 12.
+- No dependency upgrade is required for Story 4.1.
+- Use existing project patterns and avoid adding new infrastructure libraries for this story.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-4-vacancy-browsing-filtering.md` - Story 4.1]
+- [Source: `_bmad-output/planning-artifacts/epics/requirements-inventory.md` - FR24, NFR10]
+- [Source: `_bmad-output/planning-artifacts/architecture/index.md`]
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md`]
+- [Source: `_bmad-output/planning-artifacts/architecture/project-context-analysis.md`]
+- [Source: `backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs`]
+- [Source: `backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs`]
+- [Source: `backend/src/JobNecto.Infrastructure/Persistance/AppDbContext.cs`]
+- [Source: `backend/tests/JobNecto.Tests/Infrastructure/VacancyRepositoryTests.cs`]
+- [Source: `backend/tests/JobNecto.Tests/Infrastructure/VacancyTestData.cs`]
+- [Source: `backend/src/JobNecto.API/Controllers/ResumesController.cs`]
+- [Source: `backend/src/JobNecto.API/Controllers/EducationsController.cs`]
+
+## Story Completion Status
+
+- Ultimate context engine analysis completed - comprehensive developer guide created.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.3-Codex
+
+### Debug Log References
+
+- Story key selected from sprint status first backlog item: `4-1-browse-vacancies-paginated-list`.
+- Epic transition required: `epic-4` backlog -> in-progress.
+
+### Completion Notes List
+
+- Story context prepared with implementation guardrails, file-level targets, and explicit testing gates.
+- Repository ordering mismatch (`updatedAt` vs required `createdAt`) identified and converted into a concrete implementation task.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/4-1-browse-vacancies-paginated-list.md` (this file)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (status update required by create-story workflow)

--- a/_bmad-output/implementation-artifacts/epic-4-sprint-plan-2026-05-10.md
+++ b/_bmad-output/implementation-artifacts/epic-4-sprint-plan-2026-05-10.md
@@ -1,0 +1,56 @@
+---
+epic: 4
+date: 2026-05-10
+author: Amelia (Developer)
+participants:
+  - Amelia (Developer)
+  - Timmy (Project Lead)
+summary: Sprint plan and implementation-time requirements for Epic 4 stories
+---
+
+# Epic 4 Sprint Plan: Vacancy Browsing & Filtering
+
+Amelia (Developer): "This plan sequences Epic 4 implementation and sets explicit time requirements for each story."
+
+## Planning Assumptions
+
+- Estimates include implementation, tests, CI-parity verification, and one review/fix pass.
+- Estimates assume one experienced backend developer with existing project context.
+- Estimates exclude external blockers (new infra setup, third-party API downtime, or product-scope changes).
+- Productive engineering capacity assumed at ~6 focused implementation hours/day.
+
+## Story-by-Story Time Requirements
+
+| Story | Scope Focus | Base Effort (hours) | Risk Buffer (hours) | Time Requirement (hours) | Time Requirement (dev days) |
+| --- | --- | --- | --- | --- | --- |
+| 4.1 Browse Vacancies (Empty Filter Mode) | `POST /api/v1/vacancies/filter` with empty criteria, cursor pagination, list DTO mapping, auth, user-scoped results, optional `sortBy` (`createdAt` default, `updatedAt`, `relevance`) and endpoint tests | 12 | 3 | **15** | **2.5** |
+| 4.2 Filter Vacancies | same `POST /api/v1/vacancies/filter` route with non-empty criteria, AND/OR filter logic, exclusion keywords, validation matrix, broad integration tests | 20 | 4 | **24** | **4.0** |
+| 4.3 Get Vacancy Detail | `GET /api/v1/vacancies/{id}`, detail DTO shape, not-found path, auth + ownership policy, endpoint tests | 9 | 2 | **11** | **1.8** |
+
+## Epic 4 Total Estimate
+
+- Total base effort: **41 hours**
+- Total risk buffer: **9 hours**
+- Total implementation-time requirement: **50 hours**
+- Single-developer duration at planned capacity: **~8.3 dev days**
+
+Amelia (Developer): "Epic 4 is best planned as roughly two development weeks when including verification and review cycles."
+
+## Recommended Execution Sequence
+
+1. Implement Story 4.1 first (establishes the unified filter route in empty-criteria browse mode and pagination contracts).
+2. Implement Story 4.2 second (extends the same route with advanced filter behavior).
+3. Implement Story 4.3 third (stable once vacancy query/retrieval patterns are finalized).
+4. Reserve final hardening pass for regression checks across 4.1 + 4.2 + 4.3.
+
+## Risk Notes
+
+- Story 4.2 is the schedule driver due to filter-composition complexity and validation edge cases.
+- If filter semantics expand during implementation, add +4 to +8 hours to Story 4.2.
+- If new performance constraints are introduced (index tuning, query-plan optimization), add +4 to +6 hours across Epic 4.
+
+## Delivery Checkpoints
+
+- Checkpoint A (after 4.1): unified filter route returns browse-mode pagination correctly with empty criteria, user-scoped rows, and `sortBy` behavior.
+- Checkpoint B (after 4.2): advanced filter matrix and exclusion behavior verified under integration tests.
+- Checkpoint C (after 4.3): detail endpoint done, full Epic 4 API regression suite green.

--- a/_bmad-output/implementation-artifacts/epic-5-sprint-plan-2026-05-10.md
+++ b/_bmad-output/implementation-artifacts/epic-5-sprint-plan-2026-05-10.md
@@ -1,0 +1,68 @@
+---
+epic: 5
+date: 2026-05-10
+author: Amelia (Developer)
+participants:
+  - Amelia (Developer)
+  - Timmy (Project Lead)
+summary: Sprint plan and implementation-time requirements for Epic 5 stories
+---
+
+# Epic 5 Sprint Plan: Cover Letter Application Management
+
+Amelia (Developer): "This plan sequences Epic 5 implementation and sets explicit time requirements for each story."
+
+## Planning Assumptions
+
+- Estimates include implementation, tests, CI-parity verification, and one review/fix pass.
+- Estimates assume one experienced backend developer with existing project context.
+- Estimates exclude external blockers (Epic 4 merge delays, product-scope changes).
+- Productive engineering capacity assumed at ~6 focused implementation hours/day.
+- Vacation entity already exists (`JobNecto.Domain.Entities.Vacancy`) — no FK blocker for 5.1.
+
+## Dependency Notes
+
+- **Epic 4 must be merged before Epic 5 begins** — Story 5.1 FK to `Vacancy` and the vacancy ID validation (`404` path) require Epic 4's `POST /api/v1/vacancies/filter` route and its integration tests to be stable. Epic 5 branch should be rebased onto `master` after Epic 4 merges.
+- The `CoverLetterTemplate` entity from Epic 3 is already merged — optional template FK in 5.1 is unblocked.
+- The shared exception pipeline (Epic 1, story 1.1) is already wired — `409 Conflict` mapping from DB uniqueness violation can reuse the existing pattern.
+
+## Story-by-Story Time Requirements
+
+| Story | Scope Focus | Base Effort (hours) | Risk Buffer (hours) | Time Requirement (hours) | Time Requirement (dev days) |
+| --- | --- | --- | --- | --- | --- |
+| 5.1 Create Cover Letter | `POST /api/v1/cover-letters`: new `CoverLetter` entity + EF migration, FK to `Vacancy` (exists check → 404) + optional FK to `CoverLetterTemplate` (ownership check → 404), DB-level unique constraint `(UserId, VacancyId)` for non-deleted records mapped to 409, content 50–10,000 char validation, `Location` header in 201, concurrent-create integration test coverage | 15 | 4 | **19** | **3.2** |
+| 5.2 List Cover Letters | `GET /api/v1/cover-letters`: cursor pagination reusing existing pattern, JOIN to `Vacancy` for `vacancyTitle` in list items, `createdAt desc` ordering, empty-state path, handler + query tests | 9 | 2 | **11** | **1.8** |
+| 5.3 Get Cover Letter Detail | `GET /api/v1/cover-letters/{id}`: full field set including nullable `templateId`, nested `vacancy` object (key fields), ownership + soft-delete guard (404), integration tests | 7 | 2 | **9** | **1.5** |
+| 5.4 Update Cover Letter Content | `PATCH /api/v1/cover-letters/{id}`: content update, silent ignore of any `vacancyId` in body (immutable), content validation, `updatedAt` refresh, 403 wrong user, 404 not found/deleted, integration tests | 7 | 2 | **9** | **1.5** |
+| 5.5 Delete Cover Letter | `DELETE /api/v1/cover-letters/{id}`: soft-delete, 204, 403 wrong user, 404 not found/deleted, verify cover letter still accessible after linked vacancy is deleted (vacancyId preserved), integration tests | 6 | 1 | **7** | **1.2** |
+
+## Epic 5 Total Estimate
+
+- Total base effort: **44 hours**
+- Total risk buffer: **11 hours**
+- Total implementation-time requirement: **55 hours**
+- Single-developer duration at planned capacity: **~9.2 dev days**
+
+Amelia (Developer): "Epic 5 spans approximately two development weeks including verification and review cycles."
+
+## Recommended Execution Sequence
+
+1. Implement Story 5.1 first — establishes the `CoverLetter` entity, EF migration, uniqueness constraint, and FK validation patterns that all subsequent stories build on.
+2. Implement Story 5.2 second — cursor pagination is proven from prior epics; the new complexity is the JOIN for `vacancyTitle`.
+3. Implement Story 5.3 third — detail endpoint with nested vacancy object; stable once entity structure is confirmed in 5.1.
+4. Implement Story 5.4 fourth — update pattern is well-established; primary attention is the immutable `vacancyId` and 403/404 split.
+5. Implement Story 5.5 last — soft-delete pattern is identical to prior epics; add cascade-behavior test for vacancy deletion.
+6. Reserve final hardening pass for regression across all five stories plus Epic 5 API regression suite.
+
+## Risk Notes
+
+- **Story 5.1 is the schedule driver.** Uniqueness-constraint race coverage adds test complexity beyond the standard CRUD pattern. If the DB-level constraint mapping requires changes to the exception pipeline, add +2 to +4 hours.
+- **Vacancy ownership ambiguity in 5.1.** The AC only checks existence (`404` if vacancy not found) — it does not require the vacancy to be owned by the requesting user. Verify during Story 5.1 implementation; if ownership must be enforced, add +2 hours.
+- **Story 5.2 JOIN query.** If the vacancy is soft-deleted after the cover letter is created, `vacancyTitle` resolution must still work (or degrade gracefully). Clarify during 5.2; may add +1 to +2 hours.
+- **PATCH vs PATCH method choice in 5.4.** Epic 5 specifies `PATCH` for update (unlike Epic 3's `PATCH`). Verify this is intentional before implementing — if changed to `PATCH`, update the epic and requirements inventory in the same pass (see agent-learnings entry 2026-05-10).
+
+## Delivery Checkpoints
+
+- **Checkpoint A (after 5.1):** Cover letter creation returns `201` with correct `Location` header; uniqueness constraint returns `409`; concurrent-create test is green.
+- **Checkpoint B (after 5.3):** Read paths (list + detail) return correct shapes including nested vacancy data; all 404 ownership paths verified.
+- **Checkpoint C (after 5.5):** Full CRUD + soft-delete lifecycle verified; Epic 5 API regression suite green; ready for retrospective.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-05-10T09:09:28Z
+# last_updated: 2026-05-10T09:16:25Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -70,8 +70,8 @@ development_status:
   epic-3-retrospective: done
 
   # --- Epic 4: Vacancy Browsing & Filtering ---
-  epic-4: backlog
-  4-1-browse-vacancies-paginated-list: backlog
+  epic-4: in-progress
+  4-1-browse-vacancies-paginated-list: ready-for-dev
   4-2-filter-vacancies: backlog
   4-3-get-vacancy-detail: backlog
   epic-4-retrospective: optional

--- a/_bmad-output/planning-artifacts/epics/epic-4-vacancy-browsing-filtering.md
+++ b/_bmad-output/planning-artifacts/epics/epic-4-vacancy-browsing-filtering.md
@@ -1,26 +1,36 @@
 # Epic 4: Vacancy Browsing & Filtering
 
-Users can discover and filter job vacancies using keyword and multi-criteria search, with full pagination support.
+Users can discover and filter job vacancies through a single filter endpoint, with full pagination support.
 
-### Story 4.1: Browse Vacancies (Paginated List)
+## Route Strategy
+
+- Epic 4 uses one list route only: `POST /api/v1/vacancies/filter`.
+- Browse mode is achieved by sending empty criteria (empty body `{}` or no filter fields).
+- Optional sort mode is provided via `sortBy`: `createdAt` (default), `updatedAt`, or `relevance` (alias of `updatedAt`).
+
+### Story 4.1: Browse Vacancies (Empty Filter Mode)
 
 As a **job seeker**,
-I want to browse all available vacancies in a paginated list,
-So that I can scan what's available without filtering.
+I want to browse all available vacancies using the filter endpoint with empty criteria,
+So that I can scan what's available without defining filters.
 
 **Acceptance Criteria:**
 
 **Given** a valid JWT token
-**When** `GET /api/v1/vacancies` is called with no params
-**Then** `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`, ordered by `createdAt desc`, `pageSize` defaulting to 20
+**When** `POST /api/v1/vacancies/filter` is called with empty body `{}`
+**Then** `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`, returning only vacancies owned by the authenticated user, ordered by `createdAt desc` by default, `pageSize` defaulting to 20
 **And** each item includes: `id`, `title`, `company`, `workLocationType`, `location`, `salary`, `currency`, `createdAt`
 
-**Given** `pageSize`, `lastSeenId`, and `lastSeenUpdatedAt` cursor params are provided
+**Given** `pageSize`, `lastSeenId`, `lastSeenUpdatedAt`, and optional `sortBy` are provided in the request body while filter criteria are empty
 **When** the request is processed
 **Then** correct cursor window is returned; `pageSize` capped at 100
 
+**Given** `sortBy` is set to `updatedAt` or `relevance`
+**When** `POST /api/v1/vacancies/filter` is called
+**Then** results are ordered by `updatedAt desc`, with deterministic tie-break by `id desc`
+
 **Given** no vacancies exist in the DB
-**When** `GET /api/v1/vacancies` is called
+**When** `POST /api/v1/vacancies/filter` is called with empty body `{}`
 **Then** `200 OK` with `{ totalCount: 0, hasNext: false, items: [] }`
 
 ---
@@ -38,9 +48,9 @@ So that I can find the roles that best match my profile.
 **Then** `200 OK` with vacancies matching ALL specified filters (AND logic between fields)
 **And** within array fields (`skills`, `workLocationTypes`, `categories`), any match is sufficient (OR logic)
 
-**Given** an empty filter body `{}`
+**Given** one or more filter fields are provided
 **When** `POST /api/v1/vacancies/filter` is called
-**Then** same result as paginated list (all vacancies)
+**Then** only the matching subset is returned while preserving the same pagination envelope and selected sort mode as Story 4.1
 
 **Given** `salaryMin` > `salaryMax` is provided
 **When** the request is processed
@@ -48,7 +58,7 @@ So that I can find the roles that best match my profile.
 
 **Given** `pageSize` exceeds 100
 **When** the request is processed
-**Then** it is capped at 100 (or `400 Bad Request` per implementation choice — must be consistent)
+**Then** it is capped at 100 (or `400 Bad Request` per implementation choice - must be consistent)
 
 **Given** `excludeKeywords` contains terms
 **When** the request is processed
@@ -73,4 +83,4 @@ So that I can decide whether to apply.
 **Then** `404 Not Found`
 
 ---
-
+<!-- EOF -->

--- a/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
+++ b/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
@@ -90,11 +90,11 @@ So that I can refine my application before submitting.
 
 **Acceptance Criteria:**
 
-**Given** a valid JWT token and `PUT /api/v1/cover-letters/{id}` with new `content`
+**Given** a valid JWT token and `PATCH /api/v1/cover-letters/{id}` with new `content`
 **When** the request is processed
 **Then** `200 OK` with updated cover letter; `updatedAt` refreshed
 
-**Given** `vacancyId` is included in the PUT body
+**Given** `vacancyId` is included in the PATCH body
 **When** the request is processed
 **Then** it is silently ignored — `vacancyId` is immutable after creation
 

--- a/_bmad-output/planning-artifacts/epics/requirements-inventory.md
+++ b/_bmad-output/planning-artifacts/epics/requirements-inventory.md
@@ -23,10 +23,10 @@ FR18: User can soft-delete a cover letter template via `DELETE /api/v1/cover-let
 FR19: User can create a job-specific cover letter with `vacancyId` (required, must exist), `content` (50-10000 chars), and optional `templateId` via `POST /api/v1/cover-letters`; one letter per vacancy per user; returns `201 Created`.
 FR20: User can list their cover letters (paginated, ordered by `createdAt desc`) via `GET /api/v1/cover-letters`; includes `vacancyTitle` from linked vacancy; returns `200 OK`.
 FR21: User can retrieve a single cover letter with full `content`, `vacancyId`, `templateId`, and linked vacancy details via `GET /api/v1/cover-letters/{id}`; returns `404` if not found.
-FR22: User can update cover letter `content` (cannot change `vacancyId` after creation) via `PUT /api/v1/cover-letters/{id}`; returns `200 OK`.
+FR22: User can update cover letter `content` (cannot change `vacancyId` after creation) via `PATCH /api/v1/cover-letters/{id}`; returns `200 OK`.
 FR23: User can soft-delete a cover letter via `DELETE /api/v1/cover-letters/{id}`; returns `204 No Content`.
-FR24: Any user can browse a paginated list of vacancies (default 20, max 100, ordered by `createdAt desc`) via `GET /api/v1/vacancies`; returns `200 OK` with `{ total, page, pageSize, items }`.
-FR25: Any user can filter vacancies by multi-criteria (`skills`, `location`, `salaryMin`, `salaryMax`, `workLocationTypes`, `categories`, `experienceLevel`, `excludeKeywords`, `page`, `pageSize`) via `POST /api/v1/vacancies/filter`; AND logic between fields, OR within arrays; returns `200 OK`.
+FR24: Authenticated user can browse their own paginated vacancies (default 20, max 100) via `POST /api/v1/vacancies/filter` using empty criteria (`{}`); default ordering is `createdAt desc`, optional `sortBy` supports `updatedAt` and `relevance` (alias of `updatedAt`); returns `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`.
+FR25: Authenticated user can filter their own vacancies by multi-criteria (`skills`, `location`, `salaryMin`, `salaryMax`, `workLocationTypes`, `categories`, `experienceLevel`, `excludeKeywords`, `lastSeenId`, `lastSeenUpdatedAt`, `pageSize`, `sortBy`) via `POST /api/v1/vacancies/filter`; AND logic between fields, OR within arrays; returns `200 OK` with the same pagination envelope as browse mode.
 FR26: Any user can retrieve a single vacancy with all fields (title, description, company, skills, workLocationType, matchScore, jobSource, etc.) via `GET /api/v1/vacancies/{id}`; returns `404` if not found.
 FR27: All user-owned list endpoints must automatically filter by `userId` at the repository/handler level to enforce data isolation.
 FR28: All mutation handlers must verify resource ownership before allowing changes; return `403 Forbidden` or throw ownership exception if violated.
@@ -42,7 +42,7 @@ NFR6: Build must pass: `dotnet build backend/JobNecto.slnx --configuration Relea
 NFR7: All tests must pass: `dotnet test backend/JobNecto.slnx --configuration Release --warnaserror`.
 NFR8: No nullable reference type warnings suppressed without documented justification.
 NFR9: OpenAPI spec auto-generated for all Phase B endpoints with request/response schemas, status codes (200, 201, 204, 400, 404, 409, 422, 500), and example bodies.
-NFR10: Pagination: cursor-based (`lastSeenId` + `lastSeenUpdatedAt`); `pageSize` min 1, max 100, default 20. Response shape: `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`. Request body max 1MB.
+NFR10: Pagination: cursor-based (`lastSeenId` + `lastSeenUpdatedAt`); `pageSize` min 1, max 100, default 20. For vacancies, `lastSeenUpdatedAt` carries cursor timestamp for the selected sort mode (`createdAt` by default, `updatedAt` for `sortBy=updatedAt|relevance`). Response shape: `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`. Request body max 1MB.
 NFR11: Zero breaking changes to Domain model entities after Phase B is complete.
 NFR12: Passwords must be stored only as one-way salted hashes; plaintext passwords are never persisted or returned, and any migration/backfill required to reach that state is part of auth readiness.
 NFR13: Any business rule surfaced as `409 Conflict` must be backed by a database-level uniqueness constraint and at least one integration test that exercises concurrent create/update attempts.

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -611,6 +611,7 @@ A job seeker can:
 - Accept POST request with filter object in body (not query params)
 - Filter criteria: `skills` (array, match any), `location` (string, partial match), `salaryMin` (number), `salaryMax` (number), `workLocationTypes` (array: remote/office/hybrid), `categories` (array), `experienceLevel` (enum), `excludeKeywords` (array)
 - Pagination: `pageSize`, `lastSeenId`, `lastSeenUpdatedAt` (cursor) in filter body
+- Sorting: optional `sortBy` supports `createdAt` (default), `updatedAt`, and `relevance` (alias of `updatedAt`)
 - Return results matching ALL provided criteria (AND logic between fields; OR logic within arrays)
 - Return `200 OK` with same shape as List endpoint: `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`
 - Return `400 Bad Request` if filter is malformed
@@ -626,6 +627,7 @@ A job seeker can:
   "categories": [],
   "experienceLevel": "mid",
   "excludeKeywords": [],
+  "sortBy": "createdAt",
   "pageSize": 20,
   "lastSeenId": null,
   "lastSeenUpdatedAt": null

--- a/backend/src/JobNecto.API/Controllers/VacanciesController.cs
+++ b/backend/src/JobNecto.API/Controllers/VacanciesController.cs
@@ -49,7 +49,21 @@ public class VacanciesController : ControllerBase
         query.UserId = userId;
 
         if (query.LastSeenId.HasValue ^ query.LastSeenUpdatedAt.HasValue)
-            return BadRequest("lastSeenId and lastSeenUpdatedAt must be provided together.");
+            return BadRequest(new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "Validation failed",
+                Detail = "lastSeenId and lastSeenUpdatedAt must be provided together.",
+            });
+
+        var allowedSortBy = new[] { "createdAt", "updatedAt", "relevance" };
+        if (!string.IsNullOrWhiteSpace(query.SortBy) && !allowedSortBy.Contains(query.SortBy, StringComparer.OrdinalIgnoreCase))
+            return BadRequest(new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "Validation failed",
+                Detail = $"sortBy must be one of: {string.Join(", ", allowedSortBy)}.",
+            });
 
         if (query.LastSeenUpdatedAt.HasValue)
         {

--- a/backend/src/JobNecto.API/Controllers/VacanciesController.cs
+++ b/backend/src/JobNecto.API/Controllers/VacanciesController.cs
@@ -48,6 +48,9 @@ public class VacanciesController : ControllerBase
         query ??= new FilterVacanciesQuery();
         query.UserId = userId;
 
+        if (query.LastSeenId.HasValue ^ query.LastSeenUpdatedAt.HasValue)
+            return BadRequest("lastSeenId and lastSeenUpdatedAt must be provided together.");
+
         if (query.LastSeenUpdatedAt.HasValue)
         {
             query.LastSeenUpdatedAt = query.LastSeenUpdatedAt.Value.Kind == DateTimeKind.Unspecified

--- a/backend/src/JobNecto.API/Controllers/VacanciesController.cs
+++ b/backend/src/JobNecto.API/Controllers/VacanciesController.cs
@@ -1,0 +1,61 @@
+using JobNecto.API.Infrastructure;
+using JobNecto.Application.Vacancies;
+using JobNecto.Domain.ValueObjects;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JobNecto.API.Controllers;
+
+/// <summary>
+/// Controller for vacancy browse and filter endpoints.
+/// </summary>
+[ApiController]
+[Route("api/v1/vacancies")]
+[Authorize]
+public class VacanciesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VacanciesController"/> class.
+    /// </summary>
+    /// <param name="mediator">MediatR dispatcher.</param>
+    public VacanciesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Returns a cursor-paginated vacancy list. Empty criteria represents browse mode.
+    /// </summary>
+    /// <param name="query">Vacancy filter payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Paginated vacancy list in the shared envelope format.</returns>
+    [HttpPost("filter")]
+    [ProducesResponseType(typeof(PagedResult<VacancyListItemResult>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<PagedResult<VacancyListItemResult>>> FilterAsync(
+        [FromBody] FilterVacanciesQuery? query,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        query ??= new FilterVacanciesQuery();
+        query.UserId = userId;
+
+        if (query.LastSeenUpdatedAt.HasValue)
+        {
+            query.LastSeenUpdatedAt = query.LastSeenUpdatedAt.Value.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(query.LastSeenUpdatedAt.Value, DateTimeKind.Utc)
+                : query.LastSeenUpdatedAt.Value.ToUniversalTime();
+        }
+
+        var result = await _mediator.Send(query, cancellationToken);
+        return Ok(result);
+    }
+}

--- a/backend/src/JobNecto.API/Program.cs
+++ b/backend/src/JobNecto.API/Program.cs
@@ -2,6 +2,7 @@ using JobNecto.API.Infrastructure;
 using JobNecto.API.Infrastructure.Cors;
 using JobNecto.API.Infrastructure.ExceptionHandling;
 using JobNecto.Application;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,8 @@ builder.Services.AddApiOpenApi();
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddJwtAuthentication(builder.Configuration);
 builder.Services.AddApplication();
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 builder.Services.AddCorsPolicies(builder.Configuration);
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();

--- a/backend/src/JobNecto.Application/Vacancies/FilterVacanciesQuery.cs
+++ b/backend/src/JobNecto.Application/Vacancies/FilterVacanciesQuery.cs
@@ -1,0 +1,87 @@
+using JobNecto.Domain.Enums;
+using JobNecto.Domain.ValueObjects;
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.Vacancies;
+
+/// <summary>
+/// Query to browse or filter vacancies through a single cursor-paginated endpoint.
+/// Empty criteria means browse mode.
+/// </summary>
+public class FilterVacanciesQuery : IRequest<PagedResult<VacancyListItemResult>>
+{
+    /// <summary>
+    /// ID of the authenticated user making the request.
+    /// Set by the API controller from the security context.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Number of items per page. Defaults to 20, capped at 100.
+    /// </summary>
+    public int PageSize { get; set; } = 20;
+
+    /// <summary>
+    /// Optional sorting mode.
+    /// Supported values: <c>createdAt</c> (default), <c>updatedAt</c>, and <c>relevance</c> (alias of <c>updatedAt</c>).
+    /// </summary>
+    public string? SortBy { get; set; }
+
+    /// <summary>
+    /// Cursor: ID of the last seen vacancy from the previous page.
+    /// </summary>
+    public Guid? LastSeenId { get; set; }
+
+    /// <summary>
+    /// Cursor timestamp paired with <see cref="LastSeenId"/>.
+    /// Holds <c>CreatedAt</c> when <see cref="SortBy"/> is <c>createdAt</c> (default), or <c>UpdatedAt</c>
+    /// when <see cref="SortBy"/> is <c>updatedAt</c>/<c>relevance</c>.
+    /// Must be reset to null when <see cref="SortBy"/> changes between requests; mixing cursor values
+    /// from a different sort mode produces undefined pagination results.
+    /// </summary>
+    public DateTime? LastSeenUpdatedAt { get; set; }
+
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public string? Company { get; set; }
+    public Location[]? Location { get; set; }
+    public WorkTimeType[]? WorkTimeType { get; set; }
+    public WorkLocationType[]? WorkLocationType { get; set; }
+    public string[]? JobCategories { get; set; }
+    public string[]? Skills { get; set; }
+    public decimal? SalaryMin { get; set; }
+    public decimal? SalaryMax { get; set; }
+    public Currency[]? Currency { get; set; }
+    public double? MatchScore { get; set; }
+    public string[]? ExperienceLevel { get; set; }
+    public string[]? JobSource { get; set; }
+    public DateTime? CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public bool? IsChosen { get; set; }
+}
+
+/// <summary>
+/// Vacancy list item DTO for browse/filter responses.
+/// </summary>
+public class VacancyListItemResult
+{
+    public Guid Id { get; set; }
+    public string? Title { get; set; }
+    public string? Company { get; set; }
+    public string? WorkLocationType { get; set; }
+    public string? Location { get; set; }
+    public VacancySalaryResult? Salary { get; set; }
+    public string? Currency { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+/// <summary>
+/// Salary representation in vacancy list results.
+/// </summary>
+public class VacancySalaryResult
+{
+    public decimal? Min { get; set; }
+    public decimal? Max { get; set; }
+}

--- a/backend/src/JobNecto.Application/Vacancies/FilterVacanciesQueryHandler.cs
+++ b/backend/src/JobNecto.Application/Vacancies/FilterVacanciesQueryHandler.cs
@@ -1,0 +1,113 @@
+using JobNecto.Application.Interfaces;
+using JobNecto.Application.Vacancies.Mappers;
+using JobNecto.Domain.ValueObjects;
+using MediatR;
+
+namespace JobNecto.Application.Vacancies;
+
+/// <summary>
+/// Handles vacancy browse/filter queries through a single endpoint contract.
+/// </summary>
+public class FilterVacanciesQueryHandler
+    : IRequestHandler<FilterVacanciesQuery, PagedResult<VacancyListItemResult>>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FilterVacanciesQueryHandler"/>.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work that provides vacancy repository access.</param>
+    public FilterVacanciesQueryHandler(IUnitOfWork unitOfWork) => _unitOfWork = unitOfWork;
+
+    /// <summary>
+    /// Executes vacancy browse/filter query with cursor pagination.
+    /// </summary>
+    /// <param name="request">The filter query payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Paginated list of vacancy items matching the optional criteria.</returns>
+    public async Task<PagedResult<VacancyListItemResult>> Handle(
+        FilterVacanciesQuery request,
+        CancellationToken cancellationToken
+    )
+    {
+        var cappedPageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, 100);
+
+        var pagedQuery = new PagedQuery
+        {
+            UserId = request.UserId,
+            PageSize = cappedPageSize,
+            SortBy = request.SortBy,
+            LastSeenId = request.LastSeenId,
+            LastSeenUpdatedAt = request.LastSeenUpdatedAt,
+        };
+
+        var filter = BuildFilterOrNull(request);
+
+        var result = await _unitOfWork.VacancyRepository.GetFilteredAsync(
+            pagedQuery,
+            filter,
+            cancellationToken
+        );
+
+        var projectedItems = result.Items.Select(v => v.ToVacancyListItemResult()).ToList();
+
+        return new PagedResult<VacancyListItemResult>(
+            projectedItems,
+            result.TotalCount,
+            result.LastSeenId,
+            result.LastSeenUpdatedAt,
+            result.PageSize,
+            result.HasNext
+        );
+    }
+
+    private static VacancyFilter? BuildFilterOrNull(FilterVacanciesQuery request)
+    {
+        var filter = new VacancyFilter
+        {
+            Title = NormalizeText(request.Title),
+            Description = NormalizeText(request.Description),
+            Company = NormalizeText(request.Company),
+            Location = NormalizeArray(request.Location),
+            WorkTimeType = NormalizeArray(request.WorkTimeType),
+            WorkLocationType = NormalizeArray(request.WorkLocationType),
+            JobCategories = NormalizeArray(request.JobCategories),
+            Skills = NormalizeArray(request.Skills),
+            SalaryMin = request.SalaryMin,
+            SalaryMax = request.SalaryMax,
+            Currency = NormalizeArray(request.Currency),
+            MatchScore = request.MatchScore,
+            ExperienceLevel = NormalizeArray(request.ExperienceLevel),
+            JobSource = NormalizeArray(request.JobSource),
+            CreatedAt = request.CreatedAt,
+            UpdatedAt = request.UpdatedAt,
+            IsChosen = request.IsChosen,
+        };
+
+        return HasAnyFilterCriteria(filter) ? filter : null;
+    }
+
+    private static string? NormalizeText(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static T[]? NormalizeArray<T>(T[]? values) => values is { Length: > 0 } ? values : null;
+
+    private static bool HasAnyFilterCriteria(VacancyFilter filter) =>
+        filter.Title is not null
+        || filter.Description is not null
+        || filter.Company is not null
+        || filter.Location is not null
+        || filter.WorkTimeType is not null
+        || filter.WorkLocationType is not null
+        || filter.JobCategories is not null
+        || filter.Skills is not null
+        || filter.SalaryMin.HasValue
+        || filter.SalaryMax.HasValue
+        || filter.Currency is not null
+        || filter.MatchScore.HasValue
+        || filter.ExperienceLevel is not null
+        || filter.JobSource is not null
+        || filter.CreatedAt.HasValue
+        || filter.UpdatedAt.HasValue
+        || filter.IsChosen.HasValue;
+}

--- a/backend/src/JobNecto.Application/Vacancies/Mappers/VacancyMappers.cs
+++ b/backend/src/JobNecto.Application/Vacancies/Mappers/VacancyMappers.cs
@@ -1,0 +1,37 @@
+using JobNecto.Domain.Entities;
+
+namespace JobNecto.Application.Vacancies.Mappers;
+
+/// <summary>
+/// Mapping extension methods for vacancy list/query DTOs.
+/// </summary>
+public static class VacancyMappers
+{
+    /// <summary>
+    /// Maps a <see cref="Vacancy"/> domain entity to a list-item response DTO.
+    /// </summary>
+    /// <param name="vacancy">The vacancy entity to map.</param>
+    /// <returns>The mapped list-item DTO.</returns>
+    public static VacancyListItemResult ToVacancyListItemResult(this Vacancy vacancy)
+    {
+        ArgumentNullException.ThrowIfNull(vacancy);
+
+        return new VacancyListItemResult
+        {
+            Id = vacancy.Id,
+            Title = vacancy.Title,
+            Company = vacancy.Company,
+            WorkLocationType = vacancy.WorkLocationType?.ToString(),
+            Location = vacancy.Location?.ToString(),
+            Salary = vacancy.SalaryMin.HasValue || vacancy.SalaryMax.HasValue
+                ? new VacancySalaryResult
+                {
+                    Min = vacancy.SalaryMin,
+                    Max = vacancy.SalaryMax,
+                }
+                : null,
+            Currency = vacancy.Currency?.ToString(),
+            CreatedAt = vacancy.CreatedAt,
+        };
+    }
+}

--- a/backend/src/JobNecto.Domain/ValueObjects/Pagination.cs
+++ b/backend/src/JobNecto.Domain/ValueObjects/Pagination.cs
@@ -6,6 +6,7 @@ public record PagedQuery
     public Guid? LastSeenId { get; init; } = null;
     public DateTime? LastSeenUpdatedAt { get; init; } = null;
     public int PageSize { get; init; } = 20;
+    public string? SortBy { get; init; } = null;
     public string? Search { get; init; } = null;
 }
 

--- a/backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs
@@ -8,6 +8,9 @@ namespace JobNecto.Infrastructure.Repositories;
 
 public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository
 {
+    private const string SortByCreatedAt = "createdat";
+    private const string SortByUpdatedAt = "updatedat";
+
     public VacancyRepository(AppDbContext context)
         : base(context) { }
 
@@ -18,21 +21,33 @@ public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository
     )
     {
         var query = _dbSet.AsNoTracking();
+
+        if (pagedQuery.UserId.HasValue)
+        {
+            query = query.Where(v => v.UserId == pagedQuery.UserId.Value);
+        }
+
         query = ApplyFilters(query, filter);
 
         var totalCount = await query.CountAsync(ct);
 
-        query = query
-            .OrderByDescending(v => v.UpdatedAt)
-            .ThenByDescending(v => v.Id)
-            .ThenByDescending(v => v.MatchScore ?? 0);
+        var normalizedSortBy = NormalizeSortBy(pagedQuery.SortBy);
 
-        if (pagedQuery.LastSeenId is not null)
+        query = normalizedSortBy == SortByUpdatedAt
+            ? query.OrderByDescending(v => v.UpdatedAt).ThenByDescending(v => v.Id)
+            : query.OrderByDescending(v => v.CreatedAt).ThenByDescending(v => v.Id);
+
+        if (pagedQuery.LastSeenId is not null && pagedQuery.LastSeenUpdatedAt is not null)
         {
-            query = query.Where(v =>
-                v.UpdatedAt < pagedQuery.LastSeenUpdatedAt
-                || (v.UpdatedAt == pagedQuery.LastSeenUpdatedAt && v.Id < pagedQuery.LastSeenId)
-            );
+            query = normalizedSortBy == SortByUpdatedAt
+                ? query.Where(v =>
+                    v.UpdatedAt < pagedQuery.LastSeenUpdatedAt
+                    || (v.UpdatedAt == pagedQuery.LastSeenUpdatedAt && v.Id < pagedQuery.LastSeenId)
+                )
+                : query.Where(v =>
+                    v.CreatedAt < pagedQuery.LastSeenUpdatedAt
+                    || (v.CreatedAt == pagedQuery.LastSeenUpdatedAt && v.Id < pagedQuery.LastSeenId)
+                );
         }
 
         var take = Math.Max(1, pagedQuery.PageSize);
@@ -44,7 +59,11 @@ public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository
         var hasNext = takePagePlusOne.Count > take;
 
         Guid? nextLastSeenId = items.Count > 0 ? items[^1].Id : null;
-        DateTime? nextLastSeenUpdatedAt = items.Count > 0 ? items[^1].UpdatedAt : null;
+        DateTime? nextLastSeenUpdatedAt = items.Count > 0
+            ? normalizedSortBy == SortByUpdatedAt
+                ? items[^1].UpdatedAt
+                : items[^1].CreatedAt
+            : null;
 
         return new PagedResult<Vacancy>(
             items,
@@ -176,6 +195,24 @@ public class VacancyRepository : BaseRepository<Vacancy>, IVacancyRepository
     public Task<Vacancy> UpdateMatchScoreAsync(Guid id, double matchScore, CancellationToken ct)
     {
         throw new NotImplementedException();
+    }
+
+    private static string NormalizeSortBy(string? sortBy)
+    {
+        if (string.IsNullOrWhiteSpace(sortBy))
+        {
+            return SortByCreatedAt;
+        }
+
+        var normalized = sortBy.Trim().ToLowerInvariant();
+
+        return normalized switch
+        {
+            SortByCreatedAt => SortByCreatedAt,
+            SortByUpdatedAt => SortByUpdatedAt,
+            "relevance" => SortByUpdatedAt,
+            _ => SortByCreatedAt,
+        };
     }
 
     /// <summary>

--- a/backend/tests/JobNecto.Tests/API/Vacancies/VacanciesApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/Vacancies/VacanciesApiTests.cs
@@ -239,6 +239,51 @@ public class VacanciesApiTests
     }
 
     [Fact]
+    public async Task Filter_WithOnlyLastSeenId_Returns400()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await PostFilterAsync(client, authCookie, new { lastSeenId = Guid.NewGuid() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Filter_WithOnlyLastSeenUpdatedAt_Returns400()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await PostFilterAsync(client, authCookie, new { lastSeenUpdatedAt = DateTime.UtcNow });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Filter_WithLocationStringFilter_ReturnsOnlyMatchingVacancies()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var seeded = await SeedVacanciesAsync(factory, userId);
+
+        var polandCount = seeded.Count(v => v.Location == JobNecto.Domain.Enums.Location.Poland);
+
+        var response = await PostFilterAsync(client, authCookie, new { location = new[] { "Poland" } });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(polandCount);
+    }
+
+    [Fact]
     public async Task Filter_WithSortByRelevance_UsesUpdatedAtOrderingAlias()
     {
         await using var factory = new JobNectoApiFactory();

--- a/backend/tests/JobNecto.Tests/API/Vacancies/VacanciesApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/Vacancies/VacanciesApiTests.cs
@@ -1,0 +1,286 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using JobNecto.Application.Users;
+using JobNecto.Domain.Entities;
+using JobNecto.Infrastructure.Persistance;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JobNecto.Tests.API.Vacancies;
+
+public class VacanciesApiTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static CreateUserCommand NewUserCommand(string prefix = "vacancy_user") =>
+        new()
+        {
+            LoginName = prefix + Guid.NewGuid().ToString("N")[..8],
+            Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+            Password = "Password123!",
+        };
+
+    private static async Task<(string AuthCookie, Guid UserId)> CreateUserAndGetCookieAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync("/api/v1/users", NewUserCommand());
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createdUser = await response.Content.ReadFromJsonAsync<CreateUserResult>(JsonOptions);
+        createdUser.Should().NotBeNull();
+
+        var authCookie = response
+            .Headers.GetValues("Set-Cookie")
+            .Select(x =>
+                x.Split(';', StringSplitOptions.TrimEntries)
+                    .FirstOrDefault(y => y.StartsWith("auth-token=", StringComparison.OrdinalIgnoreCase))
+            )
+            .First(x => !string.IsNullOrWhiteSpace(x));
+
+        authCookie.Should().NotBeNullOrWhiteSpace();
+        return (authCookie!, createdUser!.Id);
+    }
+
+    private static async Task<HttpResponseMessage> PostFilterAsync(
+        HttpClient client,
+        string authCookie,
+        object payload
+    )
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/vacancies/filter")
+        {
+            Content = JsonContent.Create(payload),
+        };
+
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<IReadOnlyList<Vacancy>> SeedVacanciesAsync(
+        JobNectoApiFactory factory,
+        Guid userId
+    )
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        if (!await db.Users.AnyAsync(u => u.Id == userId))
+        {
+            var owner = VacancyTestData.CreateOwnerUser(id: userId);
+            db.Users.Add(owner);
+        }
+
+        var seeded = VacancyTestData.AllDistinctUpdatedAt(userId).ToList();
+        db.Vacancies.AddRange(seeded);
+
+        await db.SaveChangesAsync();
+        return seeded;
+    }
+
+    [Fact]
+    public async Task Filter_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/v1/vacancies/filter", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Filter_EmptyBody_WithNoVacancies_Returns200WithEmptyResult()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await PostFilterAsync(client, authCookie, new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(0);
+        result.PageSize.Should().Be(20);
+        result.HasNext.Should().BeFalse();
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Filter_EmptyBody_WithSeededVacancies_ReturnsCreatedAtDescending()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var seeded = await SeedVacanciesAsync(factory, userId);
+        var expectedOrder = seeded.OrderByDescending(v => v.CreatedAt).ThenByDescending(v => v.Id).ToList();
+
+        var response = await PostFilterAsync(client, authCookie, new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(expectedOrder.Count);
+        result.Items.Should().HaveCount(expectedOrder.Count);
+
+        var returnedIds = result.Items.Select(i => i.Id).ToList();
+        var expectedIds = expectedOrder.Select(v => v.Id).ToList();
+        returnedIds.Should().Equal(expectedIds);
+
+        result.Items.Should().OnlyContain(i => i.Id != Guid.Empty);
+        result.Items.Should().OnlyContain(i => i.CreatedAt != default);
+    }
+
+    [Fact]
+    public async Task Filter_ReturnsOnlyAuthenticatedUsersVacancies()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var ownSeeded = await SeedVacanciesAsync(factory, userId);
+        await SeedVacanciesAsync(factory, Guid.NewGuid());
+
+        var expectedOrder = ownSeeded
+            .OrderByDescending(v => v.CreatedAt)
+            .ThenByDescending(v => v.Id)
+            .Select(v => v.Id)
+            .ToList();
+
+        var response = await PostFilterAsync(client, authCookie, new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(ownSeeded.Count);
+        result.Items.Select(i => i.Id).Should().Equal(expectedOrder);
+    }
+
+    [Fact]
+    public async Task Filter_PageSizeAbove100_IsCappedTo100()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        await SeedVacanciesAsync(factory, userId);
+
+        var response = await PostFilterAsync(client, authCookie, new { pageSize = 500 });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.PageSize.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task Filter_WithCursor_ReturnsNextSlice()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var seeded = await SeedVacanciesAsync(factory, userId);
+        var expectedOrder = seeded.OrderByDescending(v => v.CreatedAt).ThenByDescending(v => v.Id).ToList();
+
+        var firstResponse = await PostFilterAsync(client, authCookie, new { pageSize = 2 });
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var firstPage = await firstResponse.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        firstPage.Should().NotBeNull();
+        firstPage!.Items.Should().HaveCount(2);
+        firstPage.HasNext.Should().BeTrue();
+        firstPage.LastSeenId.Should().NotBeNull();
+        firstPage.LastSeenUpdatedAt.Should().NotBeNull();
+
+        var secondResponse = await PostFilterAsync(
+            client,
+            authCookie,
+            new
+            {
+                pageSize = 2,
+                lastSeenId = firstPage.LastSeenId,
+                lastSeenUpdatedAt = firstPage.LastSeenUpdatedAt,
+            }
+        );
+
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondPage = await secondResponse.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        secondPage.Should().NotBeNull();
+        secondPage!.Items.Should().HaveCount(2);
+
+        secondPage.Items[0].Id.Should().Be(expectedOrder[2].Id);
+        secondPage.Items[1].Id.Should().Be(expectedOrder[3].Id);
+    }
+
+    [Fact]
+    public async Task Filter_WithSortByUpdatedAt_ReturnsUpdatedAtDescending()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var seeded = await SeedVacanciesAsync(factory, userId);
+        var expectedOrder = seeded.OrderByDescending(v => v.UpdatedAt).ThenByDescending(v => v.Id).ToList();
+
+        var response = await PostFilterAsync(client, authCookie, new { sortBy = "updatedAt" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Items.Select(i => i.Id).Should().Equal(expectedOrder.Select(v => v.Id));
+    }
+
+    [Fact]
+    public async Task Filter_WithSortByRelevance_UsesUpdatedAtOrderingAlias()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var seeded = await SeedVacanciesAsync(factory, userId);
+        var expectedOrder = seeded.OrderByDescending(v => v.UpdatedAt).ThenByDescending(v => v.Id).ToList();
+
+        var response = await PostFilterAsync(client, authCookie, new { sortBy = "relevance" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<VacancyPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Items.Select(i => i.Id).Should().Equal(expectedOrder.Select(v => v.Id));
+    }
+
+    private sealed class VacancyPagedResultDto
+    {
+        public List<VacancyListItemDto> Items { get; set; } = [];
+        public int TotalCount { get; set; }
+        public Guid? LastSeenId { get; set; }
+        public DateTime? LastSeenUpdatedAt { get; set; }
+        public int PageSize { get; set; }
+        public bool HasNext { get; set; }
+    }
+
+    private sealed class VacancyListItemDto
+    {
+        public Guid Id { get; set; }
+        public string? Title { get; set; }
+        public string? Company { get; set; }
+        public string? WorkLocationType { get; set; }
+        public string? Location { get; set; }
+        public VacancySalaryDto? Salary { get; set; }
+        public string? Currency { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    private sealed class VacancySalaryDto
+    {
+        public decimal? Min { get; set; }
+        public decimal? Max { get; set; }
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/Vacancies/VacanciesApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/Vacancies/VacanciesApiTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using JobNecto.Application.Users;
 using JobNecto.Domain.Entities;
 using JobNecto.Infrastructure.Persistance;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -239,7 +240,7 @@ public class VacanciesApiTests
     }
 
     [Fact]
-    public async Task Filter_WithOnlyLastSeenId_Returns400()
+    public async Task Filter_WithOnlyLastSeenId_Returns400WithProblemDetails()
     {
         await using var factory = new JobNectoApiFactory();
         var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
@@ -249,10 +250,13 @@ public class VacanciesApiTests
         var response = await PostFilterAsync(client, authCookie, new { lastSeenId = Guid.NewGuid() });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        problem!.Title.Should().Be("Validation failed");
+        problem.Detail.Should().Contain("lastSeenId");
     }
 
     [Fact]
-    public async Task Filter_WithOnlyLastSeenUpdatedAt_Returns400()
+    public async Task Filter_WithOnlyLastSeenUpdatedAt_Returns400WithProblemDetails()
     {
         await using var factory = new JobNectoApiFactory();
         var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
@@ -262,6 +266,25 @@ public class VacanciesApiTests
         var response = await PostFilterAsync(client, authCookie, new { lastSeenUpdatedAt = DateTime.UtcNow });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        problem!.Title.Should().Be("Validation failed");
+        problem.Detail.Should().Contain("lastSeenUpdatedAt");
+    }
+
+    [Fact]
+    public async Task Filter_WithUnknownSortBy_Returns400WithProblemDetails()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await PostFilterAsync(client, authCookie, new { sortBy = "popularity" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        problem!.Title.Should().Be("Validation failed");
+        problem.Detail.Should().Contain("sortBy");
     }
 
     [Fact]

--- a/backend/tests/JobNecto.Tests/Application/Vacancies/FilterVacanciesQueryHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Vacancies/FilterVacanciesQueryHandlerTests.cs
@@ -1,0 +1,239 @@
+using FluentAssertions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Application.Vacancies;
+using JobNecto.Domain.Entities;
+using JobNecto.Domain.Enums;
+using JobNecto.Domain.ValueObjects;
+using Moq;
+
+namespace JobNecto.Tests.Application.Vacancies;
+
+public class FilterVacanciesQueryHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<IVacancyRepository> _vacancyRepositoryMock;
+    private readonly FilterVacanciesQueryHandler _handler;
+
+    public FilterVacanciesQueryHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _vacancyRepositoryMock = new Mock<IVacancyRepository>();
+        _uowMock.Setup(x => x.VacancyRepository).Returns(_vacancyRepositoryMock.Object);
+        _handler = new FilterVacanciesQueryHandler(_uowMock.Object);
+    }
+
+    private static PagedResult<Vacancy> MakePagedResult(
+        IReadOnlyList<Vacancy> items,
+        int totalCount,
+        Guid? lastSeenId,
+        DateTime? lastSeenUpdatedAt,
+        int pageSize,
+        bool hasNext
+    ) => new(items, totalCount, lastSeenId, lastSeenUpdatedAt, pageSize, hasNext);
+
+    [Fact]
+    public async Task Handle_PageSizeAbove100_IsCappedAt100()
+    {
+        // Arrange
+        PagedQuery? capturedQuery = null;
+        _vacancyRepositoryMock
+            .Setup(x => x.GetFilteredAsync(It.IsAny<PagedQuery>(), It.IsAny<VacancyFilter?>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, VacancyFilter?, CancellationToken>((q, _, _) => capturedQuery = q)
+            .ReturnsAsync(MakePagedResult([], 0, null, null, 100, false));
+
+        // Act
+        await _handler.Handle(new FilterVacanciesQuery { PageSize = 500 }, CancellationToken.None);
+
+        // Assert
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.PageSize.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task Handle_PageSizeBelowOne_DefaultsToTwenty()
+    {
+        // Arrange
+        PagedQuery? capturedQuery = null;
+        _vacancyRepositoryMock
+            .Setup(x => x.GetFilteredAsync(It.IsAny<PagedQuery>(), It.IsAny<VacancyFilter?>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, VacancyFilter?, CancellationToken>((q, _, _) => capturedQuery = q)
+            .ReturnsAsync(MakePagedResult([], 0, null, null, 20, false));
+
+        // Act
+        await _handler.Handle(new FilterVacanciesQuery { PageSize = 0 }, CancellationToken.None);
+
+        // Assert
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.PageSize.Should().Be(20);
+    }
+
+    [Fact]
+    public async Task Handle_ForwardsSortByToPagedQuery()
+    {
+        // Arrange
+        PagedQuery? capturedQuery = null;
+        _vacancyRepositoryMock
+            .Setup(x => x.GetFilteredAsync(It.IsAny<PagedQuery>(), It.IsAny<VacancyFilter?>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, VacancyFilter?, CancellationToken>((q, _, _) => capturedQuery = q)
+            .ReturnsAsync(MakePagedResult([], 0, null, null, 20, false));
+
+        // Act
+        await _handler.Handle(new FilterVacanciesQuery { SortBy = "updatedAt" }, CancellationToken.None);
+
+        // Assert
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.SortBy.Should().Be("updatedAt");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyCriteria_ForwardsNullFilterAndCursorValues()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var lastSeenId = Guid.NewGuid();
+        var lastSeenUpdatedAt = DateTime.UtcNow.AddMinutes(-3);
+
+        PagedQuery? capturedQuery = null;
+        VacancyFilter? capturedFilter = null;
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetFilteredAsync(It.IsAny<PagedQuery>(), It.IsAny<VacancyFilter?>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, VacancyFilter?, CancellationToken>((q, f, _) =>
+            {
+                capturedQuery = q;
+                capturedFilter = f;
+            })
+            .ReturnsAsync(MakePagedResult([], 0, null, null, 20, false));
+
+        var query = new FilterVacanciesQuery
+        {
+            UserId = userId,
+            LastSeenId = lastSeenId,
+            LastSeenUpdatedAt = lastSeenUpdatedAt,
+        };
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.UserId.Should().Be(userId);
+        capturedQuery!.LastSeenId.Should().Be(lastSeenId);
+        capturedQuery.LastSeenUpdatedAt.Should().Be(lastSeenUpdatedAt);
+        capturedFilter.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_NonEmptyCriteria_BuildsVacancyFilter()
+    {
+        // Arrange
+        VacancyFilter? capturedFilter = null;
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetFilteredAsync(It.IsAny<PagedQuery>(), It.IsAny<VacancyFilter?>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, VacancyFilter?, CancellationToken>((_, f, _) => capturedFilter = f)
+            .ReturnsAsync(MakePagedResult([], 0, null, null, 20, false));
+
+        var query = new FilterVacanciesQuery
+        {
+            Company = "  MedStack  ",
+            WorkLocationType = [WorkLocationType.Remote],
+        };
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        capturedFilter.Should().NotBeNull();
+        capturedFilter!.Company.Should().Be("MedStack");
+        capturedFilter.WorkLocationType.Should().BeEquivalentTo([WorkLocationType.Remote]);
+    }
+
+    [Fact]
+    public async Task Handle_MapsVacancyWithNoSalary_ToNullSalaryInResult()
+    {
+        // Arrange
+        var vacancy = new Vacancy
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Title = "Engineering role — details on apply",
+            SalaryMin = null,
+            SalaryMax = null,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            JobSource = new JobSource { Name = "RSSFeed", Url = "https://jobs.example/feed.xml" },
+        };
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetFilteredAsync(It.IsAny<PagedQuery>(), It.IsAny<VacancyFilter?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MakePagedResult([vacancy], 1, vacancy.Id, vacancy.CreatedAt, 20, false));
+
+        // Act
+        var result = await _handler.Handle(new FilterVacanciesQuery(), CancellationToken.None);
+
+        // Assert
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Salary.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_MapsEntitiesAndPreservesEnvelopeMetadata()
+    {
+        // Arrange
+        var vacancy = new Vacancy
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Title = "Senior Backend Engineer",
+            Company = "MedStack",
+            Location = Location.Poland,
+            WorkLocationType = WorkLocationType.Remote,
+            SalaryMin = 95_000m,
+            SalaryMax = 118_000m,
+            Currency = Currency.EUR,
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1),
+            JobSource = new JobSource { Name = "LinkedIn", Url = "https://www.linkedin.com/jobs" },
+        };
+
+        var expectedLastSeenId = vacancy.Id;
+        var expectedLastSeenUpdatedAt = vacancy.CreatedAt;
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetFilteredAsync(It.IsAny<PagedQuery>(), It.IsAny<VacancyFilter?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                MakePagedResult(
+                    [vacancy],
+                    totalCount: 42,
+                    lastSeenId: expectedLastSeenId,
+                    lastSeenUpdatedAt: expectedLastSeenUpdatedAt,
+                    pageSize: 20,
+                    hasNext: true
+                )
+            );
+
+        // Act
+        var result = await _handler.Handle(new FilterVacanciesQuery(), CancellationToken.None);
+
+        // Assert
+        result.TotalCount.Should().Be(42);
+        result.PageSize.Should().Be(20);
+        result.HasNext.Should().BeTrue();
+        result.LastSeenId.Should().Be(expectedLastSeenId);
+        result.LastSeenUpdatedAt.Should().Be(expectedLastSeenUpdatedAt);
+
+        result.Items.Should().HaveCount(1);
+        var item = result.Items[0];
+        item.Id.Should().Be(vacancy.Id);
+        item.Title.Should().Be(vacancy.Title);
+        item.Company.Should().Be(vacancy.Company);
+        item.Location.Should().Be(Location.Poland.ToString());
+        item.WorkLocationType.Should().Be(WorkLocationType.Remote.ToString());
+        item.Currency.Should().Be(Currency.EUR.ToString());
+        item.CreatedAt.Should().Be(vacancy.CreatedAt);
+        item.Salary.Should().NotBeNull();
+        item.Salary!.Min.Should().Be(vacancy.SalaryMin);
+        item.Salary.Max.Should().Be(vacancy.SalaryMax);
+    }
+}

--- a/backend/tests/JobNecto.Tests/Infrastructure/VacancyRepositoryTests.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/VacancyRepositoryTests.cs
@@ -68,13 +68,44 @@ public class VacancyRepositoryTests
     }
 
     [Fact]
-    public async Task GetFilteredAsync_orders_by_UpdatedAt_desc_then_Id_and_pages()
+    public async Task GetFilteredAsync_with_user_scope_returns_only_current_users_vacancies()
+    {
+        var (context, ownerId, _) = await SeedAllVacanciesAsync();
+        await using (context)
+        {
+            var otherUser = VacancyTestData.CreateOwnerUser(id: Guid.NewGuid());
+            otherUser.Login = "vacancy-repo-tester-other";
+            otherUser.Email = "vacancy.tests.other@example.com";
+            context.Users.Add(otherUser);
+
+            var otherUsersVacancy = VacancyTestData.JuniorReactHybridBerlin(
+                otherUser.Id,
+                VacancyTestData.AnchorUtc.AddDays(-1),
+                VacancyTestData.AnchorUtc.AddHours(4)
+            );
+            context.Vacancies.Add(otherUsersVacancy);
+            await context.SaveChangesAsync();
+
+            var repo = new VacancyRepository(context);
+            var result = await repo.GetFilteredAsync(
+                new PagedQuery { UserId = ownerId, PageSize = 50 },
+                filter: null,
+                CancellationToken.None
+            );
+
+            result.TotalCount.Should().Be(7);
+            result.Items.Should().OnlyContain(v => v.UserId == ownerId);
+        }
+    }
+
+    [Fact]
+    public async Task GetFilteredAsync_orders_by_CreatedAt_desc_then_Id_and_pages()
     {
         var (context, _, seeded) = await SeedAllVacanciesAsync();
         await using (context)
         {
             var repo = new VacancyRepository(context);
-            var expectedOrder = seeded.OrderByDescending(v => v.UpdatedAt).ThenByDescending(v => v.Id).ToList();
+            var expectedOrder = seeded.OrderByDescending(v => v.CreatedAt).ThenByDescending(v => v.Id).ToList();
 
             var result = await repo.GetFilteredAsync(
                 new PagedQuery { PageSize = 2 },
@@ -88,7 +119,31 @@ public class VacancyRepositoryTests
             result.Items[0].Id.Should().Be(expectedOrder[0].Id);
             result.Items[1].Id.Should().Be(expectedOrder[1].Id);
             result.LastSeenId.Should().Be(expectedOrder[1].Id);
-            result.LastSeenUpdatedAt.Should().Be(expectedOrder[1].UpdatedAt);
+            result.LastSeenUpdatedAt.Should().Be(expectedOrder[1].CreatedAt);
+        }
+    }
+
+    [Fact]
+    public async Task GetFilteredAsync_with_sort_by_updated_at_orders_by_UpdatedAt_desc_then_Id()
+    {
+        var (context, _, seeded) = await SeedAllVacanciesAsync();
+        await using (context)
+        {
+            var repo = new VacancyRepository(context);
+            var expectedOrder = seeded.OrderByDescending(v => v.UpdatedAt).ThenByDescending(v => v.Id).ToList();
+
+            var result = await repo.GetFilteredAsync(
+                new PagedQuery { PageSize = 3, SortBy = "updatedAt" },
+                filter: null,
+                CancellationToken.None
+            );
+
+            result.TotalCount.Should().Be(7);
+            result.Items.Should().HaveCount(3);
+            result.Items[0].Id.Should().Be(expectedOrder[0].Id);
+            result.Items[1].Id.Should().Be(expectedOrder[1].Id);
+            result.Items[2].Id.Should().Be(expectedOrder[2].Id);
+            result.LastSeenUpdatedAt.Should().Be(expectedOrder[2].UpdatedAt);
         }
     }
 
@@ -99,7 +154,7 @@ public class VacancyRepositoryTests
         await using (context)
         {
             var repo = new VacancyRepository(context);
-            var expectedOrder = seeded.OrderByDescending(v => v.UpdatedAt).ThenByDescending(v => v.Id).ToList();
+            var expectedOrder = seeded.OrderByDescending(v => v.CreatedAt).ThenByDescending(v => v.Id).ToList();
 
             var first = await repo.GetFilteredAsync(
                 new PagedQuery { PageSize = 2 },
@@ -433,6 +488,51 @@ public class VacancyRepositoryTests
             result.PageSize.Should().Be(0);
             result.HasNext.Should().BeTrue();
         }
+    }
+
+    [Fact]
+    public async Task GetFilteredAsync_ties_on_same_created_at_are_paginated_deterministically_by_id()
+    {
+        await using var context = CreateContext();
+        var owner = VacancyTestData.CreateOwnerUser();
+        context.Users.Add(owner);
+
+        var sharedCreatedAt = VacancyTestData.AnchorUtc;
+        var v1 = VacancyTestData.SeniorDotNetRemotePoland(owner.Id, sharedCreatedAt, sharedCreatedAt);
+        var v2 = VacancyTestData.JuniorReactHybridBerlin(owner.Id, sharedCreatedAt, sharedCreatedAt);
+        context.Vacancies.AddRange(v1, v2);
+        await context.SaveChangesAsync();
+
+        var repo = new VacancyRepository(context);
+
+        var firstPage = await repo.GetFilteredAsync(
+            new PagedQuery { PageSize = 1 },
+            filter: null,
+            CancellationToken.None
+        );
+
+        firstPage.TotalCount.Should().Be(2);
+        firstPage.Items.Should().HaveCount(1);
+        firstPage.HasNext.Should().BeTrue();
+
+        var secondPage = await repo.GetFilteredAsync(
+            new PagedQuery
+            {
+                PageSize = 1,
+                LastSeenId = firstPage.LastSeenId,
+                LastSeenUpdatedAt = firstPage.LastSeenUpdatedAt,
+            },
+            filter: null,
+            CancellationToken.None
+        );
+
+        secondPage.Items.Should().HaveCount(1);
+        secondPage.HasNext.Should().BeFalse();
+
+        // Both pages together cover all records with no duplicates or gaps.
+        var allReturnedIds = new[] { firstPage.Items[0].Id, secondPage.Items[0].Id };
+        allReturnedIds.Should().BeEquivalentTo(new[] { v1.Id, v2.Id });
+        allReturnedIds.Distinct().Should().HaveCount(2);
     }
 
     [Fact]

--- a/backend/tests/JobNecto.Tests/Infrastructure/VacancyTestData.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/VacancyTestData.cs
@@ -6,7 +6,7 @@ using JobNecto.Domain.ValueObjects;
 /// <summary>
 /// Realistic <see cref="Vacancy"/> fixtures for repository and filter tests.
 /// Use <see cref="CreateOwnerUser"/> (or your own user) and pass <paramref name="userId"/> into each factory.
-/// Timestamps: pass explicit <c>createdAt</c>/<c>updatedAt</c> when testing pagination (ordering is by <c>UpdatedAt</c> desc).
+/// Timestamps: pass explicit <c>createdAt</c>/<c>updatedAt</c> when testing pagination (ordering is by <c>CreatedAt</c> desc).
 /// </summary>
 /// <remarks>
 /// <see cref="VacancyRepository"/> filters on <c>Skills</c> / <c>JobCategories</c> are not exercised with EF InMemory in this project
@@ -280,7 +280,7 @@ internal static class VacancyTestData
         };
 
     /// <summary>
-    /// Ordered by <see cref="Vacancy.UpdatedAt"/> descending: index 0 is newest (best for cursor pagination tests).
+    /// Returns fixtures with distinct timestamps suitable for deterministic cursor pagination tests.
     /// </summary>
     public static IReadOnlyList<Vacancy> AllDistinctUpdatedAt(Guid userId)
     {


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/vacancies/filter` endpoint supporting browse (empty criteria) and filter modes through a single keyset-paginated contract
- Implements cursor pagination (`lastSeenId` + `lastSeenUpdatedAt`) with sorting by `createdAt` (default), `updatedAt`, and `relevance` (alias for `updatedAt`)
- Scopes all results to the authenticated user; page size capped at 100

## Code review fixes included

- **Cursor semantics documented**: `LastSeenUpdatedAt` XML comment now explicitly states it holds `CreatedAt` or `UpdatedAt` depending on `SortBy`, and that the cursor must be reset when changing sort mode between requests
- **Tie-break pagination test**: new repository test verifies that two vacancies sharing the same `CreatedAt` are paged deterministically by `Id desc` with no duplicates or gaps
- **Null salary mapper test**: new handler test verifies a vacancy with no salary data maps to `Salary: null` in the DTO

## Test plan

- [ ] 17/17 vacancy-scoped tests pass (`dotnet test --filter "FullyQualifiedName~Vacancies"`)
- [ ] `POST /api/v1/vacancies/filter` with no body returns 200 with empty items (no vacancies seeded)
- [ ] `POST /api/v1/vacancies/filter` with `{ "pageSize": 2 }` returns first page and `hasNext: true`
- [ ] Subsequent request with cursor fields returns next slice without overlap
- [ ] `{ "sortBy": "updatedAt" }` returns items ordered by `UpdatedAt desc`
- [ ] `{ "sortBy": "relevance" }` returns same order as `updatedAt`
- [ ] Request without auth token returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)