### PR TITLE
feat(epic-5): implement cover letter management and harden DB uniqueness tests

### DIFF
--- a/_bmad-output/agent-learnings.md
+++ b/_bmad-output/agent-learnings.md
@@ -11,6 +11,56 @@ See `.github/instructions/self-improvement.instructions.md` for the protocol.
 
 <!-- Entries are appended here. Newest at the top. -->
 
+### 2026-05-10 - Verify xUnit runtime-skip APIs before coding dependency-gated tests
+
+**Trigger:** Test failure
+**Context:** Applying Epic 5 review fixes in `backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersUniquenessApiTests.cs`.
+**Wrong action:** I implemented runtime skipping with `Xunit.Sdk.SkipException`, which is not available in the xUnit 2.9 package set used by this repo, causing compile failure.
+**Root cause:** I assumed a skip exception API existed without checking the concrete xUnit version and exported types in this project.
+**Correct behavior:** Before adding runtime skip logic, confirm the exact xUnit runtime capabilities in the repository and choose a compatible approach (or CI-gated fail-fast fallback) that compiles in the current package set.
+**Pattern / trigger:** Any dependency-gated integration test where runtime skipping is introduced after a review recommendation.
+**Generalize?** Yes
+
+### 2026-05-10 - Enforce soft-delete predicates explicitly in specialized joined queries
+
+**Trigger:** Test failure
+**Context:** Story 5.5 post-delete API tests showed `GET /cover-letters/{id}` and list visibility regressions after soft delete.
+**Wrong action:** I relied only on global query filters in specialized cover letter queries that also used JOIN/group-join with `IgnoreQueryFilters()` on related vacancy data.
+**Root cause:** I assumed global filters would remain unambiguous in every composed query shape; in this path, deleted records still surfaced in tests.
+**Correct behavior:** In specialized repository queries (especially with joins and query-filter overrides), add explicit base predicates for active records (`!IsDeleted`) on the primary entity to guarantee visibility rules.
+**Pattern / trigger:** Any custom query that combines soft-deletable entities with `IgnoreQueryFilters()` on related entities.
+**Generalize?** Yes
+
+### 2026-05-10 - Verify enum members before writing new tests and DTO fixtures
+
+**Trigger:** Test failure
+**Context:** Story 5.3 unit/API tests for cover letter detail used `Location.ISTANBUL`.
+**Wrong action:** I referenced an enum member that does not exist in `JobNecto.Domain.Enums.Location`, which caused compile failure.
+**Root cause:** I assumed location granularity from endpoint expectations instead of checking the actual enum contract in the codebase.
+**Correct behavior:** Before using enum literals in new tests or seeded fixtures, open the enum declaration and use only existing members; align expected JSON values with actual serializer output.
+**Pattern / trigger:** Any new test or mapper that introduces enum constants from memory rather than from the source enum file.
+**Generalize?** Yes
+
+### 2026-05-10 - Do not reassign filtered IQueryable into implicitly ordered query vars
+
+**Trigger:** Test failure
+**Context:** Story 5.2 `CoverLetterRepository.GetPagedListAsync` cursor filter implementation.
+**Wrong action:** I assigned an ordered LINQ query to `var query` (inferred as `IOrderedQueryable`) and then reassigned `query = query.Where(...)`, which returns `IQueryable` and caused compile error CS0266.
+**Root cause:** I relied on implicit type inference for a mutable query pipeline and overlooked that adding `Where` changes the static interface from ordered to non-ordered.
+**Correct behavior:** When a query variable is conditionally reassigned with filters, declare it as `IQueryable<T>` up front (or re-apply ordering after filtering) instead of relying on `var` from `OrderBy`.
+**Pattern / trigger:** Any repository method that builds an ordered query then conditionally applies `Where` before paging.
+**Generalize?** Yes
+
+### 2026-05-10 - Keep EF Core types out of Application handlers
+
+**Trigger:** Test failure
+**Context:** Story 5.1 `CreateCoverLetterCommandHandler` initially caught `DbUpdateException` directly from `Microsoft.EntityFrameworkCore` in the Application layer.
+**Wrong action:** I introduced an EF Core type dependency into Application to catch database uniqueness violations.
+**Root cause:** I followed the story note too literally and missed the architecture boundary: Application must remain persistence-provider agnostic.
+**Correct behavior:** In Application handlers, catch provider-agnostic exceptions and map conflicts without referencing EF packages; keep EF-specific details in Infrastructure/API exception mapping.
+**Pattern / trigger:** Any new Application handler that tries to catch `DbUpdateException` or import `Microsoft.EntityFrameworkCore`.
+**Generalize?** Yes
+
 ### 2026-05-10 - Return structured ProblemDetails for all 400 responses, never plain strings
 
 **Trigger:** PR review comment (LLM reviewer, second pass)

--- a/_bmad-output/implementation-artifacts/5-1-create-cover-letter.md
+++ b/_bmad-output/implementation-artifacts/5-1-create-cover-letter.md
@@ -1,0 +1,142 @@
+# Story 5.1: Create Cover Letter
+
+Status: ready-for-dev
+
+## Story
+
+As a job seeker,
+I want to write a cover letter for a specific vacancy,
+so that I can submit a tailored application.
+
+## Acceptance Criteria
+
+1. Given a valid JWT token and `POST /api/v1/cover-letters` with `vacancyId` (existing, owned by user) and `content` (50–10000 chars), when the request is processed, then `201 Created` with the cover letter object and `Location` header set to `/api/v1/cover-letters/{id}`.
+2. Given the user already has a non-deleted cover letter for the same `vacancyId`, when `POST /api/v1/cover-letters` is called again with the same `vacancyId`, then `409 Conflict` from database-backed per-user/per-vacancy uniqueness enforcement.
+3. Given `vacancyId` references a vacancy that does not exist or belongs to another user, when the request is processed, then `404 Not Found` with detail referencing the vacancy.
+4. Given `content` is fewer than 50 or more than 10000 characters, when the request is processed, then `400 Bad Request` with field-level error on `content`.
+5. Given no JWT token, when `POST /api/v1/cover-letters` is called, then `401 Unauthorized`.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add partial unique index to EF configuration and migrate (AC: 2)
+  - [ ] In `backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterConfiguration.cs`, add partial unique index: `(UserId, VacancyId)` WHERE `IsDeleted = false`.
+  - [ ] Add EF migration: `dotnet ef migrations add AddCoverLetterUniqueVacancyPerUser --project backend/src/JobNecto.Infrastructure --startup-project backend/src/JobNecto.API`.
+
+- [ ] Task 2: Create command, DTO, and handler (AC: 1, 2, 3)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/CreateCoverLetterCommand.cs` with `CreateCoverLetterCommand` (implementing `IRequest<CreateCoverLetterResult>`) and `CreateCoverLetterResult` DTO in the same file.
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/CreateCoverLetterCommandHandler.cs` — verify vacancy exists + belongs to user; create entity; catch `DbUpdateException` → throw `ConflictException`.
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/Mappers/CoverLetterMappers.cs` with `ToEntity(CreateCoverLetterCommand)` and `ToCreateResult(CoverLetter)` extensions.
+  - [ ] Set `CreatedAt` and `UpdatedAt` to `DateTime.UtcNow` in the handler (per agent-learnings: do not rely on DB defaults in-memory).
+
+- [ ] Task 3: Create FluentValidation validator (AC: 4)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/Validators/CreateCoverLetterCommandValidator.cs`.
+  - [ ] Rules: `VacancyId` not empty; `Content` length 50–10000, not empty/whitespace.
+
+- [ ] Task 4: Add API controller and endpoint (AC: 1, 5)
+  - [ ] Create `backend/src/JobNecto.API/Controllers/CoverLettersController.cs` with `[ApiController]`, `[Route("api/v1/cover-letters")]`, `[Authorize]`.
+  - [ ] Add `[HttpPost]` action: extract `UserId` via `HttpContext.GetCurrentUserId()`; dispatch `CreateCoverLetterCommand`; return `Created($"/api/v1/cover-letters/{result.Id}", result)`.
+  - [ ] `ProducesResponseType` for 201, 400, 401, 404, 409.
+  - [ ] Use `BadRequest(new ProblemDetails { Status = 400, Title = "Validation failed", Detail = "..." })` pattern (per agent-learnings — never `BadRequest("plain string")`).
+
+- [ ] Task 5: Add tests (AC: 1–5)
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/CoverLetters/CreateCoverLetterCommandHandlerTests.cs` — mock `IUnitOfWork`; test: valid create succeeds, missing vacancy → NotFoundException, other-user vacancy → NotFoundException, duplicate (DbUpdateException with unique violation) → ConflictException.
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/CoverLetters/CreateCoverLetterCommandValidatorTests.cs` — test content boundary (49, 50, 10000, 10001 chars), empty/whitespace content, empty vacancyId.
+  - [ ] Create `backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersApiTests.cs` — integration tests: no token → 401; valid create → 201 with Location header; content too short → 400; duplicate vacancyId (same user) → 409; invalid vacancyId → 404.
+
+- [ ] Task 6: Verification gates
+  - [ ] Build: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` — 0 warnings, 0 errors.
+  - [ ] Tests: `dotnet test backend/JobNecto.slnx` — all pass.
+
+## Dev Notes
+
+### EF Configuration Change
+
+In `CoverLetterConfiguration.Configure`, add the partial unique index:
+
+```csharp
+// One non-deleted cover letter per user per vacancy
+builder.HasIndex(cl => new { cl.UserId, cl.VacancyId })
+    .IsUnique()
+    .HasFilter("\"IsDeleted\" = false");
+```
+
+PostgreSQL-specific filter syntax. The migration will emit `WHERE ("IsDeleted" = false)`. No changes to the `CoverLetter` domain entity are needed.
+
+### Critical: 409 Must Come from DB Constraint
+
+Per NFR13 and the Epic 5 readiness constraint: the uniqueness rule must be backed by a database constraint. Throw `ConflictException` by catching `DbUpdateException` (not by pre-checking existence), exactly as cover letter template name uniqueness works.
+
+```csharp
+try
+{
+    await _unitOfWork.CoverLetterRepository.CreateAsync(coverLetter, cancellationToken);
+    await _unitOfWork.SaveChangesAsync(cancellationToken);
+}
+catch (DbUpdateException ex) when (ex.InnerException?.Message.Contains("unique") == true
+                                   || ex.InnerException?.Message.Contains("duplicate") == true)
+{
+    throw new ConflictException("A cover letter for this vacancy already exists.");
+}
+```
+
+### Vacancy Ownership Check
+
+Per AC 3: vacancy must exist **and belong to the current user**. `GetByIdAsync` throws `NotFoundException` if absent. Check ownership after — return `NotFoundException` (not `ForbiddenException`) to prevent existence leakage, consistent with Decision 7.
+
+```csharp
+var vacancy = await _unitOfWork.VacancyRepository.GetByIdAsync(request.VacancyId, cancellationToken);
+if (vacancy.UserId != request.UserId)
+    throw new NotFoundException("Vacancy", request.VacancyId);
+```
+
+### Response DTO
+
+`CreateCoverLetterResult` fields: `Id`, `VacancyId`, `Content`, `CreatedAt`, `UpdatedAt`.
+
+### Controller Pattern
+
+Follow `CoverLetterTemplatesController` exactly for auth extraction and command population. `UserId` is injected from JWT: `command.UserId = userId;` — mark it `[JsonIgnore]` on the command.
+
+### Test: 409 Uniqueness
+
+The 409 integration test must seed a first cover letter for the user+vacancy, then POST again with the same `vacancyId`. EF InMemory does not enforce unique constraints at the DB level — follow the `CoverLetterTemplatesUniquenessApiTests.cs` test setup pattern (uses a real Npgsql test DB) for the 409 case.
+
+### Files to Read Before Implementation
+
+- `backend/src/JobNecto.Domain/Entities/CoverLetter.cs` (current entity — no changes needed)
+- `backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterConfiguration.cs`
+- `backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterTemplateConfiguration.cs` (unique index pattern reference)
+- `backend/src/JobNecto.Application/CoverLetterTemplates/CreateCoverLetterTemplateCommandHandler.cs` (DbUpdateException catch pattern)
+- `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`
+- `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs` (409 test pattern)
+
+### Project Structure Notes
+
+- New files under `backend/src/JobNecto.Application/CoverLetters/`, `CoverLetters/Validators/`, `CoverLetters/Mappers/`.
+- Controller at `backend/src/JobNecto.API/Controllers/CoverLettersController.cs`.
+- Tests at `backend/tests/JobNecto.Tests/Application/CoverLetters/` and `API/CoverLetters/`.
+- Namespaces: `JobNecto.Application.CoverLetters`, `JobNecto.Application.CoverLetters.Validators`, `JobNecto.Application.CoverLetters.Mappers`, `JobNecto.API.Controllers`, `JobNecto.Tests.Application.CoverLetters`, `JobNecto.Tests.API.CoverLetters`.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md` — Story 5.1]
+- [Source: `_bmad-output/planning-artifacts/epics/requirements-inventory.md` — FR19, NFR2, NFR13]
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` — Decision 2, 3, 4, 6, 7]
+- [Source: `_bmad-output/agent-learnings.md` — timestamp in handlers, BadRequest shape, DB-backed uniqueness]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Completion Notes List
+
+- `templateId` dropped per product decision: content is injected by the user; no reference persisted.
+- `CoverLetter` entity unchanged — only EF configuration (partial unique index) and migration needed.
+- Vacancy ownership returns 404 (not 403) per Decision 7.
+- 409 must be DB-backed — catch `DbUpdateException`.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-1-create-cover-letter.md` (this file)

