### PR TITLE
test: enforce 80% per-file coverage (backend + frontend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,45 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Restore
         run: dotnet restore backend/JobNecto.slnx
 
       - name: Build
         run: dotnet build backend/JobNecto.slnx --configuration Release --no-restore --warnaserror
 
-      - name: Test
-        run: dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror
+      - name: Test (with coverage)
+        run: >-
+          dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserror
+          --collect:"XPlat Code Coverage"
+          --settings backend/coverlet.runsettings
+          --results-directory ./coverage/backend
+
+      - name: Coverage gate (>=80% per file)
+        run: python scripts/check_coverage.py ./coverage/backend --threshold 80
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Test (with coverage gate >=80% per file)
+        run: npx ng test --no-watch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,14 @@ JobNecto is a .NET 10 backend API for job vacancy aggregation and matching. Clea
 - **Test:** `dotnet test backend/JobNecto.slnx`
 - **CI-equivalent lint/build:** `dotnet build backend/JobNecto.slnx --configuration Release --warnaserror`
 
+### Test coverage policy (enforced in CI)
+
+- **Target:** ≥80% line coverage on **every hand-written file** (backend and frontend). CI fails when any included file drops below 80%.
+- **Backend gate:** `dotnet test ... --collect:"XPlat Code Coverage" --settings backend/coverlet.runsettings --results-directory ./coverage/backend` then `python scripts/check_coverage.py ./coverage/backend --threshold 80`.
+- **Frontend gate:** `cd frontend && npx ng test --no-watch` — the Angular unit-test builder enforces the per-file threshold (`coverageThresholds.perFile` in `frontend/angular.json`).
+- **Excluded from the gate:** generated code (EF Core migrations, OpenAPI source generators, the OpenAPI-typed `frontend/src/shared/api/generated`), barrels/config/bootstrap, and pure design-token/data files. Exclusions live in `backend/coverlet.runsettings` and `frontend/angular.json` (`coverageExclude`).
+- **Genuinely untestable I/O** (e.g. live Cloudinary HTTP calls) is marked `[ExcludeFromCodeCoverage]` with a justification rather than left uncovered. Prefer testing the surrounding logic; only exclude the unavoidable I/O boundary.
+
 ### Running the API
 
 - Start: `cd backend/src/JobNecto.API && ASPNETCORE_ENVIRONMENT=Development DOTNET_URLS="http://localhost:5000" dotnet run`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ dotnet test backend/JobNecto.slnx --configuration Release --no-build --warnaserr
 
 > Use **`backend/JobNecto.slnx`** for all CLI operations. The root `Jobnecto.sln` uses legacy path style and does not include the test project.
 
+### Test coverage (80% per-file gate)
+
+CI enforces **≥80% line coverage on every hand-written file**. Generated code
+(EF Core migrations, OpenAPI source generators, the OpenAPI-typed frontend
+schema) and pure wiring/config are excluded; genuinely untestable I/O is marked
+`[ExcludeFromCodeCoverage]`.
+
+Backend — collect coverage and run the per-file gate locally:
+
+```bash
+dotnet test backend/JobNecto.slnx \
+  --collect:"XPlat Code Coverage" \
+  --settings backend/coverlet.runsettings \
+  --results-directory ./coverage/backend
+python scripts/check_coverage.py ./coverage/backend --threshold 80
+```
+
+Frontend — the Angular unit-test builder enforces the per-file threshold itself
+(it fails the run when any file drops below 80%):
+
+```bash
+cd frontend && npx ng test --no-watch
+```
+
 ### Run the API locally
 
 ```bash
@@ -189,7 +213,10 @@ For more database workflows, see [AGENTS.md](AGENTS.md) and the project skill fo
 
 ## Continuous integration
 
-GitHub Actions (`.github/workflows/ci.yml`) runs **restore**, **build**, and **test** on pushes to `master` and on pull requests.
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes to `master` and on pull requests:
+
+- **`build`** — restores, builds (Release, warnings as errors), runs the .NET tests with coverage, and fails if any hand-written file is below 80% line coverage (`scripts/check_coverage.py`).
+- **`frontend`** — installs the Angular app and runs the Vitest suite with its per-file 80% coverage gate.
 
 ## Comprehensive PR review workflow
 

--- a/backend/coverlet.runsettings
+++ b/backend/coverlet.runsettings
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Coverage settings passed to dotnet test via the settings option.
+  Excludes auto-generated code that must never be unit-tested so the per-file
+  80 percent gate (scripts/check_coverage.py) only measures hand-written code.
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!-- Skip auto-property getters/setters (entities, DTOs, records). -->
+          <SkipAutoProps>true</SkipAutoProps>
+          <!-- Exclude code marked generated or explicitly opted out. -->
+          <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+          <!-- Exclude EF Core migrations and any source emitted into obj (source generators). -->
+          <ExcludeByFile>**/Migrations/**/*.cs,**/obj/**/*.cs</ExcludeByFile>
+          <!-- Only measure our own assemblies. -->
+          <Include>[JobNecto.*]*</Include>
+          <Exclude>[JobNecto.Tests]*</Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/backend/src/JobNecto.Infrastructure/JobNecto.Infrastructure.csproj
+++ b/backend/src/JobNecto.Infrastructure/JobNecto.Infrastructure.csproj
@@ -5,6 +5,10 @@
     <ProjectReference Include="..\JobNecto.Domain\JobNecto.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="JobNecto.Tests" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/backend/src/JobNecto.Infrastructure/Services/CloudinaryAvatarStorageService.cs
+++ b/backend/src/JobNecto.Infrastructure/Services/CloudinaryAvatarStorageService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CloudinaryDotNet;
 using CloudinaryDotNet.Actions;
 using JobNecto.Application.Interfaces;
@@ -29,6 +30,7 @@ public sealed class CloudinaryAvatarStorageService : IAvatarStorageService
     }
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage(Justification = "Performs live Cloudinary HTTP upload; not unit-testable without the external service.")]
     public async Task<AvatarUploadResult> UploadUserAvatarAsync(
         Guid userId,
         Stream content,
@@ -73,6 +75,7 @@ public sealed class CloudinaryAvatarStorageService : IAvatarStorageService
     }
 
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage(Justification = "Performs live Cloudinary HTTP delete; not unit-testable without the external service.")]
     public async Task DeleteUserAvatarAsync(Guid userId, CancellationToken ct)
     {
         EnsureConfigured();
@@ -149,12 +152,12 @@ public sealed class CloudinaryAvatarStorageService : IAvatarStorageService
         return new Account(cloudName, apiKey, apiSecret);
     }
 
-    private static string BuildAvatarPublicId(Guid userId)
+    internal static string BuildAvatarPublicId(Guid userId)
     {
         return $"users/{userId:N}/avatar";
     }
 
-    private static string ResolveImageFormat(string? contentType)
+    internal static string ResolveImageFormat(string? contentType)
     {
         if (string.IsNullOrWhiteSpace(contentType))
         {

--- a/backend/tests/JobNecto.Tests/API/AuthenticationCollectionExtensionsTests.cs
+++ b/backend/tests/JobNecto.Tests/API/AuthenticationCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using JobNecto.API.Infrastructure;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -29,7 +30,7 @@ public class AuthenticationCollectionExtensionsTests
         var act = () => services.AddJwtAuthentication(Config(ValidSecret, "jobnecto", "jobnecto-clients"));
 
         act.Should().NotThrow();
-        services.Should().Contain(d => d.ServiceType.Name.Contains("IAuthenticationService"));
+        services.Should().Contain(d => d.ServiceType == typeof(IAuthenticationService));
     }
 
     [Theory]

--- a/backend/tests/JobNecto.Tests/API/AuthenticationCollectionExtensionsTests.cs
+++ b/backend/tests/JobNecto.Tests/API/AuthenticationCollectionExtensionsTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using JobNecto.API.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JobNecto.Tests.API;
+
+public class AuthenticationCollectionExtensionsTests
+{
+    private const string ValidSecret = "this-is-a-sufficiently-long-secret-key!!";
+
+    private static IConfiguration Config(string? secret, string? issuer, string? audience)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["JwtSettings:SecretKey"] = secret,
+            ["JwtSettings:Issuer"] = issuer,
+            ["JwtSettings:Audience"] = audience,
+        };
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    [Fact]
+    public void AddJwtAuthentication_WithValidConfig_RegistersAuthentication()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.AddJwtAuthentication(Config(ValidSecret, "jobnecto", "jobnecto-clients"));
+
+        act.Should().NotThrow();
+        services.Should().Contain(d => d.ServiceType.Name.Contains("IAuthenticationService"));
+    }
+
+    [Theory]
+    [InlineData(null, "SecretKey")]
+    [InlineData("", "SecretKey")]
+    [InlineData("too-short", "at least 32")]
+    public void AddJwtAuthentication_WithMissingOrShortSecret_Throws(string? secret, string expectedFragment)
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddJwtAuthentication(Config(secret, "issuer", "audience"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain(expectedFragment);
+    }
+
+    [Fact]
+    public void AddJwtAuthentication_WithMissingIssuer_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddJwtAuthentication(Config(ValidSecret, null, "audience"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("Issuer");
+    }
+
+    [Fact]
+    public void AddJwtAuthentication_WithMissingAudience_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddJwtAuthentication(Config(ValidSecret, "issuer", null));
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("Audience");
+    }
+}

--- a/backend/tests/JobNecto.Tests/API/InfrastructureHostingTests.cs
+++ b/backend/tests/JobNecto.Tests/API/InfrastructureHostingTests.cs
@@ -169,4 +169,58 @@ public sealed class InfrastructureHostingTests
             .Contain("Host")
             .And.Contain("non-empty");
     }
+
+    /// <summary>
+    /// Purpose: cover the "Cloudinary is configured" branch so the startup warning is skipped.
+    /// Contract: registration completes and <see cref="IAvatarStorageService"/> is registered.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_with_Cloudinary_configured_skips_warning()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:Postgres"] =
+                        "Host=localhost;Port=5432;Database=JobNecto;Username=test;Password=test",
+                    ["Cloudinary:CloudName"] = "demo",
+                    ["Cloudinary:ApiKey"] = "key",
+                    ["Cloudinary:ApiSecret"] = "secret",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging();
+
+        var act = () => services.AddInfrastructure(configuration);
+
+        act.Should().NotThrow();
+        services.Should().Contain(d => d.ServiceType == typeof(IAvatarStorageService));
+    }
+
+    /// <summary>
+    /// Purpose: cover the warning fallback when no <see cref="ILoggerFactory"/> is registered.
+    /// Contract: registration still completes (warning written to console instead of the log).
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_without_logging_and_Cloudinary_does_not_throw()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:Postgres"] =
+                        "Host=localhost;Port=5432;Database=JobNecto;Username=test;Password=test",
+                }
+            )
+            .Build();
+
+        var services = new ServiceCollection();
+
+        var act = () => services.AddInfrastructure(configuration);
+
+        act.Should().NotThrow();
+    }
 }

--- a/backend/tests/JobNecto.Tests/Application/ApplicationExceptionsTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/ApplicationExceptionsTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using JobNecto.Application.Exceptions;
+
+namespace JobNecto.Tests.Application;
+
+public class ApplicationExceptionsTests
+{
+    [Fact]
+    public void ConflictException_Parameterless_UsesDefaultMessage()
+    {
+        var ex = new ConflictException();
+
+        ex.Message.Should().Be("A conflict occurred with the current state of the resource.");
+    }
+
+    [Fact]
+    public void ConflictException_WithMessage_UsesProvidedMessage()
+    {
+        var ex = new ConflictException("duplicate email");
+
+        ex.Message.Should().Be("duplicate email");
+    }
+
+    [Fact]
+    public void UnauthorizedException_Parameterless_CanBeConstructed()
+    {
+        var ex = new UnauthorizedException();
+
+        ex.Should().BeAssignableTo<Exception>();
+        ex.Message.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void UnauthorizedException_WithMessage_UsesProvidedMessage()
+    {
+        var ex = new UnauthorizedException("invalid credentials");
+
+        ex.Message.Should().Be("invalid credentials");
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/Resumes/ResumeMappersTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Resumes/ResumeMappersTests.cs
@@ -1,0 +1,221 @@
+using FluentAssertions;
+using JobNecto.Application.Resumes;
+using JobNecto.Application.Resumes.Mappers;
+using JobNecto.Domain.Entities;
+using JobNecto.Domain.Enums;
+
+namespace JobNecto.Tests.Application.Resumes;
+
+public class ResumeMappersTests
+{
+    [Fact]
+    public void ToEntity_NullCommand_Throws()
+    {
+        CreateResumeCommand command = null!;
+
+        var act = () => command.ToEntity();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ToEntity_WithValidEnumStrings_ParsesEnums()
+    {
+        var command = new CreateResumeCommand
+        {
+            UserId = Guid.NewGuid(),
+            Title = "Senior .NET",
+            Skills = ["C#"],
+            WorkLocationType = "Remote",
+            Salary = 1000m,
+            Currency = "USD",
+            Experience = "ThreeToFiveYears",
+            Locations = [Location.Ukraine],
+        };
+
+        var entity = command.ToEntity();
+
+        entity.UserId.Should().Be(command.UserId);
+        entity.Title.Should().Be("Senior .NET");
+        entity.Currency.Should().Be(Currency.USD);
+        entity.WorkLocationType.Should().Be(WorkLocationType.Remote);
+        entity.Experience.Should().Be(Experience.ThreeToFiveYears);
+    }
+
+    [Fact]
+    public void ToEntity_WithInvalidEnumStrings_MapsToNull()
+    {
+        var command = new CreateResumeCommand
+        {
+            UserId = Guid.NewGuid(),
+            Title = "Dev",
+            Skills = ["C#"],
+            WorkLocationType = "not-a-value",
+            Currency = "XXX",
+            Experience = "huge",
+        };
+
+        var entity = command.ToEntity();
+
+        entity.Currency.Should().BeNull();
+        entity.WorkLocationType.Should().BeNull();
+        entity.Experience.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToEntity_WithBlankCurrencyAndExperience_MapsToNull()
+    {
+        var command = new CreateResumeCommand
+        {
+            UserId = Guid.NewGuid(),
+            Title = "Dev",
+            Skills = ["C#"],
+            WorkLocationType = "Remote",
+            Currency = "   ",
+            Experience = "   ",
+        };
+
+        var entity = command.ToEntity();
+
+        entity.Currency.Should().BeNull();
+        entity.Experience.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToResumeResult_NullResume_Throws()
+    {
+        Resume resume = null!;
+
+        var act = () => resume.ToResumeResult();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ToResumeResult_WithNullOptionalFields_UsesEmptyDefaults()
+    {
+        var resume = new Resume
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Title = null,
+            Currency = null,
+            Skills = null,
+            WorkLocationType = null,
+            Experience = null,
+        };
+
+        var result = resume.ToResumeResult();
+
+        result.Title.Should().BeEmpty();
+        result.Currency.Should().BeEmpty();
+        result.Skills.Should().BeEmpty();
+        result.WorkLocationType.Should().BeEmpty();
+        result.Experience.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToResumeResult_WithValues_MapsAllFields()
+    {
+        var resume = new Resume
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Title = "QA",
+            Salary = 500m,
+            Currency = Currency.EUR,
+            Skills = ["test"],
+            WorkLocationType = WorkLocationType.Hybrid,
+            Experience = Experience.OneToThreeYears,
+        };
+
+        var result = resume.ToResumeResult();
+
+        result.Title.Should().Be("QA");
+        result.Currency.Should().Be("EUR");
+        result.WorkLocationType.Should().Be("Hybrid");
+        result.Experience.Should().Be("OneToThreeYears");
+        result.Skills.Should().BeEquivalentTo(["test"]);
+    }
+
+    [Fact]
+    public void ApplyUpdates_WithAllFieldsSet_UpdatesEntity()
+    {
+        var resume = new Resume { Title = "old", UserId = Guid.NewGuid() };
+        var command = new UpdateResumeCommand
+        {
+            Title = "new",
+            Salary = 42m,
+            Currency = "GBP",
+            Skills = ["a", "b"],
+            WorkLocationType = "OnSite",
+            Experience = "MoreThanFiveYears",
+            Projects = ["p"],
+            Certifications = ["c"],
+            Languages = [],
+            Locations = [Location.Poland],
+            ExcludedWords = ["x"],
+        };
+
+        resume.ApplyUpdates(command);
+
+        resume.Title.Should().Be("new");
+        resume.Salary.Should().Be(42m);
+        resume.Currency.Should().Be(Currency.GBP);
+        resume.Skills.Should().BeEquivalentTo(["a", "b"]);
+        resume.WorkLocationType.Should().Be(WorkLocationType.OnSite);
+        resume.Experience.Should().Be(Experience.MoreThanFiveYears);
+        resume.Projects.Should().BeEquivalentTo(["p"]);
+        resume.Certifications.Should().BeEquivalentTo(["c"]);
+        resume.Locations.Should().BeEquivalentTo([Location.Poland]);
+        resume.ExcludedWords.Should().BeEquivalentTo(["x"]);
+    }
+
+    [Fact]
+    public void ApplyUpdates_WithBlankOrInvalidEnums_MapsToNull()
+    {
+        var resume = new Resume
+        {
+            UserId = Guid.NewGuid(),
+            Currency = Currency.USD,
+            WorkLocationType = WorkLocationType.Remote,
+            Experience = Experience.OneToThreeYears,
+        };
+        var command = new UpdateResumeCommand
+        {
+            Currency = "   ",
+            WorkLocationType = "nonsense",
+            Experience = "   ",
+        };
+
+        resume.ApplyUpdates(command);
+
+        resume.Currency.Should().BeNull();
+        resume.WorkLocationType.Should().BeNull();
+        resume.Experience.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyUpdates_WithNoFieldsSet_LeavesEntityUnchanged()
+    {
+        var resume = new Resume
+        {
+            Title = "keep",
+            Salary = 10m,
+            Currency = Currency.USD,
+            Skills = ["s"],
+            WorkLocationType = WorkLocationType.Remote,
+            Experience = Experience.LessThanOneYear,
+            UserId = Guid.NewGuid(),
+        };
+
+        resume.ApplyUpdates(new UpdateResumeCommand());
+
+        resume.Title.Should().Be("keep");
+        resume.Salary.Should().Be(10m);
+        resume.Currency.Should().Be(Currency.USD);
+        resume.Skills.Should().BeEquivalentTo(["s"]);
+        resume.WorkLocationType.Should().Be(WorkLocationType.Remote);
+        resume.Experience.Should().Be(Experience.LessThanOneYear);
+    }
+}

--- a/backend/tests/JobNecto.Tests/Application/Users/UploadCurrentUserAvatarCommandValidatorTests.cs
+++ b/backend/tests/JobNecto.Tests/Application/Users/UploadCurrentUserAvatarCommandValidatorTests.cs
@@ -96,4 +96,82 @@ public class UploadCurrentUserAvatarCommandValidatorTests
         result!.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "ContentType");
     }
+
+    public static IEnumerable<object[]> ValidSignatures()
+    {
+        yield return ["image/jpeg", new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }];
+        yield return ["image/jpg", new byte[] { 0xFF, 0xD8, 0xFF, 0xDB }];
+        yield return ["image/png", new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }];
+        yield return ["image/webp", new byte[] { 0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50 }];
+        yield return ["image/gif", new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }];
+        yield return ["image/gif", new byte[] { 0x47, 0x49, 0x46, 0x38, 0x37, 0x61 }];
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidSignatures))]
+    public void Validate_MatchingSignatureForEachType_Passes(string contentType, byte[] content)
+    {
+        var command = new UploadCurrentUserAvatarCommand
+        {
+            FileName = "avatar",
+            ContentType = contentType,
+            Content = content
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_EmptyFileName_Fails()
+    {
+        var command = new UploadCurrentUserAvatarCommand
+        {
+            FileName = "",
+            ContentType = "image/png",
+            Content = PngBytes
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "FileName");
+    }
+
+    [Fact]
+    public void Validate_FileNameTooLong_Fails()
+    {
+        var command = new UploadCurrentUserAvatarCommand
+        {
+            FileName = new string('a', 256),
+            ContentType = "image/png",
+            Content = PngBytes
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "FileName");
+    }
+
+    [Fact]
+    public void Validate_ContentLargerThanFiveMegabytes_Fails()
+    {
+        var oversized = new byte[5 * 1024 * 1024 + 1];
+        // Keep a valid PNG signature so only the size rule fails.
+        Array.Copy(PngBytes, oversized, PngBytes.Length);
+
+        var command = new UploadCurrentUserAvatarCommand
+        {
+            FileName = "avatar.png",
+            ContentType = "image/png",
+            Content = oversized
+        };
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("5 MB"));
+    }
 }

--- a/backend/tests/JobNecto.Tests/Domain/LanguageProficiencyTests.cs
+++ b/backend/tests/JobNecto.Tests/Domain/LanguageProficiencyTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using JobNecto.Domain.Enums;
+using JobNecto.Domain.ValueObjects;
+
+// Intentionally in the global namespace (matching PaginationTests): a
+// `JobNecto.Tests.Domain` namespace would shadow `JobNecto.Domain` for tests
+// that reference `Domain.Enums.*` relatively.
+public class LanguageProficiencyTests
+{
+    [Fact]
+    public void Constructor_SetsLanguageAndLevel()
+    {
+        var proficiency = new LanguageProficiency(Language.English, LanguageLevel.Advanced);
+
+        proficiency.Language.Should().Be(Language.English);
+        proficiency.Level.Should().Be(LanguageLevel.Advanced);
+    }
+
+    [Fact]
+    public void Records_WithSameValues_AreEqual()
+    {
+        var a = new LanguageProficiency(Language.German, LanguageLevel.Intermediate);
+        var b = new LanguageProficiency(Language.German, LanguageLevel.Intermediate);
+
+        a.Should().Be(b);
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void Records_WithDifferentValues_AreNotEqual()
+    {
+        var a = new LanguageProficiency(Language.French, LanguageLevel.Beginner);
+        var b = new LanguageProficiency(Language.French, LanguageLevel.Native);
+
+        a.Should().NotBe(b);
+    }
+}

--- a/backend/tests/JobNecto.Tests/Infrastructure/DbCommandTimingInterceptorTests.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/DbCommandTimingInterceptorTests.cs
@@ -1,0 +1,198 @@
+using System.Data.Common;
+using FluentAssertions;
+using JobNecto.Infrastructure.Persistance.Interceptors;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Npgsql;
+
+namespace JobNecto.Tests.Infrastructure;
+
+public class DbCommandTimingInterceptorTests
+{
+    private static DbCommand Command(string sql) => new NpgsqlCommand(sql);
+
+    private static Mock<ILogger<DbCommandTimingInterceptor>> Logger(bool enabled)
+    {
+        var logger = new Mock<ILogger<DbCommandTimingInterceptor>>();
+        logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(enabled);
+        return logger;
+    }
+
+    private static CommandExecutedEventData ExecutedData(DbCommand command) =>
+        new(
+            eventDefinition: null!,
+            messageGenerator: null!,
+            connection: null!,
+            command: command,
+            logCommandText: command.CommandText,
+            context: null,
+            executeMethod: DbCommandMethod.ExecuteReader,
+            commandId: Guid.NewGuid(),
+            connectionId: Guid.NewGuid(),
+            result: null,
+            async: false,
+            logParameterValues: false,
+            startTime: DateTimeOffset.UtcNow,
+            duration: TimeSpan.FromMilliseconds(12.345),
+            commandSource: CommandSource.Unknown);
+
+    private static CommandErrorEventData ErrorData(DbCommand command) =>
+        new(
+            eventDefinition: null!,
+            messageGenerator: null!,
+            connection: null!,
+            command: command,
+            logCommandText: command.CommandText,
+            context: null,
+            executeMethod: DbCommandMethod.ExecuteReader,
+            commandId: Guid.NewGuid(),
+            connectionId: Guid.NewGuid(),
+            exception: new InvalidOperationException("boom"),
+            async: false,
+            logParameterValues: false,
+            startTime: DateTimeOffset.UtcNow,
+            duration: TimeSpan.FromMilliseconds(7),
+            commandSource: CommandSource.Unknown);
+
+    [Fact]
+    public void ReaderExecuted_WhenLoggingEnabled_LogsAndReturnsResult()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+        using var reader = new EmptyDataReader();
+
+        var result = interceptor.ReaderExecuted(Command("SELECT 1"), ExecutedData(Command("SELECT 1")), reader);
+
+        result.Should().BeSameAs(reader);
+    }
+
+    [Fact]
+    public void ScalarExecuted_ReturnsResult()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+
+        var result = interceptor.ScalarExecuted(Command("SELECT 1"), ExecutedData(Command("SELECT 1")), 42);
+
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void NonQueryExecuted_ReturnsResult()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+
+        var result = interceptor.NonQueryExecuted(Command("DELETE FROM t"), ExecutedData(Command("DELETE FROM t")), 3);
+
+        result.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task AsyncExecutedMethods_ReturnResults()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+        using var reader = new EmptyDataReader();
+
+        var readerResult = await interceptor.ReaderExecutedAsync(Command("SELECT 1"), ExecutedData(Command("SELECT 1")), reader);
+        var scalarResult = await interceptor.ScalarExecutedAsync(Command("SELECT 1"), ExecutedData(Command("SELECT 1")), 9);
+        var nonQueryResult = await interceptor.NonQueryExecutedAsync(Command("UPDATE t SET x=1"), ExecutedData(Command("UPDATE t SET x=1")), 1);
+
+        readerResult.Should().BeSameAs(reader);
+        scalarResult.Should().Be(9);
+        nonQueryResult.Should().Be(1);
+    }
+
+    [Fact]
+    public void Executed_WhenLoggingDisabled_SkipsLoggingAndReturnsResult()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: false).Object);
+
+        var result = interceptor.ScalarExecuted(Command("SELECT 1"), ExecutedData(Command("SELECT 1")), 5);
+
+        result.Should().Be(5);
+    }
+
+    [Fact]
+    public void Executed_WithLongSql_TruncatesWithoutThrowing()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+        var longSql = "SELECT " + new string('x', 400) + "    \n   FROM t";
+
+        var act = () => interceptor.NonQueryExecuted(Command(longSql), ExecutedData(Command(longSql)), 0);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Executed_WithEmptySql_DoesNotThrow()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+
+        var act = () => interceptor.NonQueryExecuted(Command(string.Empty), ExecutedData(Command(string.Empty)), 0);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CommandFailed_WhenWarningEnabled_LogsWarning()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+
+        var act = () => interceptor.CommandFailed(Command("SELECT bad"), ErrorData(Command("SELECT bad")));
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CommandFailed_WhenWarningDisabled_SkipsLogging()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: false).Object);
+
+        var act = () => interceptor.CommandFailed(Command("SELECT bad"), ErrorData(Command("SELECT bad")));
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task CommandFailedAsync_DoesNotThrow()
+    {
+        var interceptor = new DbCommandTimingInterceptor(Logger(enabled: true).Object);
+
+        await interceptor.CommandFailedAsync(Command("SELECT bad"), ErrorData(Command("SELECT bad")));
+    }
+
+    /// <summary>Minimal DbDataReader so interceptor tests need no live connection.</summary>
+    private sealed class EmptyDataReader : DbDataReader
+    {
+        public override bool Read() => false;
+        public override bool NextResult() => false;
+        public override int Depth => 0;
+        public override bool IsClosed => false;
+        public override int RecordsAffected => 0;
+        public override int FieldCount => 0;
+        public override bool HasRows => false;
+        public override object this[int ordinal] => throw new NotSupportedException();
+        public override object this[string name] => throw new NotSupportedException();
+        public override bool GetBoolean(int ordinal) => throw new NotSupportedException();
+        public override byte GetByte(int ordinal) => throw new NotSupportedException();
+        public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+        public override char GetChar(int ordinal) => throw new NotSupportedException();
+        public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+        public override string GetDataTypeName(int ordinal) => throw new NotSupportedException();
+        public override DateTime GetDateTime(int ordinal) => throw new NotSupportedException();
+        public override decimal GetDecimal(int ordinal) => throw new NotSupportedException();
+        public override double GetDouble(int ordinal) => throw new NotSupportedException();
+        public override Type GetFieldType(int ordinal) => throw new NotSupportedException();
+        public override float GetFloat(int ordinal) => throw new NotSupportedException();
+        public override Guid GetGuid(int ordinal) => throw new NotSupportedException();
+        public override short GetInt16(int ordinal) => throw new NotSupportedException();
+        public override int GetInt32(int ordinal) => throw new NotSupportedException();
+        public override long GetInt64(int ordinal) => throw new NotSupportedException();
+        public override string GetName(int ordinal) => throw new NotSupportedException();
+        public override int GetOrdinal(string name) => throw new NotSupportedException();
+        public override string GetString(int ordinal) => throw new NotSupportedException();
+        public override object GetValue(int ordinal) => throw new NotSupportedException();
+        public override int GetValues(object[] values) => throw new NotSupportedException();
+        public override bool IsDBNull(int ordinal) => throw new NotSupportedException();
+        public override System.Collections.IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+    }
+}

--- a/backend/tests/JobNecto.Tests/Infrastructure/Services/CloudinaryAvatarStorageServiceTests.cs
+++ b/backend/tests/JobNecto.Tests/Infrastructure/Services/CloudinaryAvatarStorageServiceTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using JobNecto.Infrastructure.Configuration;
+using JobNecto.Infrastructure.Services;
+using Microsoft.Extensions.Options;
+
+namespace JobNecto.Tests.Infrastructure.Services;
+
+public class CloudinaryAvatarStorageServiceTests
+{
+    private static CloudinaryAvatarStorageService Create(CloudinarySettings settings) =>
+        new(Options.Create(settings));
+
+    [Fact]
+    public void Constructor_WithCloudinaryUrl_ConfiguresWithoutThrowing()
+    {
+        var act = () => Create(new CloudinarySettings { CloudinaryUrl = "cloudinary://mykey:mysecret@mycloud" });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Constructor_WithDiscreteCredentials_ConfiguresWithoutThrowing()
+    {
+        var act = () => Create(new CloudinarySettings { CloudName = "c", ApiKey = "k", ApiSecret = "s" });
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("http://example.com")]          // wrong scheme
+    [InlineData("::: not a uri")]               // unparseable
+    [InlineData("cloudinary://onlyuser@host")]  // userinfo has no secret
+    [InlineData("cloudinary://:@host")]         // empty key and secret
+    public async Task Constructor_WithUnusableUrlAndNoCredentials_LeavesServiceUnconfigured(string url)
+    {
+        var service = Create(new CloudinarySettings { CloudinaryUrl = url });
+
+        var act = async () => await service.DeleteUserAvatarAsync(Guid.NewGuid(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Cloudinary settings are missing*");
+    }
+
+    [Fact]
+    public async Task UploadUserAvatarAsync_WhenUnconfigured_ThrowsInvalidOperation()
+    {
+        var service = Create(new CloudinarySettings());
+
+        using var content = new MemoryStream([1, 2, 3]);
+        var act = async () => await service.UploadUserAvatarAsync(
+            Guid.NewGuid(), content, "a.png", "image/png", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Cloudinary settings are missing*");
+    }
+
+    [Fact]
+    public void BuildAvatarPublicId_UsesUserScopedPath()
+    {
+        var userId = Guid.NewGuid();
+
+        CloudinaryAvatarStorageService.BuildAvatarPublicId(userId)
+            .Should().Be($"users/{userId:N}/avatar");
+    }
+
+    [Theory]
+    [InlineData("image/jpeg", "jpg")]
+    [InlineData("image/jpg", "jpg")]
+    [InlineData("IMAGE/PNG", "png")]
+    [InlineData("image/webp", "webp")]
+    [InlineData("image/gif", "gif")]
+    [InlineData("application/octet-stream", "jpg")]
+    [InlineData(null, "jpg")]
+    [InlineData("   ", "jpg")]
+    public void ResolveImageFormat_MapsContentTypeToExtension(string? contentType, string expected)
+    {
+        CloudinaryAvatarStorageService.ResolveImageFormat(contentType).Should().Be(expected);
+    }
+}

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -70,7 +70,26 @@
           "defaultConfiguration": "development"
         },
         "test": {
-          "builder": "@angular/build:unit-test"
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "coverage": true,
+            "coverageReporters": ["text", "text-summary", "cobertura"],
+            "coverageExclude": [
+              "src/main.ts",
+              "src/**/index.ts",
+              "src/app/app.config.ts",
+              "src/app/app.routes.ts",
+              "src/shared/api/generated/**",
+              "src/shared/config/**",
+              "src/entities/user/model.ts",
+              "src/**/*.spec.ts"
+            ],
+            "coverageThresholds": {
+              "perFile": true,
+              "lines": 80,
+              "statements": 80
+            }
+          }
         }
       }
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@angular/build": "^21.2.12",
         "@angular/cli": "^21.2.12",
         "@angular/compiler-cli": "^21.2.0",
+        "@vitest/coverage-v8": "^4.1.9",
         "autoprefixer": "^10.4.20",
         "jsdom": "^28.0.0",
         "openapi-typescript": "^7.13.0",
@@ -986,6 +987,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -4184,17 +4195,48 @@
         "vite": "^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -4203,13 +4245,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.7",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4230,9 +4272,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4243,13 +4285,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4257,14 +4299,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4273,9 +4315,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4283,13 +4325,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4515,6 +4557,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -6000,6 +6061,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -6071,6 +6142,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -6437,6 +6515,48 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -6808,6 +6928,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -9454,19 +9602,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.7",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/runner": "4.1.7",
-        "@vitest/snapshot": "4.1.7",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -9494,12 +9642,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.7",
-        "@vitest/browser-preview": "4.1.7",
-        "@vitest/browser-webdriverio": "4.1.7",
-        "@vitest/coverage-istanbul": "4.1.7",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@angular/build": "^21.2.12",
     "@angular/cli": "^21.2.12",
     "@angular/compiler-cli": "^21.2.0",
+    "@vitest/coverage-v8": "^4.1.9",
     "autoprefixer": "^10.4.20",
     "jsdom": "^28.0.0",
     "openapi-typescript": "^7.13.0",

--- a/frontend/src/pages/auth-sign-up/sign-up.page.spec.ts
+++ b/frontend/src/pages/auth-sign-up/sign-up.page.spec.ts
@@ -149,4 +149,90 @@ describe('SignUpPage', () => {
       expect(errorEl?.getAttribute('aria-live')).toBe('polite');
     });
   });
+
+  describe('errorFor message mapping', () => {
+    /** Sets one field's value, marks it touched, and returns its message. */
+    function messageFor(field: 'loginName' | 'email' | 'password', value: string): string {
+      const control = page.form.controls[field];
+      control.setValue(value);
+      control.markAsTouched();
+      return page.errorFor(field);
+    }
+
+    it('returns empty string while the control is untouched and pristine', () => {
+      page.form.controls.loginName.setValue('ab'); // invalid, but not touched/dirty
+      expect(page.errorFor('loginName')).toBe('');
+    });
+
+    it.each([
+      ['loginName', '', 'Login name is required.'],
+      ['loginName', 'ab', 'Login name must be between 3 and 50 characters.'],
+      ['loginName', 'bad name', 'Login name may only contain letters, numbers, or underscore.'],
+      ['email', '', 'Email is required.'],
+      ['email', 'bad', 'Enter a valid email address.'],
+      ['email', 'a'.repeat(45) + '@b.com', 'Email must be at most 50 characters.'],
+      ['password', '', 'Password is required.'],
+      ['password', '123', 'Password must be at least 8 characters.'],
+      ['password', 'p'.repeat(51), 'Password must be at most 50 characters.'],
+    ] as const)('maps %s "%s" to a plain-language message', (field, value, expected) => {
+      expect(messageFor(field, value)).toBe(expected);
+    });
+  });
+
+  describe('handleError branches', () => {
+    function submitAndFlush(body: object, status: number, statusText: string) {
+      fillValid();
+      page.onSubmit();
+      httpMock.expectOne(`${env.apiBaseUrl}/users`).flush(body, { status, statusText });
+      fixture.detectChanges();
+    }
+
+    it('maps 400 server errors onto loginName and password controls', () => {
+      submitAndFlush(
+        {
+          title: 'Validation failed',
+          status: 400,
+          errors: {
+            loginName: ['Login name already taken.'],
+            password: ['Password is too weak.'],
+          },
+        },
+        400,
+        'Bad Request',
+      );
+
+      expect(page.errorFor('loginName')).toBe('Login name already taken.');
+      expect(page.errorFor('password')).toBe('Password is too weak.');
+      httpMock.verify();
+    });
+
+    it('shows a generic banner when a 400 carries only unrecognized fields', () => {
+      submitAndFlush(
+        {
+          title: 'Validation failed',
+          status: 400,
+          detail: 'Some fields were invalid.',
+          errors: { captcha: ['Captcha failed.'] },
+        },
+        400,
+        'Bad Request',
+      );
+
+      expect(page.generalError()).toBe('Some fields were invalid.');
+      httpMock.verify();
+    });
+
+    it('shows a generic error for non-conflict, non-validation failures (500)', () => {
+      submitAndFlush(
+        { title: 'Server error', status: 500, detail: 'Something exploded.' },
+        500,
+        'Server Error',
+      );
+
+      expect(page.generalError()).toBe('Something exploded.');
+      expect(page.conflictMessage()).toBe('');
+      expect(page.submitting()).toBe(false);
+      httpMock.verify();
+    });
+  });
 });

--- a/frontend/src/pages/dashboard/dashboard.page.spec.ts
+++ b/frontend/src/pages/dashboard/dashboard.page.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { UserService } from '@entities/user';
+import type { UserProfile } from '@entities/user';
+import { DashboardPage } from './dashboard.page';
+
+describe('DashboardPage', () => {
+  const profile = signal<UserProfile | null>(null);
+
+  beforeEach(() => {
+    profile.set(null);
+    TestBed.configureTestingModule({
+      providers: [{ provide: UserService, useValue: { profile } }],
+    });
+  });
+
+  it('shows a generic welcome and "being prepared" copy when there is no profile', () => {
+    const fixture = TestBed.createComponent(DashboardPage);
+    fixture.detectChanges();
+    const text: string = fixture.nativeElement.textContent;
+
+    expect(text).toContain('Welcome');
+    expect(text).toContain('Your dashboard is being prepared.');
+  });
+
+  it('greets the hydrated user by login name and shows their email', () => {
+    profile.set({ loginName: 'ada', email: 'ada@example.com' } as UserProfile);
+
+    const fixture = TestBed.createComponent(DashboardPage);
+    fixture.detectChanges();
+    const text: string = fixture.nativeElement.textContent;
+
+    expect(text).toContain('ada');
+    expect(text).toContain("You're signed in as ada@example.com.");
+  });
+
+  it('exposes the service profile signal on the component', () => {
+    const fixture = TestBed.createComponent(DashboardPage);
+    expect(fixture.componentInstance.profile).toBe(profile);
+  });
+});

--- a/frontend/src/shared/lib/cn.spec.ts
+++ b/frontend/src/shared/lib/cn.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from './cn';
+
+describe('cn', () => {
+  it('joins truthy class names with single spaces', () => {
+    expect(cn('a', 'b', 'c')).toBe('a b c');
+  });
+
+  it('filters out falsy values', () => {
+    expect(cn('a', false, null, undefined, '', 'b')).toBe('a b');
+  });
+
+  it('returns an empty string when every value is falsy', () => {
+    expect(cn(false, null, undefined, '')).toBe('');
+  });
+
+  it('returns an empty string when called with no arguments', () => {
+    expect(cn()).toBe('');
+  });
+});

--- a/frontend/src/shared/ui/form/text-field.spec.ts
+++ b/frontend/src/shared/ui/form/text-field.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TextFieldComponent } from './text-field';
+
+describe('TextFieldComponent', () => {
+  let fixture: ComponentFixture<TextFieldComponent>;
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TextFieldComponent);
+    fixture.componentRef.setInput('label', 'Email');
+    fixture.detectChanges();
+    input = fixture.nativeElement.querySelector('input');
+  });
+
+  it('renders the label tied to the input', () => {
+    const label: HTMLLabelElement = fixture.nativeElement.querySelector('label');
+    expect(label.textContent).toContain('Email');
+    expect(label.getAttribute('for')).toBe(input.getAttribute('id'));
+  });
+
+  it('shows a required marker and aria-required when required', () => {
+    fixture.componentRef.setInput('required', true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('label').textContent).toContain('*');
+    expect(input.getAttribute('aria-required')).toBe('true');
+  });
+
+  it('writeValue reflects the value into the input', () => {
+    fixture.componentInstance.writeValue('hello');
+    fixture.detectChanges();
+    expect(input.value).toBe('hello');
+  });
+
+  it('writeValue(null) clears the value', () => {
+    fixture.componentInstance.writeValue('x');
+    fixture.detectChanges();
+    fixture.componentInstance.writeValue(null);
+    fixture.detectChanges();
+    expect(input.value).toBe('');
+  });
+
+  it('emits changes through registerOnChange when the input fires', () => {
+    let captured = '';
+    fixture.componentInstance.registerOnChange((v: string) => (captured = v));
+    input.value = 'typed';
+    input.dispatchEvent(new Event('input'));
+    expect(captured).toBe('typed');
+  });
+
+  it('notifies touched through registerOnTouched on blur', () => {
+    let touched = false;
+    fixture.componentInstance.registerOnTouched(() => (touched = true));
+    input.dispatchEvent(new Event('blur'));
+    expect(touched).toBe(true);
+  });
+
+  it('setDisabledState disables the input', () => {
+    fixture.componentInstance.setDisabledState(true);
+    fixture.detectChanges();
+    expect(input.disabled).toBe(true);
+  });
+
+  it('marks aria-invalid and points aria-describedby at the error region when in error', () => {
+    fixture.componentRef.setInput('error', 'Required');
+    fixture.detectChanges();
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(input.getAttribute('aria-describedby')).toContain('-error');
+    expect(fixture.nativeElement.textContent).toContain('Required');
+  });
+
+  it('points aria-describedby at the hint when a hint is present and there is no error', () => {
+    fixture.componentRef.setInput('hint', 'We never share it');
+    fixture.detectChanges();
+    expect(input.getAttribute('aria-describedby')).toContain('-hint');
+    expect(fixture.nativeElement.textContent).toContain('We never share it');
+  });
+
+  it('has no aria-describedby when there is neither hint nor error', () => {
+    expect(input.getAttribute('aria-describedby')).toBeNull();
+  });
+});

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -75,6 +75,10 @@ def main() -> int:
         return 2
 
     files = collect(reports)
+    # Drop files with no measurable lines (e.g. pure declarations / class
+    # headers). They cannot be meaningfully scored and would otherwise be
+    # counted as trivially "100%", masking a missing or empty source file.
+    files = {name: counts for name, counts in files.items() if counts[1] > 0}
     if not files:
         print("ERROR: no covered source files found in report(s).", file=sys.stderr)
         return 2

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Per-file coverage gate for Cobertura reports.
+
+Parses one or more `coverage.cobertura.xml` files, aggregates line coverage per
+source file (merging partial classes), and fails if total coverage OR any
+single included file falls below the threshold.
+
+Generated code (EF migrations, source-generator output in obj/, and files
+flagged generated) is excluded so the gate only measures hand-written code.
+
+Usage:
+    python scripts/check_coverage.py <report-or-dir> [--threshold 80]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+# Substrings (matched against the normalized filename) that mark generated code.
+EXCLUDED_FRAGMENTS = (
+    "/migrations/",
+    "/obj/",
+    ".designer.cs",
+    "appdbcontextmodelsnapshot",
+    ".generated.cs",
+    "/generated/",
+)
+
+
+def is_generated(filename: str) -> bool:
+    f = filename.replace("\\", "/").lower()
+    return any(frag in f for frag in EXCLUDED_FRAGMENTS)
+
+
+def find_reports(target: str) -> list[str]:
+    if os.path.isdir(target):
+        return glob.glob(os.path.join(target, "**", "coverage.cobertura.xml"), recursive=True)
+    if os.path.isfile(target):
+        return [target]
+    return []
+
+
+def collect(reports: list[str]) -> dict[str, list[int]]:
+    """filename -> [covered_lines, total_lines] merged across reports/classes."""
+    files: dict[str, list[int]] = {}
+    for report in reports:
+        root = ET.parse(report).getroot()
+        for cls in root.iter("class"):
+            filename = cls.get("filename", "")
+            if not filename or is_generated(filename):
+                continue
+            entry = files.setdefault(filename, [0, 0])
+            lines = cls.find("lines")
+            if lines is None:
+                continue
+            for line in lines.findall("line"):
+                entry[1] += 1
+                if int(line.get("hits", "0")) > 0:
+                    entry[0] += 1
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Per-file Cobertura coverage gate.")
+    parser.add_argument("target", help="Cobertura xml file or directory to search.")
+    parser.add_argument("--threshold", type=float, default=80.0, help="Minimum %% per file and overall.")
+    args = parser.parse_args()
+
+    reports = find_reports(args.target)
+    if not reports:
+        print(f"ERROR: no coverage.cobertura.xml found under '{args.target}'", file=sys.stderr)
+        return 2
+
+    files = collect(reports)
+    if not files:
+        print("ERROR: no covered source files found in report(s).", file=sys.stderr)
+        return 2
+
+    total_c = sum(c for c, _ in files.values())
+    total_t = sum(t for _, t in files.values())
+    total_pct = (total_c / total_t * 100) if total_t else 100.0
+
+    below = []
+    for filename, (c, t) in sorted(files.items()):
+        pct = (c / t * 100) if t else 100.0
+        if pct < args.threshold:
+            below.append((pct, c, t, filename))
+
+    print(f"Coverage: {total_c}/{total_t} lines = {total_pct:.1f}% across {len(files)} files "
+          f"(threshold {args.threshold:.0f}%)")
+
+    ok = True
+    if below:
+        ok = False
+        print(f"\n{len(below)} file(s) below {args.threshold:.0f}%:")
+        for pct, c, t, filename in sorted(below):
+            print(f"  {pct:5.1f}%  {c:4d}/{t:<4d}  {filename}")
+    if total_pct < args.threshold:
+        ok = False
+        print(f"\nTotal coverage {total_pct:.1f}% is below {args.threshold:.0f}%.")
+
+    if ok:
+        print("\nPASS: all files meet the threshold.")
+        return 0
+    print("\nFAIL: coverage gate not met.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Establishes and **enforces a ≥80% line-coverage-per-file policy** on all hand-written code across the backend (.NET) and frontend (Angular). Generated code is excluded, and genuinely untestable I/O is opted out explicitly rather than left uncovered.

The raw backend number was misleading (≈36%) because it was dominated by auto-generated EF migrations and the OpenAPI source generator — hand-written code was already ~86%. This PR closes the remaining gaps and locks the policy in via CI.

## Coverage tooling
- `backend/coverlet.runsettings` — excludes EF migrations + `obj/` source generators, skips auto-properties, scopes to `JobNecto.*`.
- `scripts/check_coverage.py` — portable Cobertura per-file gate (fails if total **or any file** < threshold); used locally and in CI.
- `frontend/angular.json` — v8 coverage with exclusions and native `coverageThresholds.perFile: 80`.

## Backend (520 → 580 tests; 96.7% lines, all 93 files ≥80%)
- New tests: `LanguageProficiency`, exception types, `ResumeMappers`, `DbCommandTimingInterceptor` (DB-independent), `CloudinaryAvatarStorageService`, JWT auth wiring.
- Extended: avatar validator (signature/filename/size) and DI hosting (Cloudinary warning branches).
- Live Cloudinary HTTP methods marked `[ExcludeFromCodeCoverage]` (justified); pure helpers exposed as `internal` (`InternalsVisibleTo`) so format/public-id logic is tested, not skipped.

## Frontend (78 tests; 96.65% lines, all 15 files ≥80%)
- New specs: `cn`, `dashboard.page`, `text-field`.
- Extended `sign-up.page` (66% → 94%): error-message mapping, multi-field server errors, generic-failure path.
- Added `@vitest/coverage-v8`.

## CI + docs
- `ci.yml`: `build` job collects coverage and runs the gate; new `frontend` job runs Vitest with its per-file gate.
- Policy + local commands documented in `AGENTS.md` and `README.md`.

## Verification (CI-parity, local)
| | Tests | Coverage | Per-file gate |
|---|---|---|---|
| Backend (Release, `--warnaserror`) | 580 pass, 0 warnings | 96.7% | ✅ all 93 |
| Frontend (`ng test --no-watch`) | 78 pass | 96.65% lines | ✅ all 15 |

## Notes
- Gate is on **line** coverage per file (matches the "80% coverage" intent). The Angular builder can also gate branches/functions per file — left off as brittle on small files; easy to tighten.
- The backend gate depends on the Postgres test DB (as CI already provides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)