--- a/_bmad-output/implementation-artifacts/5-2-list-cover-letters.md
+++ b/_bmad-output/implementation-artifacts/5-2-list-cover-letters.md
@@ -1,0 +1,178 @@
+# Story 5.2: List Cover Letters
+
+Status: ready-for-dev
+
+## Story
+
+As a job seeker,
+I want to see all my cover letters in a paginated list,
+so that I can track all my job applications.
+
+## Acceptance Criteria
+
+1. Given a valid JWT token, when `GET /api/v1/cover-letters` is called, then `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }` — non-deleted cover letters owned by this user, ordered by `createdAt desc`, each item includes: `id`, `vacancyId`, `vacancyTitle` (from linked vacancy), `createdAt`, `updatedAt`.
+2. Given `pageSize`, `lastSeenId`, `lastSeenUpdatedAt` cursor params are provided, when the request is processed, then correct cursor window returned; `pageSize` capped at 100.
+3. Given the user has no cover letters, when `GET /api/v1/cover-letters` is called, then `200 OK` with `{ totalCount: 0, hasNext: false, items: [] }`.
+4. Given no JWT token, when `GET /api/v1/cover-letters` is called, then `401 Unauthorized`.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Introduce `ICoverLetterRepository` with specialized list method (AC: 1, 2)
+  - [ ] Create `backend/src/JobNecto.Application/Interfaces/ICoverLetterRepository.cs` extending `IMutableRepository<CoverLetter>` with `GetPagedListAsync(PagedQuery pagedQuery, CancellationToken ct)` returning `PagedResult<CoverLetterListItem>`.
+  - [ ] Define `CoverLetterListItem` record in the same file (or in `ListCoverLettersQuery.cs`): `Id`, `VacancyId`, `VacancyTitle` (nullable string), `CreatedAt`, `UpdatedAt`.
+  - [ ] Update `IUnitOfWork.CoverLetterRepository` from `IMutableRepository<CoverLetter>` to `ICoverLetterRepository`.
+
+- [ ] Task 2: Implement `ICoverLetterRepository` in Infrastructure (AC: 1, 2, 3)
+  - [ ] Update `backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs` to implement `ICoverLetterRepository` (still extends `SoftDeletableRepository<CoverLetter>`).
+  - [ ] Implement `GetPagedListAsync`: user-scoped (`UserId` filter), ordered by `CreatedAt DESC, Id DESC`, JOIN to `Vacancies` for `Title`, `pageSize` cap 100, cursor logic uses `CreatedAt` (not `UpdatedAt`), returns `PagedResult<CoverLetterListItem>` with correct `hasNext`, `totalCount`, and cursor fields.
+  - [ ] Cursor field `LastSeenUpdatedAt` in `PagedQuery` carries `CreatedAt` of the last seen cover letter for this endpoint (the field name is a shared contract name — the value semantics differ here).
+  - [ ] Update `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs` to return `ICoverLetterRepository`.
+
+- [ ] Task 3: Create query, handler, and DTOs (AC: 1, 2, 3)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/ListCoverLettersQuery.cs` with `ListCoverLettersQuery` (`IRequest<PagedResult<CoverLetterListItem>>`), `UserId` (JsonIgnore), `PageSize` (default 20), `LastSeenId`, `LastSeenUpdatedAt`.
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/ListCoverLettersQueryHandler.cs`: cap `PageSize` to 100, build `PagedQuery`, call `_unitOfWork.CoverLetterRepository.GetPagedListAsync(...)`, return result.
+
+- [ ] Task 4: Add API endpoint (AC: 4)
+  - [ ] Add `[HttpGet]` action to `backend/src/JobNecto.API/Controllers/CoverLettersController.cs`.
+  - [ ] Query params: `pageSize`, `lastSeenId`, `lastSeenUpdatedAt`; normalize `lastSeenUpdatedAt` to UTC (same pattern as `CoverLetterTemplatesController`).
+  - [ ] `ProducesResponseType` for 200, 401.
+
+- [ ] Task 5: Add tests (AC: 1–4)
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/CoverLetters/ListCoverLettersQueryHandlerTests.cs` — mock `ICoverLetterRepository`; test: empty list, populated list with correct item fields, pageSize cap.
+  - [ ] In `backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersApiTests.cs` — add integration tests: no token → 401; empty result when no cover letters; correct `createdAt desc` ordering; `vacancyTitle` populated from linked vacancy; cursor pagination advances correctly; cross-user isolation (user A's letters not visible to user B).
+
+- [ ] Task 6: Verification gates
+  - [ ] Build: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` — 0 warnings, 0 errors.
+  - [ ] Tests: `dotnet test backend/JobNecto.slnx` — all pass.
+
+## Dev Notes
+
+### Critical: Why `ICoverLetterRepository` Is Needed
+
+`BaseRepository<T>.GetAsync` always orders by `UpdatedAt DESC` and returns only the entity's own fields. Story 5.2 requires:
+1. **Ordering by `CreatedAt DESC`** — different from standard.
+2. **JOIN to `Vacancies` table** for `vacancyTitle` — not available via generic `GetAsync`.
+
+This justifies introducing `ICoverLetterRepository` per Decision 3: "Do not introduce bespoke repository interfaces only for naming symmetry" — but this case has **real specialized query behavior**. Same rationale as `IVacancyRepository` for `GetFilteredAsync`.
+
+### `GetPagedListAsync` Implementation Sketch
+
+```csharp
+public async Task<PagedResult<CoverLetterListItem>> GetPagedListAsync(
+    PagedQuery pagedQuery, CancellationToken ct)
+{
+    var pageSize = Math.Max(1, Math.Min(pagedQuery.PageSize, 100));
+
+    var query = _context.Set<CoverLetter>()
+        .AsNoTracking()
+        .Where(cl => cl.UserId == pagedQuery.UserId!.Value)
+        .Join(_context.Set<Vacancy>().AsNoTracking(),
+            cl => cl.VacancyId,
+            v => v.Id,
+            (cl, v) => new { CoverLetter = cl, VacancyTitle = v.Title });
+
+    var totalCount = await query.CountAsync(ct);
+
+    // Order by CreatedAt DESC for cover letters (not UpdatedAt)
+    var orderedQuery = query.OrderByDescending(x => x.CoverLetter.CreatedAt)
+                            .ThenByDescending(x => x.CoverLetter.Id);
+
+    // Cursor logic: LastSeenUpdatedAt carries CreatedAt of last seen item
+    if (pagedQuery.LastSeenId is Guid lastSeenId && pagedQuery.LastSeenUpdatedAt is DateTime cursorCreatedAt)
+    {
+        orderedQuery = orderedQuery.Where(x =>
+            x.CoverLetter.CreatedAt < cursorCreatedAt
+            || (x.CoverLetter.CreatedAt == cursorCreatedAt && x.CoverLetter.Id < lastSeenId));
+    }
+
+    var pagePlusOne = await orderedQuery.Take(pageSize + 1).ToListAsync(ct);
+    var items = pagePlusOne.Take(pageSize)
+        .Select(x => new CoverLetterListItem
+        {
+            Id = x.CoverLetter.Id,
+            VacancyId = x.CoverLetter.VacancyId,
+            VacancyTitle = x.VacancyTitle,
+            CreatedAt = x.CoverLetter.CreatedAt,
+            UpdatedAt = x.CoverLetter.UpdatedAt,
+        }).ToList();
+
+    var hasNext = pagePlusOne.Count > pageSize;
+    // LastSeenUpdatedAt carries CreatedAt value for this endpoint
+    return new PagedResult<CoverLetterListItem>(
+        items, totalCount,
+        items.Count > 0 ? items[^1].Id : null,
+        items.Count > 0 ? items[^1].CreatedAt : null,  // ← createdAt, not updatedAt
+        pageSize, hasNext);
+}
+```
+
+**Note**: The EF global query filter for `CoverLetter` (`!IsDeleted`) applies automatically. The `Vacancy` soft-delete filter also applies, so soft-deleted vacancies won't appear in the JOIN. Per AC of Story 5.5: a cover letter whose vacancy was deleted should still return — check if the query needs `IgnoreQueryFilters` for the vacancy side if the FK cascade deletes the cover letter anyway (it does — see `CoverLetterConfiguration`: `ON DELETE CASCADE` on VacancyId FK). So this case doesn't arise in practice (cover letter is hard-deleted when vacancy is deleted).
+
+### `IUnitOfWork` Change
+
+In `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`, change:
+```csharp
+// From:
+IMutableRepository<CoverLetter> CoverLetterRepository { get; }
+// To:
+ICoverLetterRepository CoverLetterRepository { get; }
+```
+
+All existing handler calls still work because `ICoverLetterRepository : IMutableRepository<CoverLetter>`.
+
+### Cursor Semantics for This Endpoint
+
+The standard pagination envelope uses `lastSeenUpdatedAt` as the cursor timestamp field name. For cover letters, the ordering is `createdAt desc`. Therefore, `lastSeenUpdatedAt` in requests/responses **carries the `createdAt` value** of the last seen item. Document this explicitly in code comments.
+
+The controller must normalize `lastSeenUpdatedAt` to UTC (same pattern as `CoverLetterTemplatesController`).
+
+### XOR Cursor Validation
+
+Per agent-learnings: cursor requires both `lastSeenId` AND `lastSeenUpdatedAt` — if only one is provided, return 400. Add this validation in the controller (not the handler), consistent with the story 4.1 pattern:
+```csharp
+if (lastSeenId.HasValue != lastSeenUpdatedAt.HasValue)
+    return BadRequest(new ProblemDetails { Status = 400, Title = "Validation failed",
+        Detail = "lastSeenId and lastSeenUpdatedAt must both be provided or both omitted." });
+```
+
+### Files to Read Before Implementation
+
+- `backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs`
+- `backend/src/JobNecto.Application/Interfaces/IVacancyRepository.cs` (specialized interface pattern)
+- `backend/src/JobNecto.Infrastructure/Repositories/BaseRepository.cs` (understand `GetAsync` to know what you're replacing)
+- `backend/src/JobNecto.Infrastructure/Repositories/VacancyRepository.cs` (ordering override pattern)
+- `backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs`
+- `backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs`
+- `backend/src/JobNecto.API/Controllers/CoverLetterTemplatesController.cs` (UTC normalization pattern)
+- `backend/src/JobNecto.Application/CoverLetterTemplates/ListCoverLetterTemplatesQuery.cs` (query DTO pattern)
+- `backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesApiTests.cs` (test helpers)
+
+### Project Structure Notes
+
+- `ICoverLetterRepository` lives in `backend/src/JobNecto.Application/Interfaces/` — namespace `JobNecto.Application.Interfaces`.
+- `CoverLetterListItem` DTO lives in `backend/src/JobNecto.Application/CoverLetters/ListCoverLettersQuery.cs`.
+- Test namespace: `JobNecto.Tests.Application.CoverLetters`, `JobNecto.Tests.API.CoverLetters`.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md` — Story 5.2]
+- [Source: `_bmad-output/planning-artifacts/epics/requirements-inventory.md` — FR20, NFR10]
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` — Decision 3, 7]
+- [Source: `_bmad-output/agent-learnings.md` — XOR cursor validation, BadRequest shape]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Completion Notes List
+
+- `ICoverLetterRepository` introduced because of ordering difference (`createdAt` vs `updatedAt`) and JOIN requirement.
+- Cursor `lastSeenUpdatedAt` carries `createdAt` value — documented explicitly.
+- XOR cursor validation required per agent-learnings.
+- `IUnitOfWork` property type change is a compile-time-breaking change — update `UnitOfWork.cs` property return type too.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-2-list-cover-letters.md` (this file)

--- a/_bmad-output/implementation-artifacts/5-3-get-cover-letter-detail.md
+++ b/_bmad-output/implementation-artifacts/5-3-get-cover-letter-detail.md
@@ -1,0 +1,149 @@
+# Story 5.3: Get Cover Letter Detail
+
+Status: ready-for-dev
+
+## Story
+
+As a job seeker,
+I want to view a cover letter's full content and associated vacancy,
+so that I can review or edit what I've written.
+
+## Acceptance Criteria
+
+1. Given a valid JWT token and a cover letter ID owned by the current user, when `GET /api/v1/cover-letters/{id}` is called, then `200 OK` with all fields: `id`, `content`, `vacancyId`, `createdAt`, `updatedAt`, plus nested `vacancy` object with key fields (`id`, `title`, `company`, `workLocationType`, `location`).
+2. Given the cover letter does not exist, is soft-deleted, or belongs to another user, then `404 Not Found`.
+3. Given no JWT token, when `GET /api/v1/cover-letters/{id}` is called, then `401 Unauthorized`.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add specialized detail method to `ICoverLetterRepository` (AC: 1, 2)
+  - [ ] Add `GetDetailByIdAsync(Guid id, CancellationToken ct)` to `backend/src/JobNecto.Application/Interfaces/ICoverLetterRepository.cs` returning `CoverLetterDetailResult?`.
+  - [ ] Define `CoverLetterDetailResult` and nested `VacancyInCoverLetterResult` DTOs in `backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQuery.cs` (or a dedicated DTOs file in the same folder).
+  - [ ] Implement in `CoverLetterRepository`: JOIN cover letter with vacancy; return null if not found (let the handler/query handler throw `NotFoundException`).
+
+- [ ] Task 2: Create query and handler (AC: 1, 2)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQuery.cs` with `GetCoverLetterQuery` (`IRequest<CoverLetterDetailResult>`), `CoverLetterId`, `UserId` (JsonIgnore).
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQueryHandler.cs`: call `ICoverLetterRepository.GetDetailByIdAsync`; if null → throw `NotFoundException`; if `result.UserId != request.UserId` → throw `NotFoundException` (existence leakage prevention per Decision 7); return result.
+
+- [ ] Task 3: Add API endpoint (AC: 3)
+  - [ ] Add `[HttpGet("{id:guid}")]` action to `backend/src/JobNecto.API/Controllers/CoverLettersController.cs`.
+  - [ ] Extract `UserId`, dispatch `GetCoverLetterQuery`, return `Ok(result)`.
+  - [ ] `ProducesResponseType` for 200, 401, 404.
+
+- [ ] Task 4: Add tests (AC: 1–3)
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/CoverLetters/GetCoverLetterQueryHandlerTests.cs` — mock `ICoverLetterRepository`; test: owned letter → returns detail with nested vacancy, not found → NotFoundException, other-user letter → NotFoundException.
+  - [ ] In `backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersApiTests.cs` — add: no token → 401; valid GET → 200 with full nested vacancy; non-existent ID → 404; other-user ID → 404.
+
+- [ ] Task 5: Verification gates
+  - [ ] Build: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` — 0 warnings, 0 errors.
+  - [ ] Tests: `dotnet test backend/JobNecto.slnx` — all pass.
+
+## Dev Notes
+
+### Prerequisite: Story 5.2 Must Be Complete
+
+This story extends `ICoverLetterRepository` introduced in Story 5.2. Ensure `ICoverLetterRepository`, `UnitOfWork.CoverLetterRepository` type change, and `CoverLetterRepository` base implementation are all in place.
+
+### `GetDetailByIdAsync` Implementation Sketch
+
+```csharp
+public async Task<CoverLetterDetailResult?> GetDetailByIdAsync(Guid id, CancellationToken ct)
+{
+    var result = await _context.Set<CoverLetter>()
+        .AsNoTracking()
+        .Where(cl => cl.Id == id)
+        .Join(_context.Set<Vacancy>().AsNoTracking().IgnoreQueryFilters(),
+            cl => cl.VacancyId,
+            v => v.Id,
+            (cl, v) => new CoverLetterDetailResult
+            {
+                Id = cl.Id,
+                UserId = cl.UserId,
+                VacancyId = cl.VacancyId,
+                Content = cl.Content,
+                CreatedAt = cl.CreatedAt,
+                UpdatedAt = cl.UpdatedAt,
+                Vacancy = new VacancyInCoverLetterResult
+                {
+                    Id = v.Id,
+                    Title = v.Title,
+                    Company = v.Company,
+                    WorkLocationType = v.WorkLocationType,
+                    Location = v.Location,
+                }
+            })
+        .FirstOrDefaultAsync(ct);
+
+    return result;
+}
+```
+
+**Important**: Use `IgnoreQueryFilters()` on the Vacancy side of the JOIN. Per Story 5.5 AC: "if the vacancy is later deleted, the cover letter is still returned with vacancyId preserved." Since `VacancyId` FK in `CoverLetterConfiguration` is `ON DELETE CASCADE`, when a vacancy is hard-deleted, its cover letters are also hard-deleted — so this edge case won't occur in practice. But if soft-delete is used for vacancies, the global query filter would hide the vacancy from the JOIN, resulting in no join result. Use `IgnoreQueryFilters()` on the vacancy query to handle this safely.
+
+### Response DTOs
+
+```csharp
+public class CoverLetterDetailResult
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }        // used for ownership check in handler, not returned to client
+    public Guid VacancyId { get; set; }
+    public string Content { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public VacancyInCoverLetterResult Vacancy { get; set; } = null!;
+}
+
+public class VacancyInCoverLetterResult
+{
+    public Guid Id { get; set; }
+    public string? Title { get; set; }
+    public string? Company { get; set; }
+    public WorkLocationType? WorkLocationType { get; set; }
+    public Location? Location { get; set; }
+}
+```
+
+The `UserId` field on `CoverLetterDetailResult` is used internally for the ownership check in the handler. Do NOT serialize it in the JSON response — add `[JsonIgnore]` or use a separate internal DTO and a public API-facing DTO.
+
+### Ownership: 404 Not 403
+
+Per Decision 7 and the AC: cross-user detail reads return `404 Not Found` (not `403`) to prevent existence leakage. This is consistent with `GetCoverLetterTemplateQueryHandler` and `GetVacancyQueryHandler`.
+
+### Files to Read Before Implementation
+
+- `backend/src/JobNecto.Application/Interfaces/ICoverLetterRepository.cs` (created in Story 5.2)
+- `backend/src/JobNecto.Application/CoverLetterTemplates/GetCoverLetterTemplateQueryHandler.cs` (404 ownership pattern)
+- `backend/src/JobNecto.Application/Vacancies/GetVacancyQueryHandler.cs` (nested DTO pattern)
+- `backend/src/JobNecto.Domain/Entities/Vacancy.cs` (to confirm which fields to include in nested DTO)
+- `backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs`
+
+### Project Structure Notes
+
+- `CoverLetterDetailResult` and `VacancyInCoverLetterResult` in `backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQuery.cs`.
+- Handler in `backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQueryHandler.cs`.
+- Namespace: `JobNecto.Application.CoverLetters`.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md` — Story 5.3]
+- [Source: `_bmad-output/planning-artifacts/epics/requirements-inventory.md` — FR21]
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` — Decision 3, 7]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Completion Notes List
+
+- Extends `ICoverLetterRepository` from Story 5.2 — that story must be complete first.
+- `IgnoreQueryFilters()` on vacancy side of JOIN handles soft-deleted vacancy edge case.
+- `UserId` on detail result is internal-only for ownership check — must NOT be serialized.
+- `templateId` is not persisted or returned — no field on `CoverLetter` entity or in the response DTO.
+- `WorkLocationType` uses `JsonStringEnumConverter` (registered globally in `Program.cs` per agent-learnings).
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-3-get-cover-letter-detail.md` (this file)

--- a/_bmad-output/implementation-artifacts/5-4-update-cover-letter-content.md
+++ b/_bmad-output/implementation-artifacts/5-4-update-cover-letter-content.md
@@ -1,0 +1,129 @@
+# Story 5.4: Update Cover Letter Content
+
+Status: ready-for-dev
+
+## Story
+
+As a job seeker,
+I want to edit the content of an existing cover letter,
+so that I can refine my application before submitting.
+
+## Acceptance Criteria
+
+1. Given a valid JWT token and `PATCH /api/v1/cover-letters/{id}` with new `content`, when the request is processed, then `200 OK` with updated cover letter; `updatedAt` refreshed.
+2. Given `vacancyId` is included in the PATCH body, when the request is processed, then it is silently ignored — `vacancyId` is immutable after creation.
+3. Given updated `content` violates 50–10000 char bounds, then `400 Bad Request` with field-level error on `content`.
+4. Given the cover letter belongs to another user, then `403 Forbidden`.
+5. Given the cover letter does not exist or is soft-deleted, then `404 Not Found`.
+6. Given no JWT token, when `PATCH /api/v1/cover-letters/{id}` is called, then `401 Unauthorized`.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create command, DTO, and handler (AC: 1, 2, 4, 5)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/UpdateCoverLetterCommand.cs` with `UpdateCoverLetterCommand` (`IRequest<CoverLetterUpdateResult>`) and `CoverLetterUpdateResult` DTO. Fields on command: `CoverLetterId` (set from route, JsonIgnore on route), `UserId` (JsonIgnore), `Content`.
+  - [ ] **Do NOT include `VacancyId`** in the command — omitting it entirely enforces immutability without needing to silently ignore it at the model-binding layer.
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/UpdateCoverLetterCommandHandler.cs`: get cover letter via `GetByIdAsync`; if `coverLetter.UserId != request.UserId` → throw `ForbiddenException`; update `Content`; call `UpdateAsync`; call `SaveChangesAsync`; return updated DTO.
+  - [ ] Set `UpdatedAt = DateTime.UtcNow` explicitly in the handler before calling `UpdateAsync` (per agent-learnings: do not rely on DB defaults).
+  - [ ] Add `ToEntity` / `ToUpdateResult` mapper extensions in `backend/src/JobNecto.Application/CoverLetters/Mappers/CoverLetterMappers.cs`.
+
+- [ ] Task 2: Create validator (AC: 3)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/Validators/UpdateCoverLetterCommandValidator.cs`.
+  - [ ] Rule: `Content` length 50–10000, `NotEmpty()`, not whitespace-only.
+
+- [ ] Task 3: Add API endpoint (AC: 6)
+  - [ ] Add `[HttpPatch("{id:guid}")]` action to `backend/src/JobNecto.API/Controllers/CoverLettersController.cs`.
+  - [ ] Bind `id` from route → `command.CoverLetterId = id`; inject `UserId` from JWT → `command.UserId = userId`.
+  - [ ] `ProducesResponseType` for 200, 400, 401, 403, 404.
+
+- [ ] Task 4: Add tests (AC: 1–6)
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/CoverLetters/UpdateCoverLetterCommandHandlerTests.cs` — mock `IUnitOfWork`; test: valid update → success with refreshed updatedAt, other-user → ForbiddenException, not found → NotFoundException.
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/CoverLetters/UpdateCoverLetterCommandValidatorTests.cs` — test content boundaries (49, 50, 10000, 10001 chars), empty/whitespace content.
+  - [ ] In `backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersApiTests.cs` — add: no token → 401; valid PATCH → 200 with updated content and refreshed `updatedAt`; content too short → 400; other-user ID → 403; non-existent ID → 404.
+
+- [ ] Task 5: Verification gates
+  - [ ] Build: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` — 0 warnings, 0 errors.
+  - [ ] Tests: `dotnet test backend/JobNecto.slnx` — all pass.
+
+## Dev Notes
+
+### VacancyId Immutability
+
+AC 2 says `vacancyId` in the PATCH body is "silently ignored." The cleanest way to enforce this is to **not include `VacancyId` in `UpdateCoverLetterCommand`** at all. If `vacancyId` appears in the JSON body, the model binder simply ignores unknown properties (default ASP.NET Core behavior). No explicit handling needed.
+
+Do NOT add a `VacancyId` field and then blank it — that invites accidental mutation bugs.
+
+### 403 vs 404 Ownership Semantics
+
+Per AC 4 and Decision 7: cover letter update returns **`403 Forbidden`** (not `404`) for cross-user access. This differs from read endpoints (which return `404` to prevent existence leakage). Update/delete mutations explicitly acknowledge existence but deny modification — consistent with `UpdateResumeCommandHandler` and `UpdateEducationCommandHandler`.
+
+Pattern:
+
+```csharp
+var coverLetter = await _unitOfWork.CoverLetterRepository.GetByIdAsync(request.CoverLetterId, ct);
+// GetByIdAsync throws NotFoundException if not found (AC 5 covered automatically)
+
+if (coverLetter.UserId != request.UserId)
+    throw new ForbiddenException("You do not have permission to update this cover letter.");
+
+coverLetter.Content = request.Content;
+coverLetter.UpdatedAt = DateTime.UtcNow;
+
+await _unitOfWork.CoverLetterRepository.UpdateAsync(coverLetter, ct);
+await _unitOfWork.SaveChangesAsync(ct);
+```
+
+### `CoverLetterUpdateResult` DTO
+
+Return the full cover letter state (matches the AC "200 OK with updated cover letter"):
+
+```csharp
+public class CoverLetterUpdateResult
+{
+    public Guid Id { get; set; }
+    public Guid VacancyId { get; set; }
+    public string Content { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+```
+
+### `UpdateAsync` in Repository
+
+`IMutableRepository<CoverLetter>.UpdateAsync` is inherited from `EditableRepository<CoverLetter>`. Read the implementation to confirm it tracks the entity and calls `SaveChanges` or relies on the UoW — do not call it if the entity is already tracked by EF (depends on implementation; check `EditableRepository.cs`).
+
+### Files to Read Before Implementation
+
+- `backend/src/JobNecto.Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandler.cs` (403 pattern)
+- `backend/src/JobNecto.Infrastructure/Repositories/EditableRepository.cs` (`UpdateAsync` implementation)
+- `backend/src/JobNecto.Application/CoverLetters/Mappers/CoverLetterMappers.cs` (created in Story 5.1 — add new mapper here)
+- `backend/src/JobNecto.Application/Exceptions/ForbiddenException.cs`
+- `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/UpdateCoverLetterTemplateCommandHandlerTests.cs` (test pattern)
+
+### Project Structure Notes
+
+- New files: `UpdateCoverLetterCommand.cs`, `UpdateCoverLetterCommandHandler.cs`, `Validators/UpdateCoverLetterCommandValidator.cs`.
+- All under `backend/src/JobNecto.Application/CoverLetters/` and sub-folders.
+- Namespace: `JobNecto.Application.CoverLetters`, `JobNecto.Application.CoverLetters.Validators`.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md` — Story 5.4]
+- [Source: `_bmad-output/planning-artifacts/epics/requirements-inventory.md` — FR22, NFR2]
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` — Decision 2, 6, 7]
+- [Source: `_bmad-output/agent-learnings.md` — timestamp in handlers, 403 vs 404 semantics]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Completion Notes List
+
+- VacancyId immutability enforced by omitting the field from the command (not by ignoring it).
+- 403 Forbidden for cross-user update (not 404) — consistent with Update/Delete handlers for Resume/Education.
+- `UpdatedAt` must be set explicitly in handler (per agent-learnings: DB defaults not reliable in-memory tests).
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-4-update-cover-letter-content.md` (this file)

--- a/_bmad-output/implementation-artifacts/5-5-delete-cover-letter.md
+++ b/_bmad-output/implementation-artifacts/5-5-delete-cover-letter.md
@@ -1,0 +1,118 @@
+# Story 5.5: Delete Cover Letter
+
+Status: ready-for-dev
+
+## Story
+
+As a job seeker,
+I want to soft-delete a cover letter I no longer need,
+so that my application history stays organized without permanent loss.
+
+## Acceptance Criteria
+
+1. Given a valid JWT token and a cover letter ID owned by the current user, when `DELETE /api/v1/cover-letters/{id}` is called, then `204 No Content`; soft-delete applied.
+2. Given `GET /api/v1/cover-letters` or `GET /api/v1/cover-letters/{id}` is called after deletion, then the cover letter is no longer visible.
+3. Given the vacancy this cover letter referenced is later deleted, when `GET /api/v1/cover-letters/{id}` is called for the cover letter before its own deletion, then the cover letter is still returned with `vacancyId` preserved.
+4. Given the cover letter belongs to another user, when `DELETE /api/v1/cover-letters/{id}` is called, then `403 Forbidden`.
+5. Given the cover letter does not exist or is soft-deleted, when `DELETE /api/v1/cover-letters/{id}` is called, then `404 Not Found`.
+6. Given no JWT token, when `DELETE /api/v1/cover-letters/{id}` is called, then `401 Unauthorized`.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create command and handler (AC: 1, 2, 4, 5)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/DeleteCoverLetterCommand.cs` with `DeleteCoverLetterCommand` (`IRequest<Unit>`), `CoverLetterId`, `UserId` (JsonIgnore).
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/DeleteCoverLetterCommandHandler.cs`: get cover letter via `GetByIdAsync`; if `coverLetter.UserId != request.UserId` → throw `ForbiddenException`; call `SoftDeleteAsync`; call `SaveChangesAsync`; return `Unit.Value`.
+  - [ ] No DTO needed — returns `Unit`.
+
+- [ ] Task 2: Create validator (minimal, AC: 1)
+  - [ ] Create `backend/src/JobNecto.Application/CoverLetters/Validators/DeleteCoverLetterCommandValidator.cs` — validate `CoverLetterId` is not empty, `UserId` is not empty.
+
+- [ ] Task 3: Add API endpoint (AC: 6)
+  - [ ] Add `[HttpDelete("{id:guid}")]` action to `backend/src/JobNecto.API/Controllers/CoverLettersController.cs`.
+  - [ ] Extract `UserId`, dispatch `DeleteCoverLetterCommand { CoverLetterId = id, UserId = userId }`, return `NoContent()`.
+  - [ ] `ProducesResponseType` for 204, 401, 403, 404.
+
+- [ ] Task 4: Add tests (AC: 1–6)
+  - [ ] Create `backend/tests/JobNecto.Tests/Application/CoverLetters/DeleteCoverLetterCommandHandlerTests.cs` — mock `IUnitOfWork`; test: valid delete → `SoftDeleteAsync` called + `SaveChangesAsync` called, other-user → ForbiddenException, not found → NotFoundException.
+  - [ ] In `backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersApiTests.cs` — add: no token → 401; valid DELETE → 204; deleted letter no longer appears in GET list; deleted letter returns 404 on GET detail; other-user ID → 403.
+
+- [ ] Task 5: Verification gates
+  - [ ] Build: `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror` — 0 warnings, 0 errors.
+  - [ ] Tests: `dotnet test backend/JobNecto.slnx` — all pass.
+  - [ ] Run full CI parity: `dotnet test backend/JobNecto.slnx --configuration Release --warnaserror`.
+
+## Dev Notes
+
+### Soft Delete via `SoftDeleteAsync`
+
+Per Decision 6 and story R.1: use `IMutableRepository<CoverLetter>.SoftDeleteAsync(entity, ct)`. The flag-setting (`IsDeleted = true`, `DeletedAt = DateTime.UtcNow`) is handled inside `SoftDeletableRepository<T>`. The handler only calls `SoftDeleteAsync` and then `SaveChangesAsync`.
+
+```csharp
+public async Task<Unit> Handle(DeleteCoverLetterCommand request, CancellationToken ct)
+{
+    var coverLetter = await _unitOfWork.CoverLetterRepository.GetByIdAsync(request.CoverLetterId, ct);
+
+    if (coverLetter.UserId != request.UserId)
+        throw new ForbiddenException("You do not have permission to delete this cover letter.");
+
+    await _unitOfWork.CoverLetterRepository.SoftDeleteAsync(coverLetter, ct);
+    await _unitOfWork.SaveChangesAsync(ct);
+
+    return Unit.Value;
+}
+```
+
+### 403 vs 404
+
+Same semantics as Story 5.4: DELETE returns **`403 Forbidden`** for cross-user (not 404). Consistent with `DeleteResumeCommandHandler` and `DeleteCoverLetterTemplateCommandHandler`.
+
+### AC 3: Vacancy Deletion Edge Case
+
+AC 3 ("vacancy is later deleted → cover letter still returns with vacancyId") is **informational context** only. The implementation doesn't require special code here because:
+- If the vacancy is **soft-deleted**: the cover letter still exists; `GetDetailByIdAsync` uses `IgnoreQueryFilters()` on the vacancy side (implemented in Story 5.3), so the cover letter detail is still returned.
+- If the vacancy is **hard-deleted**: `CoverLetterConfiguration` has `ON DELETE CASCADE` on `VacancyId` FK — the cover letter is also hard-deleted. This means AC 3 (before its own deletion) is satisfied automatically since the cover letter would already be gone.
+
+No special implementation needed for this AC — it is covered by the Story 5.3 `IgnoreQueryFilters()` design. Add a comment in the handler or a test note explaining this.
+
+### EF Global Query Filter
+
+The `CoverLetter` entity has `HasQueryFilter(cl => !cl.IsDeleted)` in `AppDbContext`. After soft-delete, `GetByIdAsync` will throw `NotFoundException` (filtered out) — so AC 2 (letter no longer visible after delete) is automatically satisfied by the global filter.
+
+### Existing Pattern Reference
+
+Follow `DeleteCoverLetterTemplateCommandHandler.cs` exactly for the handler structure.
+
+### Files to Read Before Implementation
+
+- `backend/src/JobNecto.Application/CoverLetterTemplates/DeleteCoverLetterTemplateCommandHandler.cs`
+- `backend/src/JobNecto.Infrastructure/Repositories/SoftDeletableRepository.cs` (`SoftDeleteAsync` implementation)
+- `backend/src/JobNecto.Application/Exceptions/ForbiddenException.cs`
+- `backend/tests/JobNecto.Tests/Application/CoverLetterTemplates/DeleteCoverLetterTemplateCommandHandlerTests.cs` (test pattern)
+
+### Project Structure Notes
+
+- New files: `DeleteCoverLetterCommand.cs`, `DeleteCoverLetterCommandHandler.cs`, `Validators/DeleteCoverLetterCommandValidator.cs`.
+- All under `backend/src/JobNecto.Application/CoverLetters/` and sub-folders.
+- Namespace: `JobNecto.Application.CoverLetters`, `JobNecto.Application.CoverLetters.Validators`.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md` — Story 5.5]
+- [Source: `_bmad-output/planning-artifacts/epics/requirements-inventory.md` — FR23, NFR5]
+- [Source: `_bmad-output/planning-artifacts/architecture/core-architectural-decisions.md` — Decision 6, 7]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Completion Notes List
+
+- AC 3 (vacancy deleted edge case) requires no special implementation — covered by `IgnoreQueryFilters()` in Story 5.3 and cascade delete behavior.
+- 403 for cross-user delete (not 404) — consistent with all mutation handlers.
+- `SoftDeleteAsync` sets `IsDeleted` and `DeletedAt` internally — handler does not set them directly.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-5-delete-cover-letter.md` (this file)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18T00:00:00.000Z
-# last_updated: 2026-05-10T12:00:00Z
+# last_updated: 2026-05-10T14:00:00Z
 # project: Jobnecto
 # project_key: NOKEY
 # tracking_system: file-system
@@ -77,10 +77,10 @@ development_status:
   epic-4-retrospective: done
 
   # --- Epic 5: Cover Letter Application Management ---
-  epic-5: backlog
-  5-1-create-cover-letter: backlog
-  5-2-list-cover-letters: backlog
-  5-3-get-cover-letter-detail: backlog
-  5-4-update-cover-letter-content: backlog
-  5-5-delete-cover-letter: backlog
+  epic-5: in-progress
+  5-1-create-cover-letter: ready-for-dev
+  5-2-list-cover-letters: ready-for-dev
+  5-3-get-cover-letter-detail: ready-for-dev
+  5-4-update-cover-letter-content: ready-for-dev
+  5-5-delete-cover-letter: ready-for-dev
   epic-5-retrospective: optional

--- a/_bmad-output/planning-artifacts/architecture/post-merge-implementation-status-2026-04-30.md
+++ b/_bmad-output/planning-artifacts/architecture/post-merge-implementation-status-2026-04-30.md
@@ -11,4 +11,3 @@
 - DB Command Timing: Added `DbCommandTimingInterceptor` to JobNecto.Infrastructure to monitor and log slow database queries (merged in story 2-4).
 - Epic 2 retrospective is complete and identifies the architecture as stable, with follow-up decisions needed for ownership-aware single-record reads and timestamp/clock policy. Epic 3 now enforces database-backed template-name uniqueness with concurrent collision coverage in tests and includes delete coverage for template lifecycle completion.
 - Current verification caveat: the Epic 2 retrospective recorded local `dotnet test backend/JobNecto.slnx` and Release build attempts failing without useful diagnostics. Treat implementation logs as positive evidence, but diagnose local solution-runner behavior before relying on a fresh green gate.
-

--- a/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
+++ b/_bmad-output/planning-artifacts/epics/epic-5-cover-letter-application-management.md
@@ -20,10 +20,6 @@ So that I can submit a tailored application.
 **When** the request is processed
 **Then** `201 Created` with the cover letter object; `Location` header set to `/api/v1/cover-letters/{id}`
 
-**Given** optional `templateId` is provided and belongs to the current user
-**When** the request is processed
-**Then** `templateId` is persisted on the cover letter; content is whatever the user provided (not auto-filled)
-
 **Given** the user already has a (non-deleted) cover letter for the same `vacancyId`
 **When** `POST /api/v1/cover-letters` is called again with the same `vacancyId`
 **Then** `409 Conflict` from database-backed per-user/per-vacancy uniqueness enforcement
@@ -31,10 +27,6 @@ So that I can submit a tailored application.
 **Given** `vacancyId` references a vacancy that does not exist
 **When** the request is processed
 **Then** `404 Not Found` with detail referencing the vacancy
-
-**Given** `templateId` is provided but does not exist or belongs to another user
-**When** the request is processed
-**Then** `404 Not Found` with detail referencing the template
 
 **Given** `content` is fewer than 50 or more than 10000 characters
 **When** the request is processed
@@ -75,7 +67,7 @@ So that I can review or edit what I've written.
 
 **Given** a valid JWT token and a cover letter ID owned by the current user
 **When** `GET /api/v1/cover-letters/{id}` is called
-**Then** `200 OK` with all fields: `id`, `content`, `vacancyId`, `templateId` (nullable), `createdAt`, `updatedAt`, plus nested `vacancy` object with key fields
+**Then** `200 OK` with all fields: `id`, `content`, `vacancyId`, `createdAt`, `updatedAt`, plus nested `vacancy` object with key fields
 
 **Given** the cover letter does not exist, is soft-deleted, or belongs to another user
 **Then** `404 Not Found`

--- a/_bmad-output/planning-artifacts/epics/requirements-inventory.md
+++ b/_bmad-output/planning-artifacts/epics/requirements-inventory.md
@@ -1,6 +1,6 @@
 # Requirements Inventory
 
-### Functional Requirements
+## Functional Requirements
 
 FR1: User can create a new account with `loginName`, `email`, `password`, and optional profile fields (`phone`, `location`, `about`, `avatar`) via `POST /api/v1/users`; returns `201 Created` with user object (excluding password).
 FR2: User can retrieve their core profile fields via `GET /api/v1/users/me`; related resources (resumes, educations, cover letters) are retrieved through dedicated user-scoped endpoints; returns `200 OK`.
@@ -20,9 +20,9 @@ FR15: User can list their cover letter templates (paginated, searchable by `name
 FR16: User can retrieve a single cover letter template with full `content` via `GET /api/v1/cover-letter-templates/{id}`; returns `404` if not found.
 FR17: User can update a cover letter template's `name` or `content` via `PATCH /api/v1/cover-letter-templates/{id}`; name uniqueness re-validated if changed; returns `200 OK`.
 FR18: User can soft-delete a cover letter template via `DELETE /api/v1/cover-letter-templates/{id}`; returns `204 No Content`.
-FR19: User can create a job-specific cover letter with `vacancyId` (required, must exist), `content` (50-10000 chars), and optional `templateId` via `POST /api/v1/cover-letters`; one letter per vacancy per user; returns `201 Created`.
+FR19: User can create a job-specific cover letter with `vacancyId` (required, must exist) and `content` (50-10000 chars) via `POST /api/v1/cover-letters`; one letter per vacancy per user; returns `201 Created`.
 FR20: User can list their cover letters (paginated, ordered by `createdAt desc`) via `GET /api/v1/cover-letters`; includes `vacancyTitle` from linked vacancy; returns `200 OK`.
-FR21: User can retrieve a single cover letter with full `content`, `vacancyId`, `templateId`, and linked vacancy details via `GET /api/v1/cover-letters/{id}`; returns `404` if not found.
+FR21: User can retrieve a single cover letter with full `content`, `vacancyId`, and linked vacancy details via `GET /api/v1/cover-letters/{id}`; returns `404` if not found.
 FR22: User can update cover letter `content` (cannot change `vacancyId` after creation) via `PATCH /api/v1/cover-letters/{id}`; returns `200 OK`.
 FR23: User can soft-delete a cover letter via `DELETE /api/v1/cover-letters/{id}`; returns `204 No Content`.
 FR24: Authenticated user can browse their own paginated vacancies (default 20, max 100) via `POST /api/v1/vacancies/filter` using empty criteria (`{}`); default ordering is `createdAt desc`, optional `sortBy` supports `updatedAt` and `relevance` (alias of `updatedAt`); returns `200 OK` with `{ totalCount, pageSize, hasNext, lastSeenId, lastSeenUpdatedAt, items }`.

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -53,7 +53,7 @@ The **enabling insight** is that LLMs in 2026 are now smart, reliable, and acces
 ### Project Classification
 
 | Attribute | Value |
-|-----------|-------|
+| --------- | ----- |
 | **Project Type** | API Backend (REST). |
 | **Domain** | HR Tech / Recruitment (job aggregation and matching). |
 | **Complexity** | Medium (multi-domain entities, third-party integrations, intelligent filtering). |
@@ -64,6 +64,7 @@ The **enabling insight** is that LLMs in 2026 are now smart, reliable, and acces
 ### User Success
 
 A job seeker can:
+
 - Create a profile with education, resumes, and cover letter templates
 - Manage (create, read, update, soft delete) their profile data, resumes, educations, and cover letter templates
 - View a paginated, filterable list of vacancies (read-only until Phase C auth)
@@ -107,17 +108,18 @@ A job seeker can:
 - **Mapping Consistency**: Standardized the use of `<Entity>Mappers` in Application feature slices to handle DTO↔Entity transformations, ensuring 100% decoupling between API contracts and Domain models.
 - **Generic Repository Usage**: Leveraging `IEditableRepository<T>` for Resume and Education to reuse the established `GetAsync(PagedQuery)` pattern which handles automated `UserId` scoping and soft-delete filtering.
 
-2. ≥ 85% code coverage on Application handlers and validators
-3. Zero breaking changes to Domain model entities post-Phase B
-4. OpenAPI spec includes all endpoints, request/response schemas, status codes (200, 400, 404, 500)
-5. Database supports test-driven setup: migrations allow fresh DB creation and teardown per test run
-6. Documentation: API versioning strategy documented in README or API docs
+1. ≥ 85% code coverage on Application handlers and validators
+2. Zero breaking changes to Domain model entities post-Phase B
+3. OpenAPI spec includes all endpoints, request/response schemas, status codes (200, 400, 404, 500)
+4. Database supports test-driven setup: migrations allow fresh DB creation and teardown per test run
+5. Documentation: API versioning strategy documented in README or API docs
 
 ## Product Scope
 
 ### MVP - Minimum Viable Product (Phase B)
 
 **Core Resources:**
+
 - **User profiles** — Create profile, retrieve/update current user core fields only (GET `/api/v1/users/me`, PATCH `/api/v1/users/me`)
 - **Resumes** — CRUD operations (GET list, POST create, GET detail, PATCH update, DELETE soft)
 - **Educations** — CRUD operations linked to user (GET list, POST create, GET detail, PATCH update, DELETE soft)
@@ -127,12 +129,14 @@ A job seeker can:
   - **Vacancy Filtering** — Complex multi-criteria filtering via POST `/api/v1/vacancies/filter` with request body (skills, location, salary range, work location type, etc.)
 
 **Validation Requirements:**
+
 - Email validation (valid format)
 - Phone validation (E.164 format per domain model)
 - Age validation per EF rules
 - Proper HTTP status codes: 200 (success), 400 (validation error), 404 (not found), 500 (server error)
 
 **Database & Architecture:**
+
 - Migrations for all new entities and relationships
 - `AddInfrastructure()` wired in `Program.cs`
 - UnitOfWork pattern supporting transactional integrity
@@ -192,6 +196,7 @@ A job seeker can:
 
 1. **Browse All Recent Vacancies** → GET `/api/v1/vacancies?page=1&pageSize=20` (see recent postings)
 2. **Apply Complex Filters** → POST `/api/v1/vacancies/filter` with request body:
+
    ```json
    {
      "skills": ["C#", "Azure"],
@@ -202,6 +207,7 @@ A job seeker can:
      "pageSize": 20
    }
    ```
+
    (apply multi-criteria filtering without URL query string pollution)
 3. **Paginate Results** → POST `/api/v1/vacancies/filter` with `page: 2` (load more results)
 4. **View Vacancy Details** → GET `/api/v1/vacancies/{id}` (read full job description, requirements, match score)
@@ -218,12 +224,14 @@ A job seeker can:
 1. **Review Vacancy** → GET `/api/v1/vacancies/{id}` (understand job requirements)
 2. **Retrieve Relevant Template** → GET `/api/v1/cover-letter-templates/{templateId}` (get starting point)
 3. **Create Job-Specific Cover Letter** → POST `/api/v1/cover-letters` with body:
+
    ```json
    {
      "vacancyId": "vacancy-123",
      "content": "Customized content based on template..."
    }
    ```
+
    (create instance for this specific vacancy)
 4. **Retrieve Cover Letter** → GET `/api/v1/cover-letters/{letterId}` (review before sending)
 5. **Update Cover Letter** → PATCH `/api/v1/cover-letters/{letterId}` (refine based on feedback)
@@ -257,13 +265,15 @@ A job seeker can:
 **Purpose:** Manage job seeker identity, contact information, and professional summary.
 
 **Endpoints:**
+
 - `GET /api/v1/users/me` — Retrieve current user core profile fields only
 - `PATCH /api/v1/users/me` — Update current user profile
 - `POST /api/v1/users` — Create new user account
 
-**Feature: Create User Profile (POST /api/v1/users)**
+#### Feature: Create User Profile (POST /api/v1/users)
 
 **Acceptance Criteria:**
+
 - User can register with `loginName`, `email`, `password`, and optional profile fields (`phone`, `location`, `about`, `avatar`)
 - Email validation: must be valid email format; must be unique across the system
 - Phone validation (if provided): must be valid E.164 format (e.g., `+1234567890`)
@@ -275,6 +285,7 @@ A job seeker can:
 - On duplicate email/loginName: return `409 Conflict` with message
 
 **Validation Rules:**
+
 - `email`: Required, valid format, unique
 - `loginName`: Required, 3-20 chars, alphanumeric + underscore, unique
 - `password`: Required, minimum 8 characters; persisted values must be one-way salted hashes
@@ -282,15 +293,17 @@ A job seeker can:
 - `avatar`: Optional, URL or base64 data
 
 **Edge Cases:**
+
 - Subdomain-style emails (e.g., `user+label@example.com`) are valid
 - Phone with country code required (e.g., `+1` for US)
 - Duplicate email attempt after another user created account moments before
 
 ---
 
-**Feature: Retrieve Current User (GET /api/v1/users/me)**
+#### Feature: Retrieve Current User (GET /api/v1/users/me)
 
 **Acceptance Criteria:**
+
 - Return current user core profile fields only: `id`, `loginName`, `email`, `phone`, `location`, `about`, `avatar`, `createdAt`, `updatedAt`
 - Exclude sensitive fields (password hash, tokens)
 - Related resources are retrieved via dedicated user-scoped routes (`/api/v1/resumes`, `/api/v1/educations`, `/api/v1/cover-letters`)
@@ -298,7 +311,8 @@ A job seeker can:
 - If JWT references non-existing user: return `404 Not Found`
 - On unauthorized (Phase C): return `401 Unauthorized`
 
-**Response Shape (Phase B, no auth yet):**
+### Response Shape (Phase B, no auth yet)
+
 ```json
 {
   "id": "uuid",
@@ -315,9 +329,10 @@ A job seeker can:
 
 ---
 
-**Feature: Update User Profile (PATCH /api/v1/users/me)**
+#### Feature: Update User Profile (PATCH /api/v1/users/me)
 
 **Acceptance Criteria:**
+
 - Update any profile field: `email`, `phone`, `location`, `about`, `avatar`
 - Can change `loginName`; must remain unique system-wide; return `409 Conflict` if new value already taken
 - Cannot change `id`, `createdAt` (immutable system fields)
@@ -336,13 +351,14 @@ A job seeker can:
 **Purpose:** Store resume templates with skills, experience expectations, and preferred work conditions.
 
 **Endpoints:**
+
 - `GET /api/v1/resumes` — List all resumes for current user (paginated)
 - `POST /api/v1/resumes` — Create new resume
 - `GET /api/v1/resumes/{id}` — Retrieve single resume detail
 - `PATCH /api/v1/resumes/{id}` — Update resume
 - `DELETE /api/v1/resumes/{id}` — Soft delete resume
 
-**Feature: Create Resume (POST /api/v1/resumes)**
+#### Feature: Create Resume (POST /api/v1/resumes)
 
 **Acceptance Criteria:**
 
@@ -377,9 +393,10 @@ A job seeker can:
 
 ---
 
-**Feature: List Resumes (GET /api/v1/resumes)**
+#### Feature: List Resumes (GET /api/v1/resumes)
 
 **Acceptance Criteria:**
+
 - Return paginated list of user's resumes
 - Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `title`, `skills` (array), `salary`, `currency`, `workLocationType`, `updatedAt`
@@ -388,9 +405,10 @@ A job seeker can:
 
 ---
 
-**Feature: Get Resume Detail (GET /api/v1/resumes/{id})**
+#### Feature: Get Resume Detail (GET /api/v1/resumes/{id})
 
 **Acceptance Criteria:**
+
 - Return full resume with all fields
 - If resume not found: return `404 Not Found`
 - If resume belongs to different user: return `403 Forbidden` (Phase C with auth)
@@ -398,9 +416,10 @@ A job seeker can:
 
 ---
 
-**Feature: Update Resume (PATCH /api/v1/resumes/{id})**
+#### Feature: Update Resume (PATCH /api/v1/resumes/{id})
 
 **Acceptance Criteria:**
+
 - Update any resume field
 - Partial updates allowed
 - Re-validate all fields same as POST
@@ -410,9 +429,10 @@ A job seeker can:
 
 ---
 
-**Feature: Delete Resume (DELETE /api/v1/resumes/{id})**
+#### Feature: Delete Resume (DELETE /api/v1/resumes/{id})
 
 **Acceptance Criteria:**
+
 - Soft delete: set `IsDeleted = true` or similar flag (don't physically remove from DB)
 - Return `204 No Content` on success
 - Resume no longer appears in list endpoints after soft delete
@@ -425,15 +445,17 @@ A job seeker can:
 **Purpose:** Store user's educational background (degrees, specializations, institutions).
 
 **Endpoints:**
+
 - `GET /api/v1/educations` — List all educations for current user
 - `POST /api/v1/educations` — Create new education record
 - `GET /api/v1/educations/{id}` — Retrieve single education
 - `PATCH /api/v1/educations/{id}` — Update education
 - `DELETE /api/v1/educations/{id}` — Soft delete education
 
-**Feature: Create Education (POST /api/v1/educations)**
+#### Feature: Create Education (POST /api/v1/educations)
 
 **Acceptance Criteria:**
+
 - Create with: `title` (degree name), `specialization` (field of study), `degree` (enum: bachelor, master, phd, postdoc, other)
 - Title: required, 1-100 characters
 - Specialization: required, 1-100 characters
@@ -443,9 +465,10 @@ A job seeker can:
 
 ---
 
-**Feature: List Educations (GET /api/v1/educations)**
+#### Feature: List Educations (GET /api/v1/educations)
 
 **Acceptance Criteria:**
+
 - Return paginated list of user's education records
 - Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `title`, `specialization`, `degree`, `createdAt`, `updatedAt`
@@ -455,9 +478,10 @@ A job seeker can:
 
 ---
 
-**Feature: Get Education Detail, Update, Delete**
+#### Feature: Get Education Detail, Update, Delete
 
 **Acceptance Criteria:** (Similar pattern to Resume)
+
 - GET `{id}`: return full education record with all fields
 - PATCH `{id}`: update any field, re-validate
 - DELETE `{id}`: soft delete
@@ -470,15 +494,17 @@ A job seeker can:
 **Purpose:** Store reusable cover letter templates that job seekers craft once and customize for each application.
 
 **Endpoints:**
+
 - `GET /api/v1/cover-letter-templates` — List all templates for current user (paginated, filterable)
 - `POST /api/v1/cover-letter-templates` — Create new template
 - `GET /api/v1/cover-letter-templates/{id}` — Retrieve single template
 - `PATCH /api/v1/cover-letter-templates/{id}` — Update template
 - `DELETE /api/v1/cover-letter-templates/{id}` — Soft delete template
 
-**Feature: Create Cover Letter Template (POST /api/v1/cover-letter-templates)**
+#### Feature: Create Cover Letter Template (POST /api/v1/cover-letter-templates)
 
 **Acceptance Criteria:**
+
 - Create with: `name` (template name), `content` (template text, may contain placeholders like {{companyName}}, {{role}})
 - Name: required, 1-100 characters, unique per user (two templates can't have same name for same user)
 - Content: required, minimum 50 characters, maximum 10000 characters
@@ -486,9 +512,10 @@ A job seeker can:
 
 ---
 
-**Feature: List Cover Letter Templates (GET /api/v1/cover-letter-templates)**
+#### Feature: List Cover Letter Templates (GET /api/v1/cover-letter-templates)
 
 **Acceptance Criteria:**
+
 - Return paginated list of user's templates
 - Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `name`, `contentPreview` (first 200 chars), `createdAt`, `updatedAt`
@@ -498,17 +525,19 @@ A job seeker can:
 
 ---
 
-**Feature: Get Template Detail (GET /api/v1/cover-letter-templates/{id})**
+#### Feature: Get Template Detail (GET /api/v1/cover-letter-templates/{id})
 
 **Acceptance Criteria:**
+
 - Return full template with complete `content`
 - If not found: return `404 Not Found`
 
 ---
 
-**Feature: Update Template (PATCH /api/v1/cover-letter-templates/{id})**
+#### Feature: Update Template (PATCH /api/v1/cover-letter-templates/{id})
 
 **Acceptance Criteria:**
+
 - Update `name` or `content` or both
 - Validate name uniqueness per user if name is being changed
 - Return `200 OK` with updated template
@@ -516,9 +545,10 @@ A job seeker can:
 
 ---
 
-**Feature: Delete Template (DELETE /api/v1/cover-letter-templates/{id})**
+#### Feature: Delete Template (DELETE /api/v1/cover-letter-templates/{id})
 
 **Acceptance Criteria:**
+
 - Soft delete
 - Return `204 No Content` on success
 - If not found: return `404 Not Found`
@@ -530,27 +560,29 @@ A job seeker can:
 **Purpose:** Store job-specific application cover letters, typically created from a template and customized for a particular vacancy.
 
 **Endpoints:**
+
 - `GET /api/v1/cover-letters` — List all cover letters for current user (paginated)
 - `POST /api/v1/cover-letters` — Create new cover letter for a vacancy
 - `GET /api/v1/cover-letters/{id}` — Retrieve single cover letter
 - `PATCH /api/v1/cover-letters/{id}` — Update cover letter
 - `DELETE /api/v1/cover-letters/{id}` — Soft delete cover letter
 
-**Feature: Create Cover Letter (POST /api/v1/cover-letters)**
+#### Feature: Create Cover Letter (POST /api/v1/cover-letters)
 
 **Acceptance Criteria:**
-- Create with: `vacancyId` (required), `content` (required), `templateId` (optional, for tracking which template was the source)
-- VacancyId: must reference valid vacancy
+
+- Create with: `vacancyId` (required), `content` (required)
+- VacancyId: must reference valid vacancy belonging to current user
 - Content: required, minimum 50 characters, maximum 10000 characters
-- TemplateId: optional, if provided must be valid template belonging to user
 - One cover letter per vacancy per user (cannot create duplicate for same vacancy)
-- Return `201 Created` with cover letter object including `id`, `vacancyId`, `content`, `templateId`, `createdAt`, `updatedAt`
+- Return `201 Created` with cover letter object including `id`, `vacancyId`, `content`, `createdAt`, `updatedAt`
 
 ---
 
-**Feature: List Cover Letters (GET /api/v1/cover-letters)**
+#### Feature: List Cover Letters (GET /api/v1/cover-letters)
 
 **Acceptance Criteria:**
+
 - Return paginated list of user's cover letters
 - Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `vacancyId`, `vacancyTitle` (from linked Vacancy), `contentPreview` (first 200 chars), `createdAt`
@@ -559,27 +591,30 @@ A job seeker can:
 
 ---
 
-**Feature: Get Cover Letter Detail (GET /api/v1/cover-letters/{id})**
+#### Feature: Get Cover Letter Detail (GET /api/v1/cover-letters/{id})
 
 **Acceptance Criteria:**
-- Return full cover letter with complete `content`, `vacancyId`, `templateId`
+
+- Return full cover letter with complete `content`, `vacancyId`
 - Include vacancy details: title, company, description
 - If not found: return `404 Not Found`
 
 ---
 
-**Feature: Update Cover Letter (PATCH /api/v1/cover-letters/{id})**
+#### Feature: Update Cover Letter (PATCH /api/v1/cover-letters/{id})
 
 **Acceptance Criteria:**
+
 - Update `content` (cannot change `vacancyId` after creation)
 - Return `200 OK` with updated cover letter
 - Update `updatedAt` timestamp
 
 ---
 
-**Feature: Delete Cover Letter (DELETE /api/v1/cover-letters/{id})**
+#### Feature: Delete Cover Letter (DELETE /api/v1/cover-letters/{id})
 
 **Acceptance Criteria:**
+
 - Soft delete
 - Return `204 No Content` on success
 
@@ -590,13 +625,15 @@ A job seeker can:
 **Purpose:** Store job vacancy listings aggregated from external sources. Phase B: read-only with filtering. Phase D: syncing from job sources.
 
 **Endpoints:**
+
 - `GET /api/v1/vacancies` — List recent vacancies (basic pagination)
 - `POST /api/v1/vacancies/filter` — Advanced filtering with complex criteria
 - `GET /api/v1/vacancies/{id}` — Retrieve single vacancy detail
 
-**Feature: List Vacancies (GET /api/v1/vacancies)**
+#### Feature: List Vacancies (GET /api/v1/vacancies)
 
 **Acceptance Criteria:**
+
 - Return paginated list of all vacancies (recent first)
 - Query params: `pageSize` (default 20, max 100), `lastSeenId` (Guid, optional cursor), `lastSeenUpdatedAt` (DateTime, optional cursor)
 - Return array with: `id`, `title`, `company`, `location`, `jobSource`, `salary`, `currency`, `matchScore`, `createdAt`
@@ -605,9 +642,10 @@ A job seeker can:
 
 ---
 
-**Feature: Filter Vacancies (POST /api/v1/vacancies/filter)**
+#### Feature: Filter Vacancies (POST /api/v1/vacancies/filter)
 
 **Acceptance Criteria:**
+
 - Accept POST request with filter object in body (not query params)
 - Filter criteria: `skills` (array, match any), `location` (string, partial match), `salaryMin` (number), `salaryMax` (number), `workLocationTypes` (array: remote/office/hybrid), `categories` (array), `experienceLevel` (enum), `excludeKeywords` (array)
 - Pagination: `pageSize`, `lastSeenId`, `lastSeenUpdatedAt` (cursor) in filter body
@@ -617,6 +655,7 @@ A job seeker can:
 - Return `400 Bad Request` if filter is malformed
 
 **Sample Request Body:**
+
 ```json
 {
   "skills": ["C#", "Azure"],
@@ -636,9 +675,10 @@ A job seeker can:
 
 ---
 
-**Feature: Get Vacancy Detail (GET /api/v1/vacancies/{id})**
+#### Feature: Get Vacancy Detail (GET /api/v1/vacancies/{id})
 
 **Acceptance Criteria:**
+
 - Return full vacancy with all fields: `title`, `description`, `company`, `companyWebsite`, `location`, `salary`, `currency`, `categories` (array), `skills` (array), `workLocationType`, `workTimeType`, `experienceLevel`, `matchScore`, `jobSource` (object with `name` and optional `url`), `isChosen`, `isHidden`, `createdAt`, `updatedAt`
 - If not found: return `404 Not Found`
 - Match score: if present, display as a number 0-100 (or null if not yet calculated in Phase B)
@@ -659,6 +699,7 @@ A job seeker can:
 - `500 Internal Server Error` — Unhandled server error
 
 **Error Response Format:**
+
 ```json
 {
   "type": "https://api.jobnecto.dev/errors/validation",
@@ -678,7 +719,7 @@ A job seeker can:
 
 **Entity Relationship Overview:**
 
-```
+```text
 User (1)
 ├── (1:N) Resumes
 ├── (1:N) Educations
@@ -693,6 +734,7 @@ User (1)
 
 **Detailed Relationships:**
 
+```markdown
 | From | To | Type | Cardinality | Notes |
 |------|-----|------|-------------|-------|
 | User | Resume | Foreign Key | 1:N | Each resume belongs to one user. Deleting user soft-deletes all resumes. |
@@ -709,8 +751,8 @@ User (1)
 | When X is deleted | What happens to related records |
 |------------------|-------------------------------|
 | User | All resumes, educations, cover letters, templates → soft-deleted |
-| Resume | References removed from any CoverLetters (templateId becomes NULL) |
-| CoverLetterTemplate | References in CoverLetters become NULL (template is optional) |
+| Resume | No direct impact on CoverLetters |
+| CoverLetterTemplate | No direct impact on CoverLetters (template reference not persisted) |
 | Vacancy | CoverLetters referencing it are soft-deleted (application record removed) |
 | Education | ResumeEducations join records deleted; resume still exists |
 
@@ -753,6 +795,7 @@ Soft deletes are logical removals—data remains in the database but is marked a
 **Implementation Approach:**
 
 Use a `IsDeleted` boolean flag (or `DeletedAt` timestamp) on affected entities:
+
 - `Resume`, `Education`, `CoverLetter`, `CoverLetterTemplate` → add `IsDeleted` flag (or `DeletedAt` timestamp)
 - `Vacancy` → add `IsDeleted` flag (or `DeletedAt` timestamp)
 
@@ -782,6 +825,7 @@ This ensures soft-deleted records are never accidentally exposed.
 **Restore Capability:**
 
 Decision: **Can soft-deleted records be restored?**
+
 - For Phase B: Not a requirement; assume permanent once soft-deleted
 - For Phase C onward: Architect to support restoration (set `IsDeleted = false`), but not yet exposed in API
 
@@ -832,7 +876,7 @@ Phase B development assumes Phase A is **complete**:
 **Uniqueness Constraints:**
 
 | Entity | Field(s) | Unique Per | Notes |
-|--------|----------|-----------|-------|
+| --- | --- | --- | --- |
 | User | `loginName` | System-wide | Case-insensitive |
 | User | `email` | System-wide | Case-insensitive |
 | Resume | `title` | Per user | Same user cannot have 2 resumes with same title |
@@ -844,7 +888,7 @@ All uniqueness rules above must be enforced by database-level unique constraints
 **Referential Integrity:**
 
 - `CoverLetter.VacancyId` → must exist in `Vacancy` table (no orphaned letters)
-- `CoverLetter.TemplateId` → optional; if present, must exist and belong to same user
+- `CoverLetter.VacancyId` → must exist in `Vacancy` table and belong to the same user (no orphaned letters)
 - `ResumeEducations.ResumeId` → must exist in `Resume` table
 - `ResumeEducations.EducationId` → must exist in `Education` table
 
@@ -857,19 +901,23 @@ See Feature Requirements & Acceptance Criteria section for detailed field-level 
 ## Non-Functional Requirements
 
 **API Response Time:**
+
 - List endpoints: < 200ms for typical 20-item page
 - Detail endpoints: < 100ms
 - Filter endpoint: < 500ms for complex multi-criteria filter (depends on dataset size)
 
 **Data Availability:**
+
 - CRUD operations should not fail due to database unavailability in Phase B (error handling in Phase E)
 
 **Pagination Limits:**
+
 - `pageSize` minimum: 1
 - `pageSize` maximum: 100 (prevent abuse)
 - Default: 20 items per page
 
 **Request Limits:**
+
 - Request body size: max 1MB (prevents abuse)
 - Content validation per field documented in Feature Requirements
 

--- a/backend/src/JobNecto.API/Controllers/CoverLettersController.cs
+++ b/backend/src/JobNecto.API/Controllers/CoverLettersController.cs
@@ -1,0 +1,191 @@
+using JobNecto.API.Infrastructure;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Domain.ValueObjects;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JobNecto.API.Controllers;
+
+/// <summary>
+/// Controller for managing cover letters.
+/// </summary>
+[ApiController]
+[Route("api/v1/cover-letters")]
+[Authorize]
+public class CoverLettersController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CoverLettersController"/> class.
+    /// </summary>
+    /// <param name="mediator">MediatR dispatcher.</param>
+    public CoverLettersController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Returns detail data for a single cover letter belonging to the authenticated user.
+    /// </summary>
+    /// <param name="id">Cover letter identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Cover letter detail response.</returns>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(CoverLetterDetailResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<CoverLetterDetailResult>> GetByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        var query = new GetCoverLetterQuery
+        {
+            CoverLetterId = id,
+            UserId = userId,
+        };
+
+        var result = await _mediator.Send(query, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Returns a cursor-paginated list of cover letters belonging to the current authenticated user.
+    /// Ordered by CreatedAt descending.
+    /// </summary>
+    /// <param name="pageSize">Number of items per page (default 20, max 100).</param>
+    /// <param name="lastSeenId">Cursor: ID of the last seen cover letter from the previous page.</param>
+    /// <param name="lastSeenUpdatedAt">Cursor timestamp field carrying CreatedAt for this endpoint.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Paginated list of cover letter list-item results.</returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(PagedResult<CoverLetterListItem>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<PagedResult<CoverLetterListItem>>> ListAsync(
+        [FromQuery] int pageSize = 20,
+        [FromQuery] Guid? lastSeenId = null,
+        [FromQuery] DateTime? lastSeenUpdatedAt = null,
+        CancellationToken cancellationToken = default)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        if (lastSeenId.HasValue ^ lastSeenUpdatedAt.HasValue)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "Validation failed",
+                Detail = "lastSeenId and lastSeenUpdatedAt must both be provided or both omitted.",
+            });
+        }
+
+        if (lastSeenUpdatedAt.HasValue)
+        {
+            lastSeenUpdatedAt =
+                lastSeenUpdatedAt.Value.Kind == DateTimeKind.Unspecified
+                    ? DateTime.SpecifyKind(lastSeenUpdatedAt.Value, DateTimeKind.Utc)
+                    : lastSeenUpdatedAt.Value.ToUniversalTime();
+        }
+
+        var query = new ListCoverLettersQuery
+        {
+            UserId = userId,
+            PageSize = pageSize,
+            LastSeenId = lastSeenId,
+            LastSeenUpdatedAt = lastSeenUpdatedAt,
+        };
+
+        var result = await _mediator.Send(query, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Creates a new cover letter for a vacancy owned by the current authenticated user.
+    /// </summary>
+    /// <param name="command">Create cover letter payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created cover letter.</returns>
+    [HttpPost]
+    [ProducesResponseType(typeof(CreateCoverLetterResult), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<CreateCoverLetterResult>> CreateAsync(
+        CreateCoverLetterCommand command,
+        CancellationToken cancellationToken)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        command.UserId = userId;
+
+        var result = await _mediator.Send(command, cancellationToken);
+        return Created($"/api/v1/cover-letters/{result.Id}", result);
+    }
+
+    /// <summary>
+    /// Updates content of an existing cover letter owned by the authenticated user.
+    /// </summary>
+    /// <param name="id">Cover letter identifier.</param>
+    /// <param name="command">Update payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Updated cover letter result.</returns>
+    [HttpPatch("{id:guid}")]
+    [ProducesResponseType(typeof(CoverLetterUpdateResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<CoverLetterUpdateResult>> UpdateAsync(
+        Guid id,
+        UpdateCoverLetterCommand command,
+        CancellationToken cancellationToken)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        command.CoverLetterId = id;
+        command.UserId = userId;
+
+        var result = await _mediator.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Soft-deletes an existing cover letter owned by the authenticated user.
+    /// </summary>
+    /// <param name="id">Cover letter identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>No content on successful deletion.</returns>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var userIdValue = HttpContext.GetCurrentUserId();
+        if (string.IsNullOrWhiteSpace(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
+            return Unauthorized();
+
+        var command = new DeleteCoverLetterCommand
+        {
+            CoverLetterId = id,
+            UserId = userId,
+        };
+
+        await _mediator.Send(command, cancellationToken);
+        return NoContent();
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/CreateCoverLetterCommand.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/CreateCoverLetterCommand.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Command for creating a new cover letter for a specific vacancy.
+/// </summary>
+public class CreateCoverLetterCommand : IRequest<CreateCoverLetterResult>
+{
+    /// <summary>
+    /// Authenticated user identifier injected by the API layer.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Vacancy identifier for which the cover letter is created.
+    /// </summary>
+    public Guid VacancyId { get; set; }
+
+    /// <summary>
+    /// Cover letter content body (50-10000 characters).
+    /// </summary>
+    public string Content { get; set; } = null!;
+}
+
+/// <summary>
+/// Response payload for a created cover letter.
+/// </summary>
+public class CreateCoverLetterResult
+{
+    public Guid Id { get; set; }
+    public Guid VacancyId { get; set; }
+    public string Content { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/CreateCoverLetterCommandHandler.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/CreateCoverLetterCommandHandler.cs
@@ -1,0 +1,72 @@
+using JobNecto.Application.CoverLetters.Mappers;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using MediatR;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Handles creation of cover letters for the current user.
+/// </summary>
+public class CreateCoverLetterCommandHandler : IRequestHandler<CreateCoverLetterCommand, CreateCoverLetterResult>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateCoverLetterCommandHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public CreateCoverLetterCommandHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<CreateCoverLetterResult> Handle(
+        CreateCoverLetterCommand request,
+        CancellationToken cancellationToken)
+    {
+        var vacancy = await _unitOfWork.VacancyRepository.GetByIdAsync(request.VacancyId, cancellationToken);
+
+        // Return 404 for non-owned vacancies to avoid leaking resource existence.
+        if (vacancy.UserId != request.UserId)
+            throw new NotFoundException("Vacancy", request.VacancyId);
+
+        var coverLetter = request.ToEntity();
+        var now = DateTime.UtcNow;
+        coverLetter.CreatedAt = now;
+        coverLetter.UpdatedAt = now;
+
+        try
+        {
+            await _unitOfWork.CoverLetterRepository.CreateAsync(coverLetter, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex) when (IsUniqueViolation(ex))
+        {
+            throw new ConflictException("A cover letter for this vacancy already exists.");
+        }
+
+        return coverLetter.ToCreateResult();
+    }
+
+    private static bool IsUniqueViolation(Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            var message = current.Message;
+            if (string.IsNullOrWhiteSpace(message))
+                continue;
+
+            if (message.Contains("23505", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/DeleteCoverLetterCommand.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/DeleteCoverLetterCommand.cs
@@ -1,0 +1,22 @@
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Command for soft-deleting an existing cover letter.
+/// </summary>
+public class DeleteCoverLetterCommand : IRequest<Unit>
+{
+    /// <summary>
+    /// Cover letter identifier from route.
+    /// </summary>
+    [JsonIgnore]
+    public Guid CoverLetterId { get; set; }
+
+    /// <summary>
+    /// Authenticated user identifier from security context.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/DeleteCoverLetterCommandHandler.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/DeleteCoverLetterCommandHandler.cs
@@ -1,0 +1,36 @@
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using MediatR;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Handles cover letter soft-delete requests.
+/// </summary>
+public class DeleteCoverLetterCommandHandler : IRequestHandler<DeleteCoverLetterCommand, Unit>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeleteCoverLetterCommandHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public DeleteCoverLetterCommandHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<Unit> Handle(DeleteCoverLetterCommand request, CancellationToken cancellationToken)
+    {
+        var coverLetter = await _unitOfWork.CoverLetterRepository.GetByIdAsync(request.CoverLetterId, cancellationToken);
+
+        if (coverLetter.UserId != request.UserId)
+            throw new ForbiddenException("You do not have permission to delete this cover letter.");
+
+        await _unitOfWork.CoverLetterRepository.SoftDeleteAsync(coverLetter, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQuery.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQuery.cs
@@ -1,0 +1,52 @@
+using JobNecto.Domain.Enums;
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Query for retrieving a single cover letter detail for the authenticated user.
+/// </summary>
+public class GetCoverLetterQuery : IRequest<CoverLetterDetailResult>
+{
+    /// <summary>
+    /// Cover letter identifier from route.
+    /// </summary>
+    [JsonIgnore]
+    public Guid CoverLetterId { get; set; }
+
+    /// <summary>
+    /// Authenticated user identifier injected by the API layer.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+}
+
+/// <summary>
+/// Detail response for a single cover letter.
+/// </summary>
+public class CoverLetterDetailResult
+{
+    public Guid Id { get; set; }
+
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    public Guid VacancyId { get; set; }
+    public string Content { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public VacancyInCoverLetterResult Vacancy { get; set; } = null!;
+}
+
+/// <summary>
+/// Nested vacancy fields returned with a cover letter detail response.
+/// </summary>
+public class VacancyInCoverLetterResult
+{
+    public Guid Id { get; set; }
+    public string? Title { get; set; }
+    public string? Company { get; set; }
+    public WorkLocationType? WorkLocationType { get; set; }
+    public Location? Location { get; set; }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQueryHandler.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/GetCoverLetterQueryHandler.cs
@@ -1,0 +1,33 @@
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using MediatR;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Handles retrieval of a single cover letter by ID for the authenticated user.
+/// </summary>
+public class GetCoverLetterQueryHandler : IRequestHandler<GetCoverLetterQuery, CoverLetterDetailResult>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetCoverLetterQueryHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public GetCoverLetterQueryHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<CoverLetterDetailResult> Handle(GetCoverLetterQuery request, CancellationToken cancellationToken)
+    {
+        var result = await _unitOfWork.CoverLetterRepository.GetDetailByIdAsync(request.CoverLetterId, cancellationToken);
+
+        if (result is null || result.UserId != request.UserId)
+            throw new NotFoundException("CoverLetter", request.CoverLetterId);
+
+        return result;
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/ListCoverLettersQuery.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/ListCoverLettersQuery.cs
@@ -1,0 +1,46 @@
+using JobNecto.Domain.ValueObjects;
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Query to retrieve a cursor-paginated list of cover letters for the current user.
+/// </summary>
+public class ListCoverLettersQuery : IRequest<PagedResult<CoverLetterListItem>>
+{
+    /// <summary>
+    /// ID of the authenticated user making the request.
+    /// Injected by the API controller.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Number of items per page. Defaults to 20, capped at 100.
+    /// </summary>
+    public int PageSize { get; set; } = 20;
+
+    /// <summary>
+    /// Cursor: ID of the last seen cover letter from the previous page.
+    /// </summary>
+    public Guid? LastSeenId { get; set; }
+
+    /// <summary>
+    /// Cursor timestamp field.
+    /// For this endpoint it carries the CreatedAt value of the last seen cover letter.
+    /// </summary>
+    public DateTime? LastSeenUpdatedAt { get; set; }
+}
+
+/// <summary>
+/// List-item response DTO for cover letter list responses.
+/// </summary>
+public class CoverLetterListItem
+{
+    public Guid Id { get; set; }
+    public Guid VacancyId { get; set; }
+    public string? VacancyTitle { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/ListCoverLettersQueryHandler.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/ListCoverLettersQueryHandler.cs
@@ -1,0 +1,40 @@
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.ValueObjects;
+using MediatR;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Handles retrieval of cursor-paginated cover letter list items for the current user.
+/// </summary>
+public class ListCoverLettersQueryHandler : IRequestHandler<ListCoverLettersQuery, PagedResult<CoverLetterListItem>>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ListCoverLettersQueryHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public ListCoverLettersQueryHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<CoverLetterListItem>> Handle(
+        ListCoverLettersQuery request,
+        CancellationToken cancellationToken)
+    {
+        var cappedPageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, 100);
+
+        var pagedQuery = new PagedQuery
+        {
+            UserId = request.UserId,
+            PageSize = cappedPageSize,
+            LastSeenId = request.LastSeenId,
+            LastSeenUpdatedAt = request.LastSeenUpdatedAt,
+        };
+
+        return await _unitOfWork.CoverLetterRepository.GetPagedListAsync(pagedQuery, cancellationToken);
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/Mappers/CoverLetterMappers.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/Mappers/CoverLetterMappers.cs
@@ -1,0 +1,67 @@
+using JobNecto.Domain.Entities;
+
+namespace JobNecto.Application.CoverLetters.Mappers;
+
+/// <summary>
+/// Mapping extensions for cover letter command/query flows.
+/// </summary>
+public static class CoverLetterMappers
+{
+    /// <summary>
+    /// Maps a create command into a domain entity.
+    /// </summary>
+    /// <param name="command">Incoming command payload.</param>
+    /// <returns>Mapped cover letter entity.</returns>
+    public static CoverLetter ToEntity(this CreateCoverLetterCommand command)
+    {
+        if (command == null)
+            throw new ArgumentNullException(nameof(command));
+
+        return new CoverLetter
+        {
+            UserId = command.UserId,
+            VacancyId = command.VacancyId,
+            Content = command.Content,
+        };
+    }
+
+    /// <summary>
+    /// Maps a domain entity to the create response DTO.
+    /// </summary>
+    /// <param name="coverLetter">Persisted cover letter entity.</param>
+    /// <returns>API-facing create cover letter result.</returns>
+    public static CreateCoverLetterResult ToCreateResult(this CoverLetter coverLetter)
+    {
+        if (coverLetter == null)
+            throw new ArgumentNullException(nameof(coverLetter));
+
+        return new CreateCoverLetterResult
+        {
+            Id = coverLetter.Id,
+            VacancyId = coverLetter.VacancyId,
+            Content = coverLetter.Content,
+            CreatedAt = coverLetter.CreatedAt,
+            UpdatedAt = coverLetter.UpdatedAt,
+        };
+    }
+
+    /// <summary>
+    /// Maps a domain entity to the update response DTO.
+    /// </summary>
+    /// <param name="coverLetter">Updated cover letter entity.</param>
+    /// <returns>API-facing update cover letter result.</returns>
+    public static CoverLetterUpdateResult ToUpdateResult(this CoverLetter coverLetter)
+    {
+        if (coverLetter == null)
+            throw new ArgumentNullException(nameof(coverLetter));
+
+        return new CoverLetterUpdateResult
+        {
+            Id = coverLetter.Id,
+            VacancyId = coverLetter.VacancyId,
+            Content = coverLetter.Content,
+            CreatedAt = coverLetter.CreatedAt,
+            UpdatedAt = coverLetter.UpdatedAt,
+        };
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/UpdateCoverLetterCommand.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/UpdateCoverLetterCommand.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using System.Text.Json.Serialization;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Command for updating content of an existing cover letter.
+/// </summary>
+public class UpdateCoverLetterCommand : IRequest<CoverLetterUpdateResult>
+{
+    /// <summary>
+    /// Cover letter identifier from route.
+    /// </summary>
+    [JsonIgnore]
+    public Guid CoverLetterId { get; set; }
+
+    /// <summary>
+    /// Authenticated user identifier injected by API layer.
+    /// </summary>
+    [JsonIgnore]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Updated cover letter content.
+    /// </summary>
+    public string Content { get; set; } = null!;
+}
+
+/// <summary>
+/// Response payload for an updated cover letter.
+/// </summary>
+public class CoverLetterUpdateResult
+{
+    public Guid Id { get; set; }
+    public Guid VacancyId { get; set; }
+    public string Content { get; set; } = null!;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/UpdateCoverLetterCommandHandler.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/UpdateCoverLetterCommandHandler.cs
@@ -1,0 +1,40 @@
+using JobNecto.Application.CoverLetters.Mappers;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using MediatR;
+
+namespace JobNecto.Application.CoverLetters;
+
+/// <summary>
+/// Handles update requests for cover letter content.
+/// </summary>
+public class UpdateCoverLetterCommandHandler : IRequestHandler<UpdateCoverLetterCommand, CoverLetterUpdateResult>
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateCoverLetterCommandHandler"/> class.
+    /// </summary>
+    /// <param name="unitOfWork">Unit of work abstraction.</param>
+    public UpdateCoverLetterCommandHandler(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    /// <inheritdoc />
+    public async Task<CoverLetterUpdateResult> Handle(UpdateCoverLetterCommand request, CancellationToken cancellationToken)
+    {
+        var coverLetter = await _unitOfWork.CoverLetterRepository.GetByIdAsync(request.CoverLetterId, cancellationToken);
+
+        if (coverLetter.UserId != request.UserId)
+            throw new ForbiddenException("You do not have permission to update this cover letter.");
+
+        coverLetter.Content = request.Content;
+        coverLetter.UpdatedAt = DateTime.UtcNow;
+
+        await _unitOfWork.CoverLetterRepository.UpdateAsync(coverLetter, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return coverLetter.ToUpdateResult();
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/Validators/CreateCoverLetterCommandValidator.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/Validators/CreateCoverLetterCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace JobNecto.Application.CoverLetters.Validators;
+
+/// <summary>
+/// Validator for <see cref="CreateCoverLetterCommand"/>.
+/// </summary>
+public class CreateCoverLetterCommandValidator : AbstractValidator<CreateCoverLetterCommand>
+{
+    /// <summary>
+    /// Initializes validation rules for cover letter creation requests.
+    /// </summary>
+    public CreateCoverLetterCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.VacancyId).NotEmpty();
+        RuleFor(x => x.Content).NotEmpty().MinimumLength(50).MaximumLength(10000);
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/Validators/DeleteCoverLetterCommandValidator.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/Validators/DeleteCoverLetterCommandValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+
+namespace JobNecto.Application.CoverLetters.Validators;
+
+/// <summary>
+/// Validator for <see cref="DeleteCoverLetterCommand"/>.
+/// </summary>
+public class DeleteCoverLetterCommandValidator : AbstractValidator<DeleteCoverLetterCommand>
+{
+    /// <summary>
+    /// Initializes validation rules for cover letter delete requests.
+    /// </summary>
+    public DeleteCoverLetterCommandValidator()
+    {
+        RuleFor(x => x.CoverLetterId)
+            .NotEmpty()
+            .WithMessage("coverLetterId is required.");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("userId is required.");
+    }
+}

--- a/backend/src/JobNecto.Application/CoverLetters/Validators/UpdateCoverLetterCommandValidator.cs
+++ b/backend/src/JobNecto.Application/CoverLetters/Validators/UpdateCoverLetterCommandValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+
+namespace JobNecto.Application.CoverLetters.Validators;
+
+/// <summary>
+/// Validator for <see cref="UpdateCoverLetterCommand"/>.
+/// </summary>
+public class UpdateCoverLetterCommandValidator : AbstractValidator<UpdateCoverLetterCommand>
+{
+    /// <summary>
+    /// Initializes validation rules for cover letter update requests.
+    /// </summary>
+    public UpdateCoverLetterCommandValidator()
+    {
+        RuleFor(x => x.CoverLetterId)
+            .NotEmpty();
+
+        RuleFor(x => x.UserId)
+            .NotEmpty();
+
+        RuleFor(x => x.Content)
+            .NotEmpty()
+            .Must(content => !string.IsNullOrWhiteSpace(content))
+            .MinimumLength(50)
+            .MaximumLength(10000);
+    }
+}

--- a/backend/src/JobNecto.Application/Interfaces/ICoverLetterRepository.cs
+++ b/backend/src/JobNecto.Application/Interfaces/ICoverLetterRepository.cs
@@ -1,0 +1,24 @@
+using JobNecto.Application.CoverLetters;
+using JobNecto.Domain.Entities;
+using JobNecto.Domain.ValueObjects;
+
+namespace JobNecto.Application.Interfaces;
+
+/// <summary>
+/// Cover letter specific repository contract.
+/// Extends mutable operations with specialized list/detail queries.
+/// </summary>
+public interface ICoverLetterRepository : IMutableRepository<CoverLetter>
+{
+    /// <summary>
+    /// Returns a cursor-paginated list of cover letters for the requested user,
+    /// ordered by CreatedAt descending.
+    /// </summary>
+    Task<PagedResult<CoverLetterListItem>> GetPagedListAsync(PagedQuery pagedQuery, CancellationToken ct);
+
+    /// <summary>
+    /// Returns detail data for a single cover letter, including related vacancy fields.
+    /// Returns null when the cover letter does not exist (or is filtered out by soft-delete).
+    /// </summary>
+    Task<CoverLetterDetailResult?> GetDetailByIdAsync(Guid id, CancellationToken ct);
+}

--- a/backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs
+++ b/backend/src/JobNecto.Application/Interfaces/IUnitOfWork.cs
@@ -23,7 +23,7 @@ public interface IUnitOfWork : IAsyncDisposable
     /// <summary>
     /// Repository for cover letters with full write support (update + soft delete).
     /// </summary>
-    IMutableRepository<CoverLetter> CoverLetterRepository { get; }
+    ICoverLetterRepository CoverLetterRepository { get; }
 
     /// <summary>
     /// Repository for resumes with full write support (update + soft delete).

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260510192135_AddCoverLetterUniqueVacancyPerUser.Designer.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260510192135_AddCoverLetterUniqueVacancyPerUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JobNecto.Infrastructure.Persistance;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JobNecto.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510192135_AddCoverLetterUniqueVacancyPerUser")]
+    partial class AddCoverLetterUniqueVacancyPerUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/JobNecto.Infrastructure/Migrations/20260510192135_AddCoverLetterUniqueVacancyPerUser.cs
+++ b/backend/src/JobNecto.Infrastructure/Migrations/20260510192135_AddCoverLetterUniqueVacancyPerUser.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobNecto.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCoverLetterUniqueVacancyPerUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CoverLetters_UserId",
+                table: "CoverLetters");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CoverLetters_UserId_VacancyId",
+                table: "CoverLetters",
+                columns: new[] { "UserId", "VacancyId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CoverLetters_UserId_VacancyId",
+                table: "CoverLetters");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CoverLetters_UserId",
+                table: "CoverLetters",
+                column: "UserId");
+        }
+    }
+}

--- a/backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterConfiguration.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/Config/CoverLetterConfiguration.cs
@@ -36,5 +36,10 @@ public class CoverLetterConfiguration : IEntityTypeConfiguration<CoverLetter>
             .WithMany()
             .HasForeignKey(cl => cl.VacancyId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder
+            .HasIndex(cl => new { cl.UserId, cl.VacancyId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
     }
 }

--- a/backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs
+++ b/backend/src/JobNecto.Infrastructure/Persistance/UnitOfWork.cs
@@ -13,7 +13,7 @@ public class UnitOfWork : IUnitOfWork
 
     private IUserRepository? _userRepository;
     private IVacancyRepository? _vacancyRepository;
-    private IMutableRepository<CoverLetter>? _coverLetterRepository;
+    private ICoverLetterRepository? _coverLetterRepository;
     private IMutableRepository<Resume>? _resumeRepository;
     private IMutableRepository<Education>? _educationRepository;
     private IMutableRepository<CoverLetterTemplate>? _coverLetterTemplateRepository;
@@ -29,7 +29,7 @@ public class UnitOfWork : IUnitOfWork
     public IVacancyRepository VacancyRepository => 
         _vacancyRepository ??= new VacancyRepository(_context);
 
-    public IMutableRepository<CoverLetter> CoverLetterRepository =>
+    public ICoverLetterRepository CoverLetterRepository =>
         _coverLetterRepository ??= new CoverLetterRepository(_context);
 
     public IMutableRepository<Resume> ResumeRepository =>

--- a/backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs
+++ b/backend/src/JobNecto.Infrastructure/Repositories/CoverLetterRepository.cs
@@ -1,11 +1,122 @@
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.ValueObjects;
 using JobNecto.Infrastructure.Persistance;
 using JobNecto.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace JobNecto.Infrastructure.Repositories;
 
-public class CoverLetterRepository : SoftDeletableRepository<CoverLetter>
+public class CoverLetterRepository : SoftDeletableRepository<CoverLetter>, ICoverLetterRepository
 {
+    private sealed class CoverLetterRow
+    {
+        public required CoverLetter CoverLetter { get; init; }
+        public Vacancy? Vacancy { get; init; }
+    }
+
     public CoverLetterRepository(AppDbContext context) : base(context)
     {
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<CoverLetterListItem>> GetPagedListAsync(
+        PagedQuery pagedQuery,
+        CancellationToken ct)
+    {
+        if (!pagedQuery.UserId.HasValue)
+            throw new ArgumentException("UserId is required for cover letter listing.", nameof(pagedQuery));
+
+        var pageSize = pagedQuery.PageSize < 1 ? 20 : Math.Min(pagedQuery.PageSize, 100);
+        var userId = pagedQuery.UserId.Value;
+
+        var baseQuery = _context
+            .Set<CoverLetter>()
+            .AsNoTracking()
+            .Where(cl => cl.UserId == userId && !cl.IsDeleted);
+
+        var totalCount = await baseQuery.CountAsync(ct);
+
+        IQueryable<CoverLetterRow> query = baseQuery
+            .GroupJoin(
+                _context.Set<Vacancy>().AsNoTracking().IgnoreQueryFilters(),
+                cl => cl.VacancyId,
+                v => v.Id,
+                (cl, vacancies) => new CoverLetterRow
+                {
+                    CoverLetter = cl,
+                    Vacancy = vacancies.FirstOrDefault(),
+                }
+            )
+            .OrderByDescending(x => x.CoverLetter.CreatedAt)
+            .ThenByDescending(x => x.CoverLetter.Id);
+
+        if (pagedQuery.LastSeenId is Guid lastSeenId && pagedQuery.LastSeenUpdatedAt is DateTime cursorCreatedAt)
+        {
+            query = query.Where(x =>
+                x.CoverLetter.CreatedAt < cursorCreatedAt
+                || (x.CoverLetter.CreatedAt == cursorCreatedAt && x.CoverLetter.Id < lastSeenId));
+        }
+
+        var pagePlusOne = await query.Take(pageSize + 1).ToListAsync(ct);
+        var page = pagePlusOne.Take(pageSize).ToList();
+        var hasNext = pagePlusOne.Count > pageSize;
+
+        var items = page
+            .Select(x => new CoverLetterListItem
+            {
+                Id = x.CoverLetter.Id,
+                VacancyId = x.CoverLetter.VacancyId,
+                VacancyTitle = x.Vacancy?.Title,
+                CreatedAt = x.CoverLetter.CreatedAt,
+                UpdatedAt = x.CoverLetter.UpdatedAt,
+            })
+            .ToList();
+
+        return new PagedResult<CoverLetterListItem>(
+            items,
+            totalCount,
+            items.Count > 0 ? items[^1].Id : null,
+            // For this endpoint, LastSeenUpdatedAt carries CreatedAt for cursor semantics.
+            items.Count > 0 ? items[^1].CreatedAt : null,
+            pageSize,
+            hasNext);
+    }
+
+    /// <inheritdoc />
+    public async Task<CoverLetterDetailResult?> GetDetailByIdAsync(Guid id, CancellationToken ct)
+    {
+        return await _context
+            .Set<CoverLetter>()
+            .AsNoTracking()
+            .Where(cl => cl.Id == id && !cl.IsDeleted)
+            .GroupJoin(
+                _context.Set<Vacancy>().AsNoTracking().IgnoreQueryFilters(),
+                cl => cl.VacancyId,
+                v => v.Id,
+                (cl, vacancies) => new CoverLetterRow
+                {
+                    CoverLetter = cl,
+                    Vacancy = vacancies.FirstOrDefault(),
+                }
+            )
+            .Select(x => new CoverLetterDetailResult
+            {
+                Id = x.CoverLetter.Id,
+                UserId = x.CoverLetter.UserId,
+                VacancyId = x.CoverLetter.VacancyId,
+                Content = x.CoverLetter.Content,
+                CreatedAt = x.CoverLetter.CreatedAt,
+                UpdatedAt = x.CoverLetter.UpdatedAt,
+                Vacancy = new VacancyInCoverLetterResult
+                {
+                    Id = x.Vacancy != null ? x.Vacancy.Id : x.CoverLetter.VacancyId,
+                    Title = x.Vacancy != null ? x.Vacancy.Title : null,
+                    Company = x.Vacancy != null ? x.Vacancy.Company : null,
+                    WorkLocationType = x.Vacancy != null ? x.Vacancy.WorkLocationType : null,
+                    Location = x.Vacancy != null ? x.Vacancy.Location : null,
+                },
+            })
+            .FirstOrDefaultAsync(ct);
     }
 }

--- a/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetterTemplates/CoverLetterTemplatesUniquenessApiTests.cs
@@ -50,14 +50,26 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
         return id;
     }
 
+    private async Task<bool> EnsureDatabaseAvailableAsync()
+    {
+        var isDatabaseReady = await _factory!.TryInitializeSchemaAsync();
+        if (isDatabaseReady)
+            return true;
+
+        const string message = "PostgreSQL test database was unavailable for cover letter template uniqueness assertions.";
+        _output.WriteLine("Skipped: " + message);
+
+        if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.OrdinalIgnoreCase))
+            isDatabaseReady.Should().BeTrue(message);
+
+        return false;
+    }
+
     [Fact]
     public async Task Create_DuplicateName_SameUser_Returns409()
     {
-        if (!await _factory!.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand());
@@ -80,11 +92,8 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_SameName_DifferentUsers_Returns201BothTimes()
     {
-        if (!await _factory!.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var cookieA = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_a_"));
@@ -108,11 +117,8 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
     [Fact]
     public async Task Create_ConcurrentDuplicateName_AtLeastOneReturns409()
     {
-        if (!await _factory!.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand());
@@ -128,11 +134,8 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
     [Fact]
     public async Task Patch_RenameToExistingName_SameUser_Returns409()
     {
-        if (!await _factory!.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_same_"));
@@ -163,11 +166,8 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
     [Fact]
     public async Task Patch_SameNameUsedByAnotherUser_DoesNotBlockUpdate_Returns200()
     {
-        if (!await _factory!.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var cookieA = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_a_"));
@@ -199,11 +199,8 @@ public class CoverLetterTemplatesUniquenessApiTests : IAsyncLifetime
     [Fact]
     public async Task Patch_ConcurrentRenameCollision_OneSuccessAndAtLeastOneConflict()
     {
-        if (!await _factory!.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped: PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
         var authCookie = await CoverLetterTemplatesApiTests.CreateUserAndGetCookieHelperAsync(client, NewUserCommand("clt_patch_race_"));

--- a/backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersApiTests.cs
@@ -1,0 +1,897 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using JobNecto.Application.Users;
+using JobNecto.Domain.Entities;
+using JobNecto.Domain.Enums;
+using JobNecto.Domain.ValueObjects;
+using JobNecto.Infrastructure.Persistance;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JobNecto.Tests.API.CoverLetters;
+
+public class CoverLettersApiTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static string ValidContent() => new string('a', 50);
+
+    private static CreateUserCommand NewUserCommand(string prefix = "cl_user") =>
+        new()
+        {
+            LoginName = prefix + Guid.NewGuid().ToString("N")[..8],
+            Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+            Password = "Password123!",
+        };
+
+    internal static async Task<(string AuthCookie, Guid UserId)> CreateUserAndGetCookieAsync(
+        HttpClient client,
+        CreateUserCommand? command = null)
+    {
+        command ??= NewUserCommand();
+
+        var response = await client.PostAsJsonAsync("/api/v1/users", command);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var createdUser = await response.Content.ReadFromJsonAsync<CreateUserResult>(JsonOptions);
+        createdUser.Should().NotBeNull();
+
+        var authCookie = response
+            .Headers.GetValues("Set-Cookie")
+            .Select(x =>
+                x.Split(';', StringSplitOptions.TrimEntries)
+                    .FirstOrDefault(y =>
+                        y.StartsWith("auth-token=", StringComparison.OrdinalIgnoreCase)))
+            .First(x => !string.IsNullOrWhiteSpace(x));
+
+        authCookie.Should().NotBeNullOrWhiteSpace();
+        return (authCookie!, createdUser!.Id);
+    }
+
+    internal static async Task<Guid> SeedVacancyAsync(
+        WebApplicationFactory<Program> factory,
+        Guid userId,
+        Guid? vacancyId = null,
+        string? title = null,
+        string? company = null,
+        Location? location = null,
+        WorkLocationType? workLocationType = null)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        if (!await db.Users.AnyAsync(u => u.Id == userId))
+        {
+            db.Users.Add(new User
+            {
+                Id = userId,
+                Login = "seed_" + Guid.NewGuid().ToString("N")[..8],
+                Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+                Password = "seeded-password-hash",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+        }
+
+        var now = DateTime.UtcNow;
+        var vacancy = new Vacancy
+        {
+            Id = vacancyId ?? Guid.NewGuid(),
+            UserId = userId,
+            Title = title ?? "Backend Engineer",
+            Company = company,
+            Location = location,
+            WorkLocationType = workLocationType,
+            JobSource = new JobSource { Name = "LinkedIn", Url = "https://linkedin.com/jobs" },
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        db.Vacancies.Add(vacancy);
+        await db.SaveChangesAsync();
+
+        return vacancy.Id;
+    }
+
+    internal static async Task<HttpResponseMessage> PostCoverLetterAsync(
+        HttpClient client,
+        string authCookie,
+        object payload)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/cover-letters")
+        {
+            Content = JsonContent.Create(payload),
+        };
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+
+        return await client.SendAsync(request);
+    }
+
+    internal static async Task<Guid> SeedCoverLetterAsync(
+        WebApplicationFactory<Program> factory,
+        Guid userId,
+        Guid vacancyId,
+        DateTime createdAt,
+        string? content = null)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var coverLetter = new CoverLetter
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            VacancyId = vacancyId,
+            Content = content ?? ValidContent(),
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        };
+
+        db.CoverLetters.Add(coverLetter);
+        await db.SaveChangesAsync();
+
+        return coverLetter.Id;
+    }
+
+    private static async Task<HttpResponseMessage> GetCoverLettersAsync(
+        HttpClient client,
+        string authCookie,
+        string queryString = "")
+    {
+        var url = "/api/v1/cover-letters" +
+                  (string.IsNullOrEmpty(queryString) ? "" : "?" + queryString);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> GetCoverLetterByIdAsync(
+        HttpClient client,
+        string authCookie,
+        Guid id)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/cover-letters/{id}");
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> PatchCoverLetterAsync(
+        HttpClient client,
+        string authCookie,
+        Guid id,
+        object payload)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Patch, $"/api/v1/cover-letters/{id}")
+        {
+            Content = JsonContent.Create(payload),
+        };
+
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> DeleteCoverLetterAsync(
+        HttpClient client,
+        string authCookie,
+        Guid id)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/v1/cover-letters/{id}");
+        request.Headers.TryAddWithoutValidation("Cookie", authCookie);
+        return await client.SendAsync(request);
+    }
+
+    [Fact]
+    public async Task Create_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/v1/cover-letters",
+            new { vacancyId = Guid.NewGuid(), content = ValidContent() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Create_ValidPayload_Returns201WithLocationAndPayload()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var vacancyId = await SeedVacancyAsync(factory, userId);
+
+        var response = await PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId,
+            content = ValidContent(),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+        var locationStr = response.Headers.Location!.ToString();
+        locationStr.Should().StartWith("/api/v1/cover-letters/");
+        Guid.TryParse(locationStr.Split('/').Last(), out _)
+            .Should().BeTrue("Location header must end with a valid GUID");
+
+        var result = await response.Content.ReadFromJsonAsync<CreateCoverLetterResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Id.Should().NotBeEmpty();
+        result.VacancyId.Should().Be(vacancyId);
+        result.Content.Should().Be(ValidContent());
+        result.CreatedAt.Should().NotBe(default(DateTime));
+        result.UpdatedAt.Should().NotBe(default(DateTime));
+    }
+
+    [Fact]
+    public async Task Create_ContentLessThan50Chars_Returns400WithFieldLevelError()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var vacancyId = await SeedVacancyAsync(factory, userId);
+
+        var response = await PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId,
+            content = new string('a', 49),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Content");
+    }
+
+    [Fact]
+    public async Task Create_ContentMoreThan10000Chars_Returns400WithFieldLevelError()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var vacancyId = await SeedVacancyAsync(factory, userId);
+
+        var response = await PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId,
+            content = new string('a', 10001),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Content");
+    }
+
+    [Fact]
+    public async Task Create_NonExistingVacancy_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId = Guid.NewGuid(),
+            content = ValidContent(),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_VacancyOwnedByAnotherUser_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(
+            new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (_, ownerUserId) = await CreateUserAndGetCookieAsync(client, NewUserCommand("owner_"));
+        var (requesterCookie, _) = await CreateUserAndGetCookieAsync(client, NewUserCommand("requester_"));
+
+        var otherUsersVacancyId = await SeedVacancyAsync(factory, ownerUserId);
+
+        var response = await PostCoverLetterAsync(client, requesterCookie, new
+        {
+            vacancyId = otherUsersVacancyId,
+            content = ValidContent(),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task List_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/cover-letters");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task List_EmptyLibrary_Returns200WithEmptyResult()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await GetCoverLettersAsync(client, authCookie);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(0);
+        result.HasNext.Should().BeFalse();
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task List_ReturnsCreatedAtDescending_WithVacancyTitles()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+
+        var vacancy1 = await SeedVacancyAsync(factory, userId, title: "Role A");
+        var vacancy2 = await SeedVacancyAsync(factory, userId, title: "Role B");
+        var vacancy3 = await SeedVacancyAsync(factory, userId, title: "Role C");
+
+        var now = DateTime.UtcNow;
+        var oldestId = await SeedCoverLetterAsync(factory, userId, vacancy1, now.AddHours(-3), new string('a', 60));
+        var newestId = await SeedCoverLetterAsync(factory, userId, vacancy2, now.AddHours(-1), new string('b', 60));
+        var middleId = await SeedCoverLetterAsync(factory, userId, vacancy3, now.AddHours(-2), new string('c', 60));
+
+        var response = await GetCoverLettersAsync(client, authCookie);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.TotalCount.Should().Be(3);
+        result.Items.Should().HaveCount(3);
+
+        result.Items[0].Id.Should().Be(newestId);
+        result.Items[1].Id.Should().Be(middleId);
+        result.Items[2].Id.Should().Be(oldestId);
+
+        result.Items.Select(i => i.VacancyTitle).Should().Contain(["Role A", "Role B", "Role C"]);
+    }
+
+    [Fact]
+    public async Task List_PageSizeAbove100_IsCappedTo100()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await GetCoverLettersAsync(client, authCookie, "pageSize=500");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.PageSize.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task List_WithCursor_ReturnsNextSlice()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var now = DateTime.UtcNow;
+
+        var v1 = await SeedVacancyAsync(factory, userId, title: "Role 1");
+        var v2 = await SeedVacancyAsync(factory, userId, title: "Role 2");
+        var v3 = await SeedVacancyAsync(factory, userId, title: "Role 3");
+        var v4 = await SeedVacancyAsync(factory, userId, title: "Role 4");
+
+        var expectedOrder = new List<Guid>
+        {
+            await SeedCoverLetterAsync(factory, userId, v1, now.AddHours(-1), new string('a', 60)),
+            await SeedCoverLetterAsync(factory, userId, v2, now.AddHours(-2), new string('b', 60)),
+            await SeedCoverLetterAsync(factory, userId, v3, now.AddHours(-3), new string('c', 60)),
+            await SeedCoverLetterAsync(factory, userId, v4, now.AddHours(-4), new string('d', 60)),
+        };
+
+        var firstResponse = await GetCoverLettersAsync(client, authCookie, "pageSize=2");
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var firstPage = await firstResponse.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+        firstPage.Should().NotBeNull();
+        firstPage!.Items.Should().HaveCount(2);
+        firstPage.Items[0].Id.Should().Be(expectedOrder[0]);
+        firstPage.Items[1].Id.Should().Be(expectedOrder[1]);
+        firstPage.HasNext.Should().BeTrue();
+        firstPage.LastSeenId.Should().NotBeNull();
+        firstPage.LastSeenUpdatedAt.Should().NotBeNull();
+
+        var lastSeenTimestamp = Uri.EscapeDataString(firstPage.LastSeenUpdatedAt!.Value.ToString("o"));
+        var secondResponse = await GetCoverLettersAsync(
+            client,
+            authCookie,
+            $"pageSize=2&lastSeenId={firstPage.LastSeenId}&lastSeenUpdatedAt={lastSeenTimestamp}");
+
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondPage = await secondResponse.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+        secondPage.Should().NotBeNull();
+        secondPage!.Items.Should().HaveCount(2);
+        secondPage.Items[0].Id.Should().Be(expectedOrder[2]);
+        secondPage.Items[1].Id.Should().Be(expectedOrder[3]);
+    }
+
+    [Fact]
+    public async Task List_AnotherUsersCoverLetters_AreNotVisible()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (cookieA, userA) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cla_"));
+        var (cookieB, userB) = await CreateUserAndGetCookieAsync(client, NewUserCommand("clb_"));
+
+        var vacancyA = await SeedVacancyAsync(factory, userA, title: "Role A");
+        var vacancyB = await SeedVacancyAsync(factory, userB, title: "Role B");
+
+        await SeedCoverLetterAsync(factory, userA, vacancyA, DateTime.UtcNow.AddHours(-1), new string('a', 60));
+        await SeedCoverLetterAsync(factory, userB, vacancyB, DateTime.UtcNow.AddHours(-1), new string('b', 60));
+
+        var responseA = await GetCoverLettersAsync(client, cookieA);
+        responseA.StatusCode.Should().Be(HttpStatusCode.OK);
+        var resultA = await responseA.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+
+        var responseB = await GetCoverLettersAsync(client, cookieB);
+        responseB.StatusCode.Should().Be(HttpStatusCode.OK);
+        var resultB = await responseB.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+
+        resultA.Should().NotBeNull();
+        resultB.Should().NotBeNull();
+        resultA!.TotalCount.Should().Be(1);
+        resultB!.TotalCount.Should().Be(1);
+        resultA.Items[0].VacancyTitle.Should().Be("Role A");
+        resultB.Items[0].VacancyTitle.Should().Be("Role B");
+    }
+
+    [Fact]
+    public async Task List_WithOnlyLastSeenId_Returns400ProblemDetails()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await GetCoverLettersAsync(client, authCookie, $"lastSeenId={Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Validation failed");
+    }
+
+    [Fact]
+    public async Task GetById_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/api/v1/cover-letters/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetById_OwnedCoverLetter_Returns200WithNestedVacancy()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var vacancyId = await SeedVacancyAsync(
+            factory,
+            userId,
+            title: "Senior Backend Engineer",
+            company: "Contoso",
+            location: Location.Turkey,
+            workLocationType: WorkLocationType.Hybrid);
+
+        var coverLetterId = await SeedCoverLetterAsync(
+            factory,
+            userId,
+            vacancyId,
+            DateTime.UtcNow.AddHours(-1),
+            new string('z', 120));
+
+        var response = await GetCoverLetterByIdAsync(client, authCookie, coverLetterId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterDetailResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(coverLetterId);
+        result.Content.Should().Be(new string('z', 120));
+        result.VacancyId.Should().Be(vacancyId);
+        result.Vacancy.Should().NotBeNull();
+        result.Vacancy.Id.Should().Be(vacancyId);
+        result.Vacancy.Title.Should().Be("Senior Backend Engineer");
+        result.Vacancy.Company.Should().Be("Contoso");
+        result.Vacancy.WorkLocationType.Should().Be("Hybrid");
+        result.Vacancy.Location.Should().Be("Turkey");
+    }
+
+    [Fact]
+    public async Task GetById_WhenVacancySoftDeleted_StillReturnsCoverLetter()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var vacancyId = await SeedVacancyAsync(
+            factory,
+            userId,
+            title: "Soft Deleted Vacancy",
+            company: "Contoso",
+            location: Location.Turkey,
+            workLocationType: WorkLocationType.Remote);
+
+        var coverLetterId = await SeedCoverLetterAsync(
+            factory,
+            userId,
+            vacancyId,
+            DateTime.UtcNow.AddHours(-1),
+            new string('w', 100));
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var vacancy = await db.Vacancies.IgnoreQueryFilters().SingleAsync(v => v.Id == vacancyId);
+            vacancy.IsDeleted = true;
+            vacancy.DeletedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+        }
+
+        var response = await GetCoverLetterByIdAsync(client, authCookie, coverLetterId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterDetailResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(coverLetterId);
+        result.VacancyId.Should().Be(vacancyId);
+        result.Vacancy.Id.Should().Be(vacancyId);
+    }
+
+    [Fact]
+    public async Task GetById_NonExistentId_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await GetCoverLetterByIdAsync(client, authCookie, Guid.NewGuid());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetById_AnotherUsersCoverLetter_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (_, ownerUserId) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_detail_owner_"));
+        var (requesterCookie, _) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_detail_requester_"));
+
+        var vacancyId = await SeedVacancyAsync(factory, ownerUserId, title: "Owner Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(
+            factory,
+            ownerUserId,
+            vacancyId,
+            DateTime.UtcNow.AddHours(-1),
+            new string('x', 80));
+
+        var response = await GetCoverLetterByIdAsync(client, requesterCookie, coverLetterId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Patch_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.PatchAsJsonAsync(
+            $"/api/v1/cover-letters/{Guid.NewGuid()}",
+            new { content = new string('a', 60) });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Patch_OwnedCoverLetter_ContentOnly_Returns200AndRefreshesUpdatedAt()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var vacancyId = await SeedVacancyAsync(factory, userId, title: "Patch Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(
+            factory,
+            userId,
+            vacancyId,
+            DateTime.UtcNow.AddHours(-2),
+            new string('a', 80));
+
+        var detailBeforeResponse = await GetCoverLetterByIdAsync(client, authCookie, coverLetterId);
+        detailBeforeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detailBefore = await detailBeforeResponse.Content.ReadFromJsonAsync<CoverLetterDetailResultDto>(JsonOptions);
+
+        var response = await PatchCoverLetterAsync(client, authCookie, coverLetterId, new
+        {
+            content = new string('b', 120),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterUpdateResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(coverLetterId);
+        result.VacancyId.Should().Be(vacancyId);
+        result.Content.Should().Be(new string('b', 120));
+        result.UpdatedAt.Should().BeAfter(detailBefore!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task Patch_WithVacancyIdInBody_IsIgnored()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var originalVacancyId = await SeedVacancyAsync(factory, userId, title: "Immutable Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(
+            factory,
+            userId,
+            originalVacancyId,
+            DateTime.UtcNow.AddHours(-1),
+            new string('c', 90));
+
+        var response = await PatchCoverLetterAsync(client, authCookie, coverLetterId, new
+        {
+            content = new string('d', 95),
+            vacancyId = Guid.NewGuid(),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<CoverLetterUpdateResultDto>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.VacancyId.Should().Be(originalVacancyId);
+        result.Content.Should().Be(new string('d', 95));
+
+        var detailResponse = await GetCoverLetterByIdAsync(client, authCookie, coverLetterId);
+        detailResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detailResult = await detailResponse.Content.ReadFromJsonAsync<CoverLetterDetailResultDto>(JsonOptions);
+        detailResult.Should().NotBeNull();
+        detailResult!.VacancyId.Should().Be(originalVacancyId);
+    }
+
+    [Fact]
+    public async Task Patch_InvalidContentBounds_Returns400()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client);
+        var vacancyId = await SeedVacancyAsync(factory, userId, title: "Validation Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(factory, userId, vacancyId, DateTime.UtcNow.AddHours(-1), new string('a', 70));
+
+        var response = await PatchCoverLetterAsync(client, authCookie, coverLetterId, new
+        {
+            content = new string('x', 49),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Content");
+    }
+
+    [Fact]
+    public async Task Patch_AnotherUsersCoverLetter_Returns403()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (_, ownerUserId) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_patch_owner_"));
+        var (attackerCookie, _) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_patch_attacker_"));
+
+        var vacancyId = await SeedVacancyAsync(factory, ownerUserId, title: "Owner Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(factory, ownerUserId, vacancyId, DateTime.UtcNow.AddHours(-1), new string('a', 80));
+
+        var response = await PatchCoverLetterAsync(client, attackerCookie, coverLetterId, new
+        {
+            content = new string('p', 85),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Patch_NonExistentId_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client);
+
+        var response = await PatchCoverLetterAsync(client, authCookie, Guid.NewGuid(), new
+        {
+            content = new string('q', 88),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_WithoutToken_Returns401()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.DeleteAsync($"/api/v1/cover-letters/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Delete_OwnedCoverLetter_Returns204()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_del_"));
+        var vacancyId = await SeedVacancyAsync(factory, userId, title: "Delete Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(factory, userId, vacancyId, DateTime.UtcNow.AddHours(-1), new string('a', 80));
+
+        var response = await DeleteCoverLetterAsync(client, authCookie, coverLetterId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Delete_NonExistentId_Returns404()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, _) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_del_nf_"));
+
+        var response = await DeleteCoverLetterAsync(client, authCookie, Guid.NewGuid());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_AnotherUsersCoverLetter_Returns403()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (_, ownerUserId) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_del_owner_"));
+        var (attackerCookie, _) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_del_attacker_"));
+
+        var vacancyId = await SeedVacancyAsync(factory, ownerUserId, title: "Owner Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(factory, ownerUserId, vacancyId, DateTime.UtcNow.AddHours(-1), new string('a', 70));
+
+        var response = await DeleteCoverLetterAsync(client, attackerCookie, coverLetterId);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Delete_OwnedCoverLetter_ExcludedFromListAfterDeletion()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_del_list_"));
+        var vacancyId = await SeedVacancyAsync(factory, userId, title: "List Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(factory, userId, vacancyId, DateTime.UtcNow.AddHours(-1), new string('b', 75));
+
+        var deleteResponse = await DeleteCoverLetterAsync(client, authCookie, coverLetterId);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var listResponse = await GetCoverLettersAsync(client, authCookie);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var listResult = await listResponse.Content.ReadFromJsonAsync<CoverLetterPagedResultDto>(JsonOptions);
+        listResult.Should().NotBeNull();
+        listResult!.Items.Should().BeEmpty();
+        listResult.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_OwnedCoverLetter_DetailReturns404AfterDeletion()
+    {
+        await using var factory = new JobNectoApiFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+
+        var (authCookie, userId) = await CreateUserAndGetCookieAsync(client, NewUserCommand("cl_del_detail_"));
+        var vacancyId = await SeedVacancyAsync(factory, userId, title: "Detail Vacancy");
+        var coverLetterId = await SeedCoverLetterAsync(factory, userId, vacancyId, DateTime.UtcNow.AddHours(-1), new string('c', 85));
+
+        var deleteResponse = await DeleteCoverLetterAsync(client, authCookie, coverLetterId);
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var detailResponse = await GetCoverLetterByIdAsync(client, authCookie, coverLetterId);
+        detailResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    internal class CreateCoverLetterResultDto
+    {
+        public Guid Id { get; set; }
+        public Guid VacancyId { get; set; }
+        public string Content { get; set; } = null!;
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    internal class CoverLetterPagedResultDto
+    {
+        public int TotalCount { get; set; }
+        public int PageSize { get; set; }
+        public bool HasNext { get; set; }
+        public Guid? LastSeenId { get; set; }
+        public DateTime? LastSeenUpdatedAt { get; set; }
+        public List<CoverLetterListItemDto> Items { get; set; } = [];
+    }
+
+    internal class CoverLetterListItemDto
+    {
+        public Guid Id { get; set; }
+        public Guid VacancyId { get; set; }
+        public string? VacancyTitle { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    internal class CoverLetterDetailResultDto
+    {
+        public Guid Id { get; set; }
+        public Guid VacancyId { get; set; }
+        public string Content { get; set; } = null!;
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public CoverLetterVacancyDto Vacancy { get; set; } = null!;
+    }
+
+    internal class CoverLetterVacancyDto
+    {
+        public Guid Id { get; set; }
+        public string? Title { get; set; }
+        public string? Company { get; set; }
+        public string? WorkLocationType { get; set; }
+        public string? Location { get; set; }
+    }
+
+    internal class CoverLetterUpdateResultDto
+    {
+        public Guid Id { get; set; }
+        public Guid VacancyId { get; set; }
+        public string Content { get; set; } = null!;
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersUniquenessApiTests.cs
+++ b/backend/tests/JobNecto.Tests/API/CoverLetters/CoverLettersUniquenessApiTests.cs
@@ -1,0 +1,245 @@
+using System.Net;
+using FluentAssertions;
+using JobNecto.Application.Users;
+using JobNecto.Infrastructure.Persistance;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Xunit.Abstractions;
+
+namespace JobNecto.Tests.API.CoverLetters;
+
+public class CoverLettersUniquenessApiTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private CoverLettersPostgresFactory? _factory;
+
+    public CoverLettersUniquenessApiTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _factory = new CoverLettersPostgresFactory(_output);
+        await Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+    }
+
+    private static CreateUserCommand NewUserCommand(string prefix = "clu_") =>
+        new()
+        {
+            LoginName = prefix + Guid.NewGuid().ToString("N")[..8],
+            Email = Guid.NewGuid().ToString("N")[..8] + "@example.com",
+            Password = "Password123!",
+        };
+
+    private async Task<bool> EnsureDatabaseAvailableAsync()
+    {
+        var isDatabaseReady = await _factory!.TryInitializeSchemaAsync();
+        if (isDatabaseReady)
+            return true;
+
+        const string message = "PostgreSQL test database was unavailable for cover letter uniqueness assertions.";
+        _output.WriteLine("Skipped: " + message);
+
+        if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.OrdinalIgnoreCase))
+            isDatabaseReady.Should().BeTrue(message);
+
+        return false;
+    }
+
+    [Fact]
+    public async Task Create_DuplicateVacancyForSameUser_Returns409()
+    {
+        if (!await EnsureDatabaseAvailableAsync())
+            return;
+
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var (authCookie, userId) = await CoverLettersApiTests.CreateUserAndGetCookieAsync(client);
+        var vacancyId = await CoverLettersApiTests.SeedVacancyAsync(_factory, userId);
+
+        var first = await CoverLettersApiTests.PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId,
+            content = new string('a', 50),
+        });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await CoverLettersApiTests.PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId,
+            content = new string('b', 50),
+        });
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Create_SameUserDifferentVacancies_Returns201ForBoth()
+    {
+        if (!await EnsureDatabaseAvailableAsync())
+            return;
+
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var (authCookie, userId) = await CoverLettersApiTests.CreateUserAndGetCookieAsync(client, NewUserCommand());
+
+        var vacancyA = await CoverLettersApiTests.SeedVacancyAsync(_factory, userId);
+        var vacancyB = await CoverLettersApiTests.SeedVacancyAsync(_factory, userId);
+
+        var first = await CoverLettersApiTests.PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId = vacancyA,
+            content = new string('a', 50),
+        });
+
+        var second = await CoverLettersApiTests.PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId = vacancyB,
+            content = new string('b', 50),
+        });
+
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+        second.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Create_ConcurrentDuplicateVacancyForSameUser_OneCreatedOneConflict()
+    {
+        if (!await EnsureDatabaseAvailableAsync())
+            return;
+
+        var client = _factory!.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
+        var (authCookie, userId) = await CoverLettersApiTests.CreateUserAndGetCookieAsync(client, NewUserCommand("clu_race_"));
+        var vacancyId = await CoverLettersApiTests.SeedVacancyAsync(_factory, userId);
+
+        var firstTask = CoverLettersApiTests.PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId,
+            content = new string('a', 50),
+        });
+        var secondTask = CoverLettersApiTests.PostCoverLetterAsync(client, authCookie, new
+        {
+            vacancyId,
+            content = new string('b', 50),
+        });
+
+        var responses = await Task.WhenAll(firstTask, secondTask);
+
+        responses.Count(x => x.StatusCode == HttpStatusCode.Created).Should().Be(1);
+        responses.Count(x => x.StatusCode == HttpStatusCode.Conflict).Should().Be(1);
+    }
+}
+
+public sealed class CoverLettersPostgresFactory : WebApplicationFactory<Program>
+{
+    private const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=JobNectoTest;Username=test;Password=test";
+
+    private readonly string _baseConnectionString;
+    private readonly string _schemaName;
+    private string? _scopedConnectionString;
+    private bool _schemaInitialized;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private readonly ITestOutputHelper? _output;
+
+    public CoverLettersPostgresFactory(ITestOutputHelper? output = null)
+    {
+        _output = output;
+        _baseConnectionString = Environment.GetEnvironmentVariable("JOBNECTO_TEST_POSTGRES")
+            ?? DefaultConnectionString;
+        _schemaName = "cl_uniqueness_" + Guid.NewGuid().ToString("N");
+    }
+
+    public async Task<bool> TryInitializeSchemaAsync(CancellationToken cancellationToken = default)
+    {
+        if (_schemaInitialized)
+            return true;
+
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_schemaInitialized)
+                return true;
+
+            await EnsureSchemaExistsAsync(cancellationToken);
+
+            var builder = new NpgsqlConnectionStringBuilder(_baseConnectionString)
+            {
+                SearchPath = _schemaName,
+            };
+
+            _scopedConnectionString = builder.ConnectionString;
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseNpgsql(
+                    _scopedConnectionString,
+                    npgsql => npgsql.MigrationsAssembly("JobNecto.Infrastructure"))
+                .Options;
+
+            await using var dbContext = new AppDbContext(options);
+            await dbContext.Database.MigrateAsync(cancellationToken);
+
+            _schemaInitialized = true;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _output?.WriteLine($"Schema initialization failed: {ex.Message}");
+            return false;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Test");
+        builder.UseSetting(
+            "ConnectionStrings:Postgres",
+            _scopedConnectionString ?? _baseConnectionString);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await DropSchemaAsync();
+        await base.DisposeAsync();
+    }
+
+    private async Task EnsureSchemaExistsAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = new NpgsqlConnection(_baseConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{_schemaName}\";";
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task DropSchemaAsync()
+    {
+        if (!_schemaInitialized)
+            return;
+
+        try
+        {
+            await using var connection = new NpgsqlConnection(_baseConnectionString);
+            await connection.OpenAsync();
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"DROP SCHEMA IF EXISTS \"{_schemaName}\" CASCADE;";
+            await command.ExecuteNonQueryAsync();
+        }
+        catch (Exception ex)
+        {
+            _output?.WriteLine($"Schema cleanup failed: {ex.Message}");
+        }
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/UsersControllerConcurrencyTests.cs
+++ b/backend/tests/JobNecto.Tests/API/UsersControllerConcurrencyTests.cs
@@ -25,14 +25,26 @@ public class UsersControllerConcurrencyTests : IClassFixture<UsersControllerConc
         _output = output;
     }
 
+    private async Task<bool> EnsureDatabaseAvailableAsync()
+    {
+        var isDatabaseReady = await _factory.TryInitializeSchemaAsync();
+        if (isDatabaseReady)
+            return true;
+
+        const string message = "PostgreSQL test database was unavailable for users concurrency assertions.";
+        _output.WriteLine("Skipped: " + message);
+
+        if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.OrdinalIgnoreCase))
+            isDatabaseReady.Should().BeTrue(message);
+
+        return false;
+    }
+
     [Fact]
     public async Task Create_ConcurrentDuplicateRequests_ReturnsOneCreatedAndOneConflict()
     {
-        if (!await _factory.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped real-database concurrency assertion because PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
 
@@ -78,11 +90,8 @@ public class UsersControllerConcurrencyTests : IClassFixture<UsersControllerConc
     [Fact]
     public async Task Create_ConcurrentDuplicatePhoneRequests_ReturnsOneCreatedAndOneConflict()
     {
-        if (!await _factory.TryInitializeSchemaAsync())
-        {
-            _output.WriteLine("Skipped real-database phone uniqueness concurrency assertion because PostgreSQL test database was unavailable.");
+        if (!await EnsureDatabaseAvailableAsync())
             return;
-        }
 
         var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = false });
 

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/CreateCoverLetterCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/CreateCoverLetterCommandHandlerTests.cs
@@ -1,0 +1,202 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.Entities;
+using JobNecto.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class CreateCoverLetterCommandHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ICoverLetterRepository> _coverLetterRepositoryMock;
+    private readonly Mock<IVacancyRepository> _vacancyRepositoryMock;
+    private readonly CreateCoverLetterCommandHandler _handler;
+
+    public CreateCoverLetterCommandHandlerTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _coverLetterRepositoryMock = new Mock<ICoverLetterRepository>();
+        _vacancyRepositoryMock = new Mock<IVacancyRepository>();
+
+        _unitOfWorkMock
+            .Setup(x => x.CoverLetterRepository)
+            .Returns(_coverLetterRepositoryMock.Object);
+
+        _unitOfWorkMock
+            .Setup(x => x.VacancyRepository)
+            .Returns(_vacancyRepositoryMock.Object);
+
+        _handler = new CreateCoverLetterCommandHandler(_unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PersistsExactlyOnceAndReturnsResultWithNonDefaultTimestamps()
+    {
+        var userId = Guid.NewGuid();
+        var vacancyId = Guid.NewGuid();
+
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = userId,
+            VacancyId = vacancyId,
+            Content = new string('a', 50),
+        };
+
+        var vacancy = new Vacancy
+        {
+            Id = vacancyId,
+            UserId = userId,
+            JobSource = new JobSource { Name = "LinkedIn", Url = "https://linkedin.com/jobs" },
+        };
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetByIdAsync(vacancyId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(vacancy);
+
+        CoverLetter? capturedEntity = null;
+        _coverLetterRepositoryMock
+            .Setup(x => x.CreateAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()))
+            .Callback<CoverLetter, CancellationToken>((entity, _) =>
+            {
+                if (entity.Id == Guid.Empty)
+                    entity.Id = Guid.NewGuid();
+                capturedEntity = entity;
+            })
+            .ReturnsAsync((CoverLetter entity, CancellationToken _) => entity);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.VacancyId.Should().Be(vacancyId);
+        result.Content.Should().Be(command.Content);
+        result.CreatedAt.Should().NotBe(default(DateTime));
+        result.UpdatedAt.Should().NotBe(default(DateTime));
+        result.CreatedAt.Should().Be(result.UpdatedAt);
+
+        capturedEntity.Should().NotBeNull();
+        capturedEntity!.UserId.Should().Be(userId);
+        capturedEntity.VacancyId.Should().Be(vacancyId);
+        capturedEntity.Content.Should().Be(command.Content);
+        capturedEntity.CreatedAt.Should().NotBe(default(DateTime));
+        capturedEntity.UpdatedAt.Should().NotBe(default(DateTime));
+
+        _vacancyRepositoryMock.Verify(
+            x => x.GetByIdAsync(vacancyId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _coverLetterRepositoryMock.Verify(
+            x => x.CreateAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _unitOfWorkMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_VacancyNotFound_ThrowsNotFoundException()
+    {
+        var vacancyId = Guid.NewGuid();
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetByIdAsync(vacancyId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("Vacancy", vacancyId));
+
+        var act = () => _handler.Handle(
+            new CreateCoverLetterCommand
+            {
+                UserId = Guid.NewGuid(),
+                VacancyId = vacancyId,
+                Content = new string('a', 50),
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        _coverLetterRepositoryMock.Verify(
+            x => x.CreateAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _unitOfWorkMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_VacancyOwnedByDifferentUser_ThrowsNotFoundException()
+    {
+        var requestUserId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
+        var vacancyId = Guid.NewGuid();
+
+        var vacancy = new Vacancy
+        {
+            Id = vacancyId,
+            UserId = ownerUserId,
+            JobSource = new JobSource { Name = "LinkedIn", Url = "https://linkedin.com/jobs" },
+        };
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetByIdAsync(vacancyId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(vacancy);
+
+        var act = () => _handler.Handle(
+            new CreateCoverLetterCommand
+            {
+                UserId = requestUserId,
+                VacancyId = vacancyId,
+                Content = new string('a', 50),
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        _coverLetterRepositoryMock.Verify(
+            x => x.CreateAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _unitOfWorkMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UniqueConstraintViolation_ThrowsConflictException()
+    {
+        var userId = Guid.NewGuid();
+        var vacancyId = Guid.NewGuid();
+
+        var vacancy = new Vacancy
+        {
+            Id = vacancyId,
+            UserId = userId,
+            JobSource = new JobSource { Name = "LinkedIn", Url = "https://linkedin.com/jobs" },
+        };
+
+        _vacancyRepositoryMock
+            .Setup(x => x.GetByIdAsync(vacancyId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(vacancy);
+
+        _coverLetterRepositoryMock
+            .Setup(x => x.CreateAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CoverLetter entity, CancellationToken _) => entity);
+
+        _unitOfWorkMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateException(
+                "duplicate key value violates unique constraint",
+                new Exception("duplicate key value violates unique constraint")));
+
+        var act = () => _handler.Handle(
+            new CreateCoverLetterCommand
+            {
+                UserId = userId,
+                VacancyId = vacancyId,
+                Content = new string('a', 50),
+            },
+            CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<ConflictException>();
+        exception.Which.Message.Should().Contain("already exists");
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/CreateCoverLetterCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/CreateCoverLetterCommandValidatorTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.CoverLetters.Validators;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class CreateCoverLetterCommandValidatorTests
+{
+    private readonly CreateCoverLetterCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidPayload_Passes()
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 50),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyVacancyId_Fails()
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.Empty,
+            Content = new string('a', 50),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "VacancyId");
+    }
+
+    [Fact]
+    public void Validate_ContentLessThan50Chars_Fails()
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 49),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Fact]
+    public void Validate_ContentExactly50Chars_Passes()
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 50),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ContentExactly10000Chars_Passes()
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 10000),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ContentMoreThan10000Chars_Fails()
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 10001),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Validate_NullOrEmptyContent_Fails(string? content)
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            Content = content!,
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Fact]
+    public void Validate_WhitespaceOnlyContent_Fails()
+    {
+        var command = new CreateCoverLetterCommand
+        {
+            UserId = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            Content = "   ",
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/DeleteCoverLetterCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/DeleteCoverLetterCommandHandlerTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.Entities;
+using MediatR;
+using Moq;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class DeleteCoverLetterCommandHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<ICoverLetterRepository> _repositoryMock;
+    private readonly DeleteCoverLetterCommandHandler _handler;
+
+    public DeleteCoverLetterCommandHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _repositoryMock = new Mock<ICoverLetterRepository>();
+        _uowMock.Setup(x => x.CoverLetterRepository).Returns(_repositoryMock.Object);
+        _handler = new DeleteCoverLetterCommandHandler(_uowMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_OwnedCoverLetter_CallsSoftDeleteAndPersists()
+    {
+        var userId = Guid.NewGuid();
+        var coverLetter = new CoverLetter
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 70),
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(coverLetter.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(coverLetter);
+
+        _repositoryMock
+            .Setup(x => x.SoftDeleteAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()))
+            .Callback<CoverLetter, CancellationToken>((entity, _) =>
+            {
+                entity.IsDeleted = true;
+                entity.DeletedAt = DateTime.UtcNow;
+            })
+            .Returns(Task.CompletedTask);
+
+        var result = await _handler.Handle(
+            new DeleteCoverLetterCommand { CoverLetterId = coverLetter.Id, UserId = userId },
+            CancellationToken.None);
+
+        result.Should().Be(Unit.Value);
+        coverLetter.IsDeleted.Should().BeTrue();
+        coverLetter.DeletedAt.Should().NotBeNull();
+
+        _repositoryMock.Verify(x => x.SoftDeleteAsync(coverLetter, It.IsAny<CancellationToken>()), Times.Once);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_PropagatesNotFoundException()
+    {
+        var id = Guid.NewGuid();
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("CoverLetter", id));
+
+        var act = () => _handler.Handle(
+            new DeleteCoverLetterCommand { CoverLetterId = id, UserId = Guid.NewGuid() },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _repositoryMock.Verify(x => x.SoftDeleteAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_CrossUserDelete_ThrowsForbiddenException()
+    {
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var coverLetter = new CoverLetter
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 70),
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(coverLetter.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(coverLetter);
+
+        var act = () => _handler.Handle(
+            new DeleteCoverLetterCommand { CoverLetterId = coverLetter.Id, UserId = attackerId },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _repositoryMock.Verify(x => x.SoftDeleteAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/DeleteCoverLetterCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/DeleteCoverLetterCommandValidatorTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.CoverLetters.Validators;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class DeleteCoverLetterCommandValidatorTests
+{
+    private readonly DeleteCoverLetterCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidPayload_Passes()
+    {
+        var command = new DeleteCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyCoverLetterId_Fails()
+    {
+        var command = new DeleteCoverLetterCommand
+        {
+            CoverLetterId = Guid.Empty,
+            UserId = Guid.NewGuid(),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "CoverLetterId");
+    }
+
+    [Fact]
+    public void Validate_EmptyUserId_Fails()
+    {
+        var command = new DeleteCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.Empty,
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "UserId");
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/GetCoverLetterQueryHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/GetCoverLetterQueryHandlerTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.Enums;
+using JobNecto.Domain.ValueObjects;
+using Moq;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class GetCoverLetterQueryHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<ICoverLetterRepository> _repositoryMock;
+    private readonly GetCoverLetterQueryHandler _handler;
+
+    public GetCoverLetterQueryHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _repositoryMock = new Mock<ICoverLetterRepository>();
+        _uowMock.Setup(x => x.CoverLetterRepository).Returns(_repositoryMock.Object);
+        _handler = new GetCoverLetterQueryHandler(_uowMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_OwnedCoverLetter_ReturnsDetailWithNestedVacancy()
+    {
+        var userId = Guid.NewGuid();
+        var coverLetterId = Guid.NewGuid();
+
+        var detail = new CoverLetterDetailResult
+        {
+            Id = coverLetterId,
+            UserId = userId,
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 100),
+            CreatedAt = DateTime.UtcNow.AddHours(-2),
+            UpdatedAt = DateTime.UtcNow.AddHours(-1),
+            Vacancy = new VacancyInCoverLetterResult
+            {
+                Id = Guid.NewGuid(),
+                Title = "Backend Engineer",
+                Company = "Contoso",
+                WorkLocationType = WorkLocationType.Hybrid,
+                Location = Location.Turkey,
+            },
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetDetailByIdAsync(coverLetterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(detail);
+
+        var result = await _handler.Handle(
+            new GetCoverLetterQuery { CoverLetterId = coverLetterId, UserId = userId },
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(coverLetterId);
+        result.Content.Should().Be(detail.Content);
+        result.Vacancy.Title.Should().Be("Backend Engineer");
+        result.Vacancy.Company.Should().Be("Contoso");
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_ThrowsNotFoundException()
+    {
+        var coverLetterId = Guid.NewGuid();
+
+        _repositoryMock
+            .Setup(x => x.GetDetailByIdAsync(coverLetterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CoverLetterDetailResult?)null);
+
+        var act = () => _handler.Handle(
+            new GetCoverLetterQuery { CoverLetterId = coverLetterId, UserId = Guid.NewGuid() },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_CrossUserAccess_ThrowsNotFoundException()
+    {
+        var ownerUserId = Guid.NewGuid();
+        var requesterUserId = Guid.NewGuid();
+        var coverLetterId = Guid.NewGuid();
+
+        _repositoryMock
+            .Setup(x => x.GetDetailByIdAsync(coverLetterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CoverLetterDetailResult
+            {
+                Id = coverLetterId,
+                UserId = ownerUserId,
+                VacancyId = Guid.NewGuid(),
+                Content = new string('a', 70),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Vacancy = new VacancyInCoverLetterResult { Id = Guid.NewGuid() },
+            });
+
+        var act = () => _handler.Handle(
+            new GetCoverLetterQuery { CoverLetterId = coverLetterId, UserId = requesterUserId },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/ListCoverLettersQueryHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/ListCoverLettersQueryHandlerTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.ValueObjects;
+using Moq;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class ListCoverLettersQueryHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<ICoverLetterRepository> _coverLetterRepositoryMock;
+    private readonly ListCoverLettersQueryHandler _handler;
+
+    public ListCoverLettersQueryHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _coverLetterRepositoryMock = new Mock<ICoverLetterRepository>();
+        _uowMock.Setup(x => x.CoverLetterRepository).Returns(_coverLetterRepositoryMock.Object);
+        _handler = new ListCoverLettersQueryHandler(_uowMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NoCoverLetters_ReturnsEmptyPagedResult()
+    {
+        _coverLetterRepositoryMock
+            .Setup(x => x.GetPagedListAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<CoverLetterListItem>([], 0, null, null, 20, false));
+
+        var result = await _handler.Handle(new ListCoverLettersQuery { UserId = Guid.NewGuid() }, CancellationToken.None);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+        result.HasNext.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ForwardsPagedQueryWithPageSizeCap()
+    {
+        var userId = Guid.NewGuid();
+        var lastSeenId = Guid.NewGuid();
+        var lastSeenUpdatedAt = DateTime.UtcNow;
+
+        PagedQuery? captured = null;
+        _coverLetterRepositoryMock
+            .Setup(x => x.GetPagedListAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, CancellationToken>((query, _) => captured = query)
+            .ReturnsAsync(new PagedResult<CoverLetterListItem>([], 0, null, null, 100, false));
+
+        await _handler.Handle(
+            new ListCoverLettersQuery
+            {
+                UserId = userId,
+                PageSize = 999,
+                LastSeenId = lastSeenId,
+                LastSeenUpdatedAt = lastSeenUpdatedAt,
+            },
+            CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.UserId.Should().Be(userId);
+        captured.PageSize.Should().Be(100);
+        captured.LastSeenId.Should().Be(lastSeenId);
+        captured.LastSeenUpdatedAt.Should().Be(lastSeenUpdatedAt);
+    }
+
+    [Fact]
+    public async Task Handle_PageSizeLessThan1_DefaultsTo20()
+    {
+        PagedQuery? captured = null;
+        _coverLetterRepositoryMock
+            .Setup(x => x.GetPagedListAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<PagedQuery, CancellationToken>((query, _) => captured = query)
+            .ReturnsAsync(new PagedResult<CoverLetterListItem>([], 0, null, null, 20, false));
+
+        await _handler.Handle(
+            new ListCoverLettersQuery
+            {
+                UserId = Guid.NewGuid(),
+                PageSize = 0,
+            },
+            CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.PageSize.Should().Be(20);
+    }
+
+    [Fact]
+    public async Task Handle_WithItems_PreservesProjectedValuesAndMetadata()
+    {
+        var item = new CoverLetterListItem
+        {
+            Id = Guid.NewGuid(),
+            VacancyId = Guid.NewGuid(),
+            VacancyTitle = "Backend Engineer",
+            CreatedAt = DateTime.UtcNow.AddHours(-2),
+            UpdatedAt = DateTime.UtcNow.AddHours(-1),
+        };
+
+        var expected = new PagedResult<CoverLetterListItem>(
+            [item],
+            1,
+            item.Id,
+            item.CreatedAt,
+            20,
+            false);
+
+        _coverLetterRepositoryMock
+            .Setup(x => x.GetPagedListAsync(It.IsAny<PagedQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var result = await _handler.Handle(new ListCoverLettersQuery { UserId = Guid.NewGuid() }, CancellationToken.None);
+
+        result.TotalCount.Should().Be(1);
+        result.LastSeenId.Should().Be(item.Id);
+        result.LastSeenUpdatedAt.Should().Be(item.CreatedAt);
+        result.Items.Should().HaveCount(1);
+        result.Items[0].VacancyTitle.Should().Be("Backend Engineer");
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/UpdateCoverLetterCommandHandlerTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/UpdateCoverLetterCommandHandlerTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.Exceptions;
+using JobNecto.Application.Interfaces;
+using JobNecto.Domain.Entities;
+using Moq;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class UpdateCoverLetterCommandHandlerTests
+{
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly Mock<ICoverLetterRepository> _repositoryMock;
+    private readonly UpdateCoverLetterCommandHandler _handler;
+
+    public UpdateCoverLetterCommandHandlerTests()
+    {
+        _uowMock = new Mock<IUnitOfWork>();
+        _repositoryMock = new Mock<ICoverLetterRepository>();
+        _uowMock.Setup(x => x.CoverLetterRepository).Returns(_repositoryMock.Object);
+        _handler = new UpdateCoverLetterCommandHandler(_uowMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_OwnedCoverLetter_UpdatesContentAndReturnsResult()
+    {
+        var userId = Guid.NewGuid();
+        var coverLetter = new CoverLetter
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 60),
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow.AddMinutes(-5),
+        };
+
+        var previousUpdatedAt = coverLetter.UpdatedAt;
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(coverLetter.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(coverLetter);
+
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CoverLetter entity, CancellationToken _) => entity);
+
+        var result = await _handler.Handle(
+            new UpdateCoverLetterCommand
+            {
+                CoverLetterId = coverLetter.Id,
+                UserId = userId,
+                Content = new string('b', 90),
+            },
+            CancellationToken.None);
+
+        result.Id.Should().Be(coverLetter.Id);
+        result.VacancyId.Should().Be(coverLetter.VacancyId);
+        result.Content.Should().Be(new string('b', 90));
+        result.UpdatedAt.Should().BeAfter(previousUpdatedAt);
+
+        _repositoryMock.Verify(x => x.UpdateAsync(coverLetter, It.IsAny<CancellationToken>()), Times.Once);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CrossUserUpdate_ThrowsForbiddenException()
+    {
+        var ownerId = Guid.NewGuid();
+        var attackerId = Guid.NewGuid();
+        var coverLetter = new CoverLetter
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            VacancyId = Guid.NewGuid(),
+            Content = new string('a', 80),
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(coverLetter.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(coverLetter);
+
+        var act = () => _handler.Handle(
+            new UpdateCoverLetterCommand
+            {
+                CoverLetterId = coverLetter.Id,
+                UserId = attackerId,
+                Content = new string('x', 80),
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<CoverLetter>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_PropagatesNotFoundException()
+    {
+        var coverLetterId = Guid.NewGuid();
+
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(coverLetterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("CoverLetter", coverLetterId));
+
+        var act = () => _handler.Handle(
+            new UpdateCoverLetterCommand
+            {
+                CoverLetterId = coverLetterId,
+                UserId = Guid.NewGuid(),
+                Content = new string('z', 90),
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/CoverLetters/UpdateCoverLetterCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/CoverLetters/UpdateCoverLetterCommandValidatorTests.cs
@@ -1,0 +1,153 @@
+using FluentAssertions;
+using JobNecto.Application.CoverLetters;
+using JobNecto.Application.CoverLetters.Validators;
+
+namespace JobNecto.Tests.Application.CoverLetters;
+
+public class UpdateCoverLetterCommandValidatorTests
+{
+    private readonly UpdateCoverLetterCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidPayload_Passes()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = new string('a', 50),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyCoverLetterId_Fails()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.Empty,
+            UserId = Guid.NewGuid(),
+            Content = new string('a', 50),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "CoverLetterId");
+    }
+
+    [Fact]
+    public void Validate_EmptyUserId_Fails()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.Empty,
+            Content = new string('a', 50),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "UserId");
+    }
+
+    [Fact]
+    public void Validate_ContentLessThan50Chars_Fails()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = new string('a', 49),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Fact]
+    public void Validate_ContentExactly50Chars_Passes()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = new string('a', 50),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ContentExactly10000Chars_Passes()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = new string('a', 10000),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ContentMoreThan10000Chars_Fails()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = new string('a', 10001),
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Validate_NullOrEmptyContent_Fails(string? content)
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = content!,
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+
+    [Fact]
+    public void Validate_WhitespaceOnlyContent_Fails()
+    {
+        var command = new UpdateCoverLetterCommand
+        {
+            CoverLetterId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Content = "   ",
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.PropertyName == "Content");
+    }
+}


### PR DESCRIPTION
## Summary
- implement Epic 5 cover letter management end to end (create, list, detail, update, delete)
- add CoverLetters API controller actions and corresponding Application command/query handlers and validators
- introduce ICoverLetterRepository with specialized list/detail queries and wire it through UnitOfWork
- enforce one cover letter per user per vacancy with EF partial unique index and migration
- add extensive API and Application tests for cover letter flows, ownership rules, pagination, and conflict behavior
- standardize CI-gated PostgreSQL availability handling in DB-backed uniqueness/concurrency test suites
- update implementation and planning artifacts for Epic 5 progress

## Validation
- targeted and full tests were run during implementation and passed
- release build with warnings as errors passed
- local database migrations applied successfully

## Notes
- includes both implementation code and related planning/documentation updates present in the working tree